### PR TITLE
fix(docs): clarify cluster creation time in Quickstart

### DIFF
--- a/developers/weaviate/quickstart/installation.md
+++ b/developers/weaviate/quickstart/installation.md
@@ -53,7 +53,9 @@ To create a new Weaviate Cluster:
 Your selections should look like this:
 <img src={WCSScreenshotImg} width="90%" alt="Cluster configuration"/>
 
-This will start the process to create a new cluster, and you should see a progress indicator. After a short while, you should see a green tick ✔️ - indicating that the cluster is ready.
+This will start the process to create a new cluster, and you should see a progress indicator. This should take a minute or two, and you should see a green tick ✔️ when it's done - indicating that the cluster is ready.
+
+(In the meantime, you can start installing a client library - or grab a hot drink 😉.)
 
 ### Connect to Weaviate
 

--- a/src/components/ContactUsForm/index.jsx
+++ b/src/components/ContactUsForm/index.jsx
@@ -79,7 +79,7 @@ export default function ContactUsForm() {
           />
         </div>
         <div className={styles.selectWrapper}>
-          <label htmlFor="foundHow">Choose:</label>
+          <label htmlFor="foundHow">How did you hear about Weaviate?</label>
 
           <select
             value={selected}


### PR DESCRIPTION
fix(docs): clarify cluster creation time in Quickstart

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)
