### PR TITLE
Specify the default limit of the GET endpoint

### DIFF
--- a/developers/weaviate/current/restful-api-references/objects.md
+++ b/developers/weaviate/current/restful-api-references/objects.md
@@ -22,7 +22,7 @@ Lists all data objects in reverse order of creation. The data will be returned a
 
 ### Method and URL
 
-Without any restrictions (across classes, default limit):
+Without any restrictions (across classes, default limit = 100):
 
 ```js
 GET /v1/objects


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

This PR fixes: NA

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Clarify the GET objects endpoint's default limit

### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature or enhancements (non-breaking change which adds functionality)
- [x] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Read the python client's [doc string](https://github.com/semi-technologies/weaviate-python-client/blob/dcd4a6afa083bf0d895aebbcca5a75159a10210b/weaviate/data/crud_data.py#L468-L470) for the get function