### PR TITLE
copyedit: cohere, vector-search-parameters

### DIFF
--- a/developers/weaviate/current/graphql-references/vector-search-parameters.md
+++ b/developers/weaviate/current/graphql-references/vector-search-parameters.md
@@ -3,7 +3,7 @@ layout: layout-documentation
 solution: weaviate
 sub-menu: GraphQL references
 title: Vector search parameters
-intro: ​Vector search parameters allow you to conduct specific vector search operations. Some are built into Weaviate directly, and others are enabled through Weaviate modules.
+intro: Vector search parameters allow you to conduct specific vector search operations. Some are built into Weaviate directly, and others are enabled through Weaviate modules.
 description: GraphQL search parameters
 tags: ['graphql', 'vector search parameters']
 menu-order: 5
@@ -21,13 +21,13 @@ For example:
 
 # Built-in parameters
 
-B​uilt in search parameters are available in all Weaviate instances and don't require any modules.​
+Built-in search parameters are available in all Weaviate instances and don't require any modules.
 
-## NearVector
+## nearVector
 
-This filter allows you to find data objects in the vicinity of an input vector. It's supported by the `Get{}` function.
+This parameter allows you to find data objects in the vicinity of an input vector. It's supported by the `Get{}` function.
 
-* Note: this argument is different from the [GraphQL `Explore{}` function](explore.html) )
+* Note: this argument is different from the [GraphQL `Explore{}` function](explore.html)
 * Note: Cannot use multiple `'near'` arguments, or a `'near'` argument along with an [`'ask'`](../modules/qna-transformers.html) filter
 
 ### Variables
@@ -52,9 +52,9 @@ reprents a perfect opposite (cosine distance of 2) and 1 represents vectors
 with an identical angle (cosine distance of 0). Certainty is not available on
 non-cosine distance metrics.
 
-## NearObject
+## nearObject
 
-This filter allows you to find data objects in the vicinity of other data objects by UUID. It's supported by the `Get{}` function.
+This parameter allows you to find data objects in the vicinity of other data objects by UUID. It's supported by the `Get{}` function.
 
 * Note: You cannot use multiple `near<Media>` arguments, or a `near<Media>` argument along with an [`ask`](../modules/qna-transformers.html) argument.
 * Note: You can specify an object's `id` or `beacon` in the argument, along with a desired `certainty`.
@@ -140,13 +140,13 @@ This results in the following. Note that publications `International New York Ti
 }
 ```
 
-# Module specific parameters
+# Module-specific parameters
 
-Module specific search parameters are made available in certain Weaviate modules.​
+Module-specific search parameters are made available in certain Weaviate modules.
 
-## NearText
+## nearText
 
-Enabled by the modules: [text2vec-openai](../retriever-vectorizer-modules/text2vec-openai.html), [text2vec-transformers](../retriever-vectorizer-modules/text2vec-transformers.html), [text2vec-contextionary](../retriever-vectorizer-modules/text2vec-contextionary.html).
+Enabled by the modules: [Transformers](../retriever-vectorizer-modules/text2vec-transformers.html#how-to-use), [Contextionary](../retriever-vectorizer-modules/text2vec-contextionary.html#how-to-use), [OpenAI](../retriever-vectorizer-modules/text2vec-openai.html#how-to-use), [CLIP](../retriever-vectorizer-modules/multi2vec-clip.html#how-to-use), [Huggingface](../retriever-vectorizer-modules/text2vec-huggingface.html#how-to-use), [Cohere](../retriever-vectorizer-modules/text2vec-cohere.html#how-to-use)
 
 This filter allows you to find data objects in the vicinity of the vector representation of a single or multiple concepts. It's supported by the `Get{}` function.
 
@@ -191,13 +191,13 @@ You can also bias results toward other data objects' vector representations. For
 
 If the distance metric is `cosine` you can also use `certainty` instead of
 `distance`. Certainty normalizes the distance in a range of 0..1, where 0
-reprents a perfect opposite (cosine distance of 2) and 1 represents vectors
+represents a perfect opposite (cosine distance of 2) and 1 represents vectors
 with an identical angle (cosine distance of 0). Certainty is not available on
 non-cosine distance metrics.
 
 #### Concept parsing
 
-Strings written in the concepts array are your fuzzy search terms. An array of concepts is required to set in the Explore query, and all words in this array should be present in the Contextionary.
+Strings in the `concepts` array are your fuzzy search terms. An array of concepts is required to set in the Explore query, and all words in this array should be present in the Contextionary.
 
 There are three ways to define the concepts array argument in the filter.
 
@@ -205,7 +205,7 @@ There are three ways to define the concepts array argument in the filter.
 - `["New", "York", "Times"]` = all concepts have a similar weight.
 - `["New York", "Times"]` = a combination of the two above.
 
-A practical example would be: `concepts: ["beatles", "John Lennon"]`
+A practical example would be: `concepts: ["beatles", "John Lennon"]`.
 
 #### Semantic Path
 

--- a/developers/weaviate/current/retriever-vectorizer-modules/text2vec-cohere.md
+++ b/developers/weaviate/current/retriever-vectorizer-modules/text2vec-cohere.md
@@ -14,7 +14,7 @@ enabled-on-wcs: true
 
 # Introduction
 
-The `text2vec-cohere` module allows you to use the [Cohere embeddings](https://docs.cohere.ai/docs/embeddings) directly in the Weaviate vector search engine as a vectorization module. ​When you create a Weaviate class that is set to use this module, it will automatically vectorize your data using Cohere's models.
+The `text2vec-cohere` module allows you to use the [Cohere embeddings](https://docs.cohere.ai/docs/embeddings) directly in the Weaviate vector search engine as a vectorization module. When you create a Weaviate class that is set to use this module, it will automatically vectorize your data using Cohere's models.
 
 * Note: this module uses a third-party API and may incur costs.
 * Note: make sure to check the Cohere [pricing page](https://cohere.ai/pricing) before vectorizing large amounts of data.
@@ -22,11 +22,11 @@ The `text2vec-cohere` module allows you to use the [Cohere embeddings](https://d
 
 # How to enable
 
-Request a Cohere API-key via [their dashboard](https://dashboard.cohere.ai/welcome/login).
+Request a Cohere API key via [their dashboard](https://dashboard.cohere.ai/welcome/login).
 
 ## Weaviate Cloud Service
 
-This module is enabled by default on the WCS
+This module is enabled by default on the WCS.
 
 ## Weaviate open source
 
@@ -56,7 +56,7 @@ services:
 
 # How to configure
 
-​In your Weaviate schema, you must define how you want this module to vectorize your data. If you are new to Weaviate schemas, you might want to check out the [getting started guide on the Weaviate schema](../getting-started/schema.html) first.
+In your Weaviate schema, you must define how you want this module to vectorize your data. If you are new to Weaviate schemas, you might want to check out the [getting started guide on the Weaviate schema](../getting-started/schema.html) first.
 
 The following schema configuration tells Weaviate to vectorize the `Document` class with `text2vec-cohere`, using the `multilingual-22-12` model and without input truncation by the Cohere API.
 
@@ -80,6 +80,7 @@ The following schema configuration tells Weaviate to vectorize the `Document` cl
       },
       "properties": [
         {
+          "name": "content",
           "dataType": [
             "text"
           ],
@@ -90,7 +91,6 @@ The following schema configuration tells Weaviate to vectorize the `Document` cl
               "vectorizePropertyName": false
             }
           },
-          "name": "content"
         }
       ]
     }
@@ -100,8 +100,8 @@ The following schema configuration tells Weaviate to vectorize the `Document` cl
 
 # How to use
 
-* If the Cohere API key is not set in the `text2vec-cohere` module, you can set the API key on query time by adding the following to the HTTP header: `X-Cohere-Api-Key: <cohere-api-key>`.
-* Using this module will enable GraphQL vector search parameters in Weaviate. They can be found [here](../graphql-references/vector-search-parameters.html#neartext).
+* If the Cohere API key is not set in the `text2vec-cohere` module, you can set the API key at query time by adding the following to the HTTP header: `X-Cohere-Api-Key: <cohere-api-key>`.
+* Using this module will enable the [`nearText` GraphQL vector search parameter](../graphql-references/vector-search-parameters.html#neartext).
 
 ## Example
 


### PR DESCRIPTION
Current:
* https://weaviate.io/developers/weaviate/current/retriever-vectorizer-modules/text2vec-cohere.html
* https://weaviate.io/developers/weaviate/current/graphql-references/vector-search-parameters.html

Proposed:
* https://639b37fc0fed3535fba0ccc6--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/current/retriever-vectorizer-modules/text2vec-cohere.html
* https://639b37fc0fed3535fba0ccc6--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/current/graphql-references/vector-search-parameters.html

Changes:
* update [list of modules that expose `nearText`](https://github.com/semi-technologies/weaviate-io/compare/main...cohere-copyedit#diff-8a7b8f2521c0d4452b664d54956835359fdc418e570f75602404165a469458dcR149)
* use "parameter" instead of "filter" in Vector Search Parameters - see https://github.com/semi-technologies/weaviate-io/pull/320/files#r1049733523
* fix capitalization of `nearText` & co in section headings
* fix grammar
* remove invisible blank spaces

Outstanding items
* create issue for [consistent terminology re. filters vs. parameters vs. semantic filters](https://github.com/semi-technologies/weaviate-io/pull/320/files#r1049733523) ?
* should Vector Search Parameters also mention `nearImage`?