### PR TITLE
[docs] componentize datatypes

### DIFF
--- a/_includes/datatypes.mdx
+++ b/_includes/datatypes.mdx
@@ -1,0 +1,18 @@
+| Weaviate Type | Exact Data Type | Formatting |
+| ---------|--------|-----------|
+| string   | string | `"string"` |
+| string[]   | list of strings | `["string", "second string"]` |
+| int      | int64 (*) | `0` |
+| int[]      | list of int64 (*) | `[0, 1]` |
+| boolean  | boolean | `true`/`false` |
+| boolean[]  | list of booleans | `[true, false]` |
+| number   | float64 | `0.0` |
+| number[]   | list of float64 | `[0.0, 1.1]` |
+| date     | string | [more info](/developers/weaviate/configuration/datatypes#datatype-date) |
+| date[]     | list of string | [more info](/developers/weaviate/configuration/datatypes#datatype-date) |
+| text     | text   | `string` |
+| text[]     | list of texts   | `["string one", "string two"]` |
+| geoCoordinates | string | [more info](/developers/weaviate/configuration/datatypes#datatype-geocoordinates) |
+| phoneNumber | string | [more info](/developers/weaviate/configuration/datatypes#datatype-phonenumber) |
+| blob | base64 encoded string | [more info](/developers/weaviate/configuration/datatypes#datatype-blob) |
+| *cross reference* | string | [more info](/developers/weaviate/configuration/datatypes#datatype-cross-reference) |

--- a/developers/weaviate/configuration/datatypes.md
+++ b/developers/weaviate/configuration/datatypes.md
@@ -18,24 +18,9 @@ import Badges from '/_includes/badges.mdx';
 
 When creating a property, Weaviate needs to know what type of data you will give it. Weaviate accepts the following types:
 
-| Weaviate Type | Exact Data Type | Formatting |
-| ---------|--------|-----------|
-| string   | string | `"string"` |
-| string[]   | list of strings | `["string", "second string"]` |
-| int      | int64 (*) | `0` |
-| int[]      | list of int64 (*) | `[0, 1]` |
-| boolean  | boolean | `true`/`false` |
-| boolean[]  | list of booleans | `[true, false]` |
-| number   | float64 | `0.0` |
-| number[]   | list of float64 | `[0.0, 1.1]` |
-| date     | string | [more info](#datatype-date) |
-| date[]     | list of string | [more info](#datatype-date) |
-| text     | text   | `string` |
-| text[]     | list of texts   | `["string one", "string two"]` |
-| geoCoordinates | string | [more info](#datatype-geocoordinates) |
-| phoneNumber | string | [more info](#datatype-phonenumber) |
-| blob | base64 encoded string | [more info](#datatype-blob) |
-| *cross reference* | string | [more info](#datatype-cross-reference) |
+import DataTypes from '/_includes/datatypes.mdx';
+
+<DataTypes />
 
 (*) Although Weaviate supports `int64`, GraphQL currently only supports `int32`, and does not support `int64`. This means that currently _integer_ data fields in Weaviate with integer values larger than `int32`, will not be returned using GraphQL queries. We are working on solving this [issue](https://github.com/weaviate/weaviate/issues/1563). As current workaround is to use a `string` instead.
 


### PR DESCRIPTION
### Why:

Componentize datatypes table for re-use in other places.

### What's being changed:

The datatypes table in `concepts/datatypes` moves to its own component in `/_includes/datatypes.mdx`

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)

