### PR TITLE
[Documentation feedback] Update data.md

### DIFF
--- a/developers/weaviate/concepts/data.md
+++ b/developers/weaviate/concepts/data.md
@@ -21,7 +21,7 @@ import Badges from '/_includes/badges.mdx';
 
 ## Overview
 
-This document lays out how Weaviate deals with data objects, including how they are stores, represented, and linked to each other.
+This document lays out how Weaviate deals with data objects, including how they are stored, represented, and linked to each other.
 
 ## Data object nomenclature
 


### PR DESCRIPTION
grammar mistake in data structures.
changed stores -> stored

### Why:

grammar mistake in data structure section of concepts

### What's being changed:

stores -> stored

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)


