### PR TITLE
docs: fix erroneous double spaces

### DIFF
--- a/_includes/code/graphql.filters.nearText.cohere.mdx
+++ b/_includes/code/graphql.filters.nearText.cohere.mdx
@@ -37,7 +37,7 @@ import TabItem from '@theme/TabItem';
 ```python
 import weaviate
 
-client  = weaviate.Client(
+client = weaviate.Client(
     url="http://localhost:8080",
     additional_headers={
         "X-Cohere-Api-Key": "<THE-KEY>"

--- a/_includes/code/graphql.filters.nearText.huggingface.mdx
+++ b/_includes/code/graphql.filters.nearText.huggingface.mdx
@@ -37,7 +37,7 @@ import TabItem from '@theme/TabItem';
 ```python
 import weaviate
 
-client  = weaviate.Client(
+client = weaviate.Client(
     url="http://localhost:8080",
     additional_headers={
         "X-HuggingFace-Api-Key": "<THE-KEY>"

--- a/_includes/code/graphql.filters.nearText.openai.mdx
+++ b/_includes/code/graphql.filters.nearText.openai.mdx
@@ -37,7 +37,7 @@ import TabItem from '@theme/TabItem';
 ```python
 import weaviate
 
-client  = weaviate.Client(
+client = weaviate.Client(
     url="http://localhost:8080",
     additional_headers={
         "X-OpenAI-Api-Key": "<THE-KEY>"

--- a/_includes/code/qna-openai.ask.mdx
+++ b/_includes/code/qna-openai.ask.mdx
@@ -35,7 +35,7 @@ import TabItem from '@theme/TabItem';
 ```python
 import weaviate
 
-client  = weaviate.Client(
+client = weaviate.Client(
     url="http://localhost:8080",
     additional_headers={
         "X-OpenAI-Api-Key": "<THE-KEY>"

--- a/_includes/code/quickstart.query.aggregate.1.mdx
+++ b/_includes/code/quickstart.query.aggregate.1.mdx
@@ -15,7 +15,7 @@ TBC
 import weaviate
 import json
 
-client  = weaviate.Client(
+client = weaviate.Client(
     url="https://some-endpoint.weaviate.network/",  # Replace with your endpoint
     additional_headers={
         "X-OpenAI-Api-Key": api_tkn  # Or "X-Cohere-Api-Key" or "X-HuggingFace-Api-Key" 

--- a/_includes/code/quickstart.query.aggregate.2.mdx
+++ b/_includes/code/quickstart.query.aggregate.2.mdx
@@ -15,7 +15,7 @@ TBC
 import weaviate
 import json
 
-client  = weaviate.Client(
+client = weaviate.Client(
     url="https://some-endpoint.weaviate.network/",  # Replace with your endpoint
     additional_headers={
         "X-OpenAI-Api-Key": api_tkn  # Or "X-Cohere-Api-Key" or "X-HuggingFace-Api-Key" 

--- a/_includes/code/quickstart.query.neartext.additional.mdx
+++ b/_includes/code/quickstart.query.neartext.additional.mdx
@@ -25,7 +25,7 @@ import TabItem from '@theme/TabItem';
 ```python
 import weaviate
 
-client  = weaviate.Client(
+client = weaviate.Client(
     url="https://some-endpoint.weaviate.network/",  # Replace with your endpoint
     additional_headers={
         "X-OpenAI-Api-Key": api_tkn  # Or "X-Cohere-Api-Key" or "X-HuggingFace-Api-Key" 

--- a/_includes/code/quickstart.query.where.1.mdx
+++ b/_includes/code/quickstart.query.where.1.mdx
@@ -15,8 +15,8 @@ TBC
 import weaviate
 import json
 
-client  = weaviate.Client(
-    url="http://localhost:8080",
+client = weaviate.Client(
+    url="https://some-endpoint.semi.network",
     additional_headers={
         'X-OpenAI-Api-Key': api_tkn
     }

--- a/_includes/code/quickstart.query.where.2.mdx
+++ b/_includes/code/quickstart.query.where.2.mdx
@@ -15,7 +15,7 @@ TBC
 import weaviate
 import json
 
-client  = weaviate.Client(
+client = weaviate.Client(
     url="https://some-endpoint.weaviate.network/",  # Replace with your endpoint
     additional_headers={
         "X-OpenAI-Api-Key": api_tkn  # Or "X-Cohere-Api-Key" or "X-HuggingFace-Api-Key" 

--- a/blog/2022-09-27-Hugging-Face-Inference-API-in-Weaviate/index.mdx
+++ b/blog/2022-09-27-Hugging-Face-Inference-API-in-Weaviate/index.mdx
@@ -116,7 +116,7 @@ For this, you need your Hugging Face API token, which is used to authorize all c
 Add your token, to a Weaviate client configuration. For example in Python, you do it like this:
 
 ```javascript
-client  = weaviate.Client(
+client = weaviate.Client(
     url='http://localhost:8080',
     additional_headers={
         'X-HuggingFace-Api-Key': '<THE-KEY>'


### PR DESCRIPTION
- [x] Documentation updates (non-breaking change which updates documents)

Fixes a number of files which had double spaces where it should not have - i.e. `client  =`.
