### PR TITLE
Fix missing `[` in Python docs

### DIFF
--- a/_includes/code/graphql.filters.nearText.cohere.mdx
+++ b/_includes/code/graphql.filters.nearText.cohere.mdx
@@ -60,7 +60,7 @@ nearText = {
 result = (
   client.query
   .get("Publication", "name")
-  .with_additional("certainty OR distance"]) # note that certainty is only supported if distance==cosine
+  .with_additional(["certainty OR distance"]) # note that certainty is only supported if distance==cosine
   .with_near_text(nearText)
   .do()
 )

--- a/_includes/code/graphql.filters.nearText.huggingface.mdx
+++ b/_includes/code/graphql.filters.nearText.huggingface.mdx
@@ -60,7 +60,7 @@ nearText = {
 result = (
   client.query
   .get("Publication", "name")
-  .with_additional("certainty OR distance"]) # note that certainty is only supported if distance==cosine
+  .with_additional(["certainty OR distance"]) # note that certainty is only supported if distance==cosine
   .with_near_text(nearText)
   .do()
 )

--- a/_includes/code/graphql.filters.nearText.mdx
+++ b/_includes/code/graphql.filters.nearText.mdx
@@ -55,7 +55,7 @@ nearText = {
 result = (
   client.query
   .get("Publication", "name")
-  .with_additional("certainty OR distance"]) # note that certainty is only supported if distance==cosine
+  .with_additional(["certainty OR distance"]) # note that certainty is only supported if distance==cosine
   .with_near_text(nearText)
   .do()
 )

--- a/_includes/code/graphql.filters.nearText.openai.mdx
+++ b/_includes/code/graphql.filters.nearText.openai.mdx
@@ -60,7 +60,7 @@ nearText = {
 result = (
   client.query
   .get("Publication", "name")
-  .with_additional("certainty OR distance"]) # note that certainty is only supported if distance==cosine
+  .with_additional(["certainty OR distance"]) # note that certainty is only supported if distance==cosine
   .with_near_text(nearText)
   .do()
 )


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

This PR fixes: #436

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
- Added missing opening parenthesis.
- Reason for not removing the closing parenthesis is the idea that there could be multiple `additional_context` as a parameter in the future, so giving `list` a higher priority than a `string`.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature or enhancements (non-breaking change which adds functionality)
- [ ] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

<img width="880" alt="Screenshot 2023-02-12 at 11 27 13 PM" src="https://user-images.githubusercontent.com/81156510/218329170-0fc87404-4806-4a3d-a475-b020e8901455.png">

#### Before
```python
result = (
  client.query
  .get("Publication", "name")
  .with_additional("certainty OR distance"]) # note that certainty is only supported if distance==cosine
  .with_near_text(nearText)
  .do()
)
```

#### After
```python
result = (
  client.query
  .get("Publication", "name")
  .with_additional(["certainty OR distance"]) # note that certainty is only supported if distance==cosine
  .with_near_text(nearText)
  .do()
)
````
