### PR TITLE
fix(generative-openai): rename Document -> Article, content -> summary

### DIFF
--- a/_includes/code/generative.openai.singleresult.mdx
+++ b/_includes/code/generative.openai.singleresult.mdx
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
         generate(
           singleResult: {
             prompt: """
-              Describe the following as a Facebook Ad: {content}
+              Describe the following as a Facebook Ad: {summary}
             """
           }
         ) {
@@ -49,7 +49,7 @@ client  = weaviate.Client(
 
 # highlight-start
 # instruction for the generative module
-generatePrompt = '"Describe the following as a Facebook Ad: {content}"'
+generatePrompt = '"Describe the following as a Facebook Ad: {summary}"'
 # highlight-end
 
 result = (
@@ -83,7 +83,7 @@ const client = weaviate.client({
 
 // highlight-start
 // instruction for the generative module
-let generatePrompt = '"Describe the following as a Facebook Ad: {content}"'
+const generatePrompt = '"Describe the following as a Facebook Ad: {summary}"';
 // highlight-end
 
 client.graphql
@@ -130,7 +130,7 @@ func main() {
 
   // highlight-start
   // instruction for the generative module
-  generatePrompt := "\"Describe the following as a Facebook Ad: {content}\""
+  generatePrompt := "\"Describe the following as a Facebook Ad: {summary}\""
   // highlight-end
 
   fields := []graphql.Field{
@@ -196,7 +196,7 @@ public class App {
 
     // highlight-start
     // instruction for the generative module
-    String generatePrompt = "\"Describe the following as a Facebook Ad: {content}\""
+    String generatePrompt = "\"Describe the following as a Facebook Ad: {summary}\""
     // highlight-end
 
     Field title = Field.builder().name("title").build();
@@ -253,7 +253,7 @@ $ echo '{
           generate(
             singleResult: {
               prompt: """
-                Describe the following as a Facebook Ad: {content}
+                Describe the following as a Facebook Ad: {summary}
               """
             }
           ) {

--- a/developers/weaviate/modules/reader-generator-modules/generative-openai.md
+++ b/developers/weaviate/modules/reader-generator-modules/generative-openai.md
@@ -41,7 +41,7 @@ You need to input both a query and a prompt (for individual responses) or a task
 
 You can provide your OpenAI API key in two ways:
 
-1. During **configuration** of your Docker instance, by adding `OPENAI_APIKEY` under `environment` to your `docker-compose` file, like this:
+1. During the **configuration** of your Docker instance, by adding `OPENAI_APIKEY` under `environment` to your `docker-compose` file, like this:
 
   ```
   environment:
@@ -143,28 +143,28 @@ Currently, you can't provide your OpenAI key in the Weaviate console. That means
 
 ```graphql
 {
-  Document {
-    title   # property 'title' of the Document class
-    content # property 'content' of the Document class
+  Article {
+    title
+    summary
   }
 }
 ```
 
-You can add both `title` and `content` to the prompt by enclosing them in curly brackets:
+You can add both `title` and `summary` to the prompt by enclosing them in curly brackets:
 
 ```graphql
 {
   Get {
-    Document {
+    Article {
       title
-      content
+      summary
       _additional {
         generate(
           singleResult: {
             prompt: """
             Summarize the following in a tweet:
             
-            {title} - {content}
+            {title} - {summary}
             """
           }
         ) {
@@ -182,7 +182,7 @@ You can add both `title` and `content` to the prompt by enclosing them in curly 
 Here is an example of a query where:
 * we run a vector search (with `nearText`) to find articles about "Italian food"
 * then we ask the generator module to describe each result as a Facebook ad.
-  * the query asks for the `summary` field, which it then includes in `prompt` argument of the `generate` operator.
+  * the query asks for the `summary` field, which it then includes in the `prompt` argument of the `generate` operator.
 
 import OpenAISingleResult from '/_includes/code/generative.openai.singleresult.mdx';
 
@@ -214,7 +214,7 @@ import OpenAISingleResult from '/_includes/code/generative.openai.singleresult.m
 ### Example - grouped result
 
 Here is an example of a query where:
-* we run a vector search (with `nearText`) to find publications about finance.
+* we run a vector search (with `nearText`) to find publications about finance,
 * then we ask the generator module to explain why these articles are about finance.
 
 import OpenAIGroupedResult from '/_includes/code/generative.openai.groupedresult.mdx';


### PR DESCRIPTION
### Why:

This PR fixes the "single result" examples from the generative-openai docs.

### What's being changed:

https://weaviate.io/developers/weaviate/modules/reader-generator-modules/generative-openai#example-of-properties-in-the-prompt

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

Dev server on localhost