### PR TITLE
docs: Fix console example link in `quickstart/modules`

### DIFF
--- a/developers/weaviate/api/graphql/get.md
+++ b/developers/weaviate/api/graphql/get.md
@@ -86,7 +86,7 @@ To combine `Get { }` with a vector search argument, here is an overview of the s
 
 ## Filters
 
-`Get{}` functions can be extended with search filters (both semantic filters as traditional filters). Because the filters work on multiple core functions (like `Aggregate{}`) there is a [specific documentation page dedicated to filters](filters.md).
+`Get{}` functions can be extended with search filters (both semantic filters and traditional filters). Because the filters work on multiple core functions (like `Aggregate{}`) there is a [specific documentation page dedicated to filters](filters.md).
 
 ### Sorting
 

--- a/developers/weaviate/quickstart/modules.md
+++ b/developers/weaviate/quickstart/modules.md
@@ -272,7 +272,7 @@ Like retrievers & vectorizers, the modules can extend the GraphQL-API. The quest
 {
   Get {
     Article(
-      # the ask filter is introduced through the Q&A module
+      # the ask filter is introduced through the QandA module
       ask: {
         question: "What was the monkey doing during Elon Musk's brain-chip startup release?"
       }
@@ -290,7 +290,7 @@ Like retrievers & vectorizers, the modules can extend the GraphQL-API. The quest
 }
 ```
 
-You can try this query in real time [here](https://link.semi.technology/3dPI0rV).
+You can try this query in real time [here](https://link.weaviate.io/3HGe3qv).
 
 ## Recap
 


### PR DESCRIPTION
- [x] Documentation updates (non-breaking change which updates documents)
    - Addresses broken link in #247 (seems to be caused by `&` in GraphQL comment)