### PR TITLE
feat: add doc feedback template

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/doc_feedback.yml
@@ -1,0 +1,25 @@
+name: Documentation Feedback
+description: Provide docs feedback
+title: "[Documentation Feedback]: "
+labels:
+  - user-feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your feedback. We highly appreciate it and are constantly striving to create better, more useful documentation.
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL
+      description: The URL of the page you provide feedback for.
+      placeholder: ex. https://weaviate.io/developers/weaviate/current/
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    attributes:
+      label: User feedback
+      description: What is your feedback? Any tips you would want us to consider?
+    validations:
+      required: true


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

This add a doc feedback issue template to help users to provide their valuable feedback to improve docs. This also adds a label `user-feedback` to the issues, so that doc specific issues are visible easily.

### What's being changed:

Added `doc-feeback.yml` to .github folder.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] Feature or enhancements (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested on my forked repository
