### PR TITLE
resolve dependency by pinning eta package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
   },
   "engines": {
     "node": ">=16.14"
-  }
+  },
+  "resolutions": {
+    "eta": "1.13.0"
+  }  
 }


### PR DESCRIPTION
Dependency resolution to force [eta](https://yarnpkg.com/package/eta) to 1.13.0

- [x] Bug fix (non-breaking change which fixes an issue)
    - ETA 1.14.0 was causing build problems; version pinned to 1.13.0
