### PR TITLE
fixed hyperlink syntax typos in faqs

### DIFF
--- a/developers/weaviate/more-resources/faq.md
+++ b/developers/weaviate/more-resources/faq.md
@@ -38,9 +38,9 @@ Custom HNSW implementation in Weaviate references:
 More information:
 
 - [Weaviate, an ANN Database with CRUD support – DB-Engines.com](https://db-engines.com/en/blog_post/87) ⬅️ best resource on the topic
-- [Weaviate's HNSW implementation in the docs)[/developers/weaviate/concepts/vector-index.md#hnsw)
+- [Weaviate's HNSW implementation in the docs](/developers/weaviate/concepts/vector-index.md#hnsw)
 
-_Note I: HNSW is just one implementation in Weaviate, but Weaviate can support multiple indexing algoritmns as outlined [here)[/developers/weaviate/vector-index/)_
+_Note I: HNSW is just one implementation in Weaviate, but Weaviate can support multiple indexing algoritmns as outlined [here](/developers/weaviate/vector-index/)_
 
 ## Q: Are all ANN algorithms potential candidates to become an indexation plugin in Weaviate?
 
@@ -94,7 +94,7 @@ A: Because you are probably one of the first that needs one! Ping us [here on Gi
 
 ## Q: How to deal with custom terminology?
 
-A: Sometimes, users work with custom terminology, which often comes in the form of abbreviations or jargon. You can find more information on how to use the endpoint [here)[/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md#extending-the-contextionary-v1modulestext2vec-contextionaryextensions)
+A: Sometimes, users work with custom terminology, which often comes in the form of abbreviations or jargon. You can find more information on how to use the endpoint [here](/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md#extending-the-contextionary-v1modulestext2vec-contextionaryextensions)
 
 ## Q: How can you index data near-realtime without losing semantic meaning?
 
@@ -208,7 +208,7 @@ A: The UUID must be presented as a string matching the [Canonical Textual repres
 
 ## Q: What is the best way to iterate through objects? Can I do paginated API calls? 
 
-A: Yes, pagination is supported. You can use the `offset` and `limit` parameters for GraphQL API calls. [Here's)[/developers/weaviate/api/graphql/filters.md#offset-filter-pagination) described how to use these parameters, including tips on performance and limitations.
+A: Yes, pagination is supported. You can use the `offset` and `limit` parameters for GraphQL API calls. [Here's](/developers/weaviate/api/graphql/filters.md#offset-filter-pagination) described how to use these parameters, including tips on performance and limitations.
 
 ## Q: What happens when the weaviate docker container restarts? Is my data in the weaviate database lost?
 


### PR DESCRIPTION
Updated hyperlink bracket typos in multiple places in documentation under faqs section

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

This PR fixes a minor typo in the faqs


### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
![image](https://user-images.githubusercontent.com/51532579/217032875-e612d7c6-4de6-4428-ab32-c15bfda12b9d.png)

![image](https://user-images.githubusercontent.com/51532579/217034630-f382c7f4-32a9-45d3-8f43-11b4e6d1a942.png)

### Type of change:

<!--Please delete options that are not relevant.-->

- [ x ] Documentation updates (non-breaking change which updates documents)



