### PR TITLE
Fix typos Greater -> GreaterThan, WroteArticles -> wroteArticles

### DIFF
--- a/_includes/code/0.23.2/graphql.filters.explore.html
+++ b/_includes/code/0.23.2/graphql.filters.explore.html
@@ -59,7 +59,7 @@ const client = weaviate.client({
 client.graphql
       .get()
       .withClassName('Author')
-      .withFields('name WroteArticles {... on Article {title _certainty}}')
+      .withFields('name wroteArticles {... on Article {title _certainty}}')
       .withExplore({
         concepts: ["fashion"],
         certainty: 0.7,

--- a/_includes/code/0.23.2/graphql.filters.where.beacon.count.html
+++ b/_includes/code/0.23.2/graphql.filters.where.beacon.count.html
@@ -7,11 +7,11 @@
         where:{
           valueInt: 2,
           operator: GreaterThanEqual,
-          path: ["WroteArticles"]
+          path: ["wroteArticles"]
         }
       ) {
         name
-        WroteArticles {
+        wroteArticles {
           ... on Article {
             title
           }
@@ -36,11 +36,11 @@ get_articles_where = """
           where:{
             valueInt: 2,
             operator: GreaterThanEqual,
-            path: ["WroteArticles"]
+            path: ["wroteArticles"]
           }
         ) {
           name
-          WroteArticles {
+          wroteArticles {
             ... on Article {
               title
             }
@@ -67,11 +67,11 @@ const client = weaviate.client({
 client.graphql
       .get()
       .withClassName('Author')
-      .withFields('name WroteArticles {... on Article {title}}')
+      .withFields('name wroteArticles {... on Article {title}}')
       .withWhere({
         valueInt: 2,
         operator: "GreaterThanEqual",
-        path: ["WroteArticles"]
+        path: ["wroteArticles"]
       })
       .do()
       .then(res => {
@@ -101,13 +101,13 @@ client := weaviate.New(cfg)
 where := `{
   valueInt: 2
   operator: GreaterThanEqual
-  path: ["WroteArticles"]
+  path: ["wroteArticles"]
 }`
 ctx := context.Background()
 
 result, err := client.GraphQL().Get().Things().
   WithClassName("Author").
-  WithFields("name WroteArticles{ ... on Article { title }}").
+  WithFields("name wroteArticles{ ... on Article { title }}").
   WithWhere(where).
   Do(ctx)
 
@@ -127,11 +127,11 @@ $ echo '{
           where:{
             valueInt: 2
             operator: GreaterThanEqual
-            path: [\"WroteArticles\"]
+            path: [\"wroteArticles\"]
           }
         ) {
           name
-          WroteArticles {
+          wroteArticles {
             ... on Article {
               title
             }

--- a/_includes/code/1.x/graphql.filters.where.beacon.count.html
+++ b/_includes/code/1.x/graphql.filters.where.beacon.count.html
@@ -6,7 +6,7 @@
       where:{
         valueInt: 2,
         operator: GreaterThanEqual,
-        path: ["WroteArticles"]
+        path: ["wroteArticles"]
       }
     ) {
       name
@@ -29,7 +29,7 @@ client = weaviate.Client("http://localhost:8080")
 where_filter = {
   'valueInt': 2,
   'operator': 'GreaterThanEqual',
-  'path': ["WroteArticles"]
+  'path': ["wroteArticles"]
 }
 
 query_result = (
@@ -73,7 +73,7 @@ public class App {
                 .build();
 
         WhereFilter where = WhereFilter.builder()
-                .path(new String[]{"WroteArticles"})
+                .path(new String[]{"wroteArticles"})
                 .operator(Operator.GreaterThanEqual)
                 .valueInt(2)
                 .build();
@@ -109,7 +109,7 @@ client.graphql
       .withWhere({
         valueInt: 2,
         operator: "GreaterThanEqual",
-        path: ["WroteArticles"]
+        path: ["wroteArticles"]
       })
       .do()
       .then(res => {
@@ -150,7 +150,7 @@ func main() {
 	}
 
 	where := filters.Where().
-		WithPath([]string{"WroteArticles"}).
+		WithPath([]string{"wroteArticles"}).
 		WithOperator(filters.GreaterThanEqual).
 		WithValueInt(2)
 
@@ -178,7 +178,7 @@ $ echo '{
         where:{
           valueInt: 2
           operator: GreaterThanEqual
-          path: [\"WroteArticles\"]
+          path: [\"wroteArticles\"]
         }
       ) {
         name

--- a/_includes/code/1.x/graphql.filters.where.timestamps.html
+++ b/_includes/code/1.x/graphql.filters.where.timestamps.html
@@ -4,7 +4,7 @@
   Get {
     Article(where: {
         path: ["_creationTimeUnix"],
-        operator: Greater,
+        operator: GreaterThan,
         valueDate: "2022-03-18T20:29:19.063-0500" // can also use `valueString: "1647653359063"`
       }) {
       title
@@ -21,7 +21,7 @@ client = weaviate.Client("http://localhost:8080")
 
 where_filter = {
   "path": ["_creationTimeUnix"],
-  "operator": "Greater",
+  "operator": "GreaterThan",
   "valueDate": "2022-03-18T20:26:34.586-0500"
 }
 
@@ -49,7 +49,7 @@ client.graphql
       .withClassName('Article')
       .withFields('title')
       .withWhere({
-        operator: 'Greater',
+        operator: 'GreaterThan',
         path: ['_creationTimeUnix'],
         valueDate: "2022-03-18T20:26:34.586-0500",
       })
@@ -163,7 +163,7 @@ $ echo '{
     Get {
       Article(where: {
           path: [\"_creationTimeUnix\"],
-          operator: Greater,
+          operator: GreaterThan,
           valueDate: \"2022-03-18T20:26:34.586-0500\"
         }) {
         title

--- a/developers/weaviate/current/graphql-references/filters.md
+++ b/developers/weaviate/current/graphql-references/filters.md
@@ -263,7 +263,7 @@ Above example shows how filter by reference can solve straightforward questions 
 
 {% include code/1.x/graphql.filters.where.beacon.count.html %}
 
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Author%28%0D%0A++++++where%3A%7B%0D%0A++++++++valueInt%3A+2%2C%0D%0A++++++++operator%3A+GreaterThanEqual%2C%0D%0A++++++++path%3A+%5B%22WroteArticles%22%5D%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++++wroteArticles+%7B%0D%0A++++++++...+on+Article+%7B%0D%0A++++++++++title%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A+%7D' %}
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Author%28%0D%0A++++++where%3A%7B%0D%0A++++++++valueInt%3A+2%2C%0D%0A++++++++operator%3A+GreaterThanEqual%2C%0D%0A++++++++path%3A+%5B%22wroteArticles%22%5D%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++++wroteArticles+%7B%0D%0A++++++++...+on+Article+%7B%0D%0A++++++++++title%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A+%7D' %}
 
 ## GeoCoordinates filter
 


### PR DESCRIPTION
### Why:

`Greater` is not a valid filter (should be `GreaterThan`).
The field `wroteArticles` should be lowercased to match https://demo.dataset.playground.semi.technology

Thanks to @ju-bezdek for raising this.
