### PR TITLE
Disable twitter badge

### DIFF
--- a/_includes/badges.mdx
+++ b/_includes/badges.mdx
@@ -54,7 +54,6 @@ export default class Badges extends Component {
                     {/* <a href="https://app.swaggerhub.com/apis/semi-technologies/weaviate/{{ site.weaviate_version }}">
                 <img src="https://img.shields.io/badge/open--api--specs-{{ site.weaviate_version }}-brightgreen?style=flat-square" alt="Weaviate {{ site.weaviate_version }} version badge"/>
             </a>                 */}
-                    <br />
                     {/* Set total pulls to Weaviate + modules as Bob suggested */}
                     <img
                         id="totalpulls"
@@ -68,20 +67,6 @@ export default class Badges extends Component {
                             alt="Go Report Card"
                         />
                     </a>
-                    &nbsp;
-                    <a href="https://weaviate.slack.com/">
-                        <img
-                            src="https://img.shields.io/badge/Slack-@weaviate.svg?logo=slack&style=flat-square"
-                            alt="Join Slack"
-                        />
-                    </a>
-                    {/* &nbsp;
-                    <a href="https://twitter.com/intent/follow?screen_name=weaviate_io">
-                        <img
-                            src="https://img.shields.io/twitter/follow/weaviate_io?logo=twitter&style=flat-square"
-                            alt="Twitter Follow"
-                        />
-                    </a> */}
                 </p>
             </span>
         );

--- a/_includes/badges.mdx
+++ b/_includes/badges.mdx
@@ -75,13 +75,13 @@ export default class Badges extends Component {
                             alt="Join Slack"
                         />
                     </a>
-                    &nbsp;
+                    {/* &nbsp;
                     <a href="https://twitter.com/intent/follow?screen_name=weaviate_io">
                         <img
                             src="https://img.shields.io/twitter/follow/weaviate_io?logo=twitter&style=flat-square"
                             alt="Twitter Follow"
                         />
-                    </a>
+                    </a> */}
                 </p>
             </span>
         );


### PR DESCRIPTION
### Why:

This PR removes social shield badges as they are now present on the navigation bar.

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)
