### PR TITLE
Set organizationName

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,7 +20,7 @@ const config = {
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.
-    organizationName: 'semi-technologies', // Usually your GitHub org/user name.
+    organizationName: 'weaviate', // Usually your GitHub org/user name.
     projectName: 'weaviate-io', // Usually your repo name.
     plugins: [
         'docusaurus-plugin-sass',


### PR DESCRIPTION
### Why:

`organizationName` was set to the old repo name.