### PR TITLE
copyedit: replace "regulate", fix schema* tables & headings

### DIFF
--- a/developers/weaviate/api/rest/schema.md
+++ b/developers/weaviate/api/rest/schema.md
@@ -8,24 +8,26 @@ import Badges from '/_includes/badges.mdx';
 
 <Badges/>
 
-NOTE: From v1.5.0 onwards creating a schema is now optional, learn more about [Auto Schema here](/developers/weaviate/configuration/schema-configuration.md#auto-schema).
+:::note
+From v1.5.0 onwards creating a schema is optional. Learn more about [Auto Schema](/developers/weaviate/configuration/schema-configuration.md#auto-schema).
+:::
 
 ## Get the schema
 Dumps the current Weaviate schema. The result contains an array of objects.
 
-#### Method and URL
+### Method and URL
 
 ```js
 GET /v1/schema
 ```
 
-#### Example request
+### Example request
 
 import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
 
 <CodeSchemaDump />
 
-#### Example response
+### Example response
 <!-- TODO: Does this really needs to be this long? -->
 
 ```json
@@ -228,39 +230,41 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
 
 Create a new data object class in the schema.
 
-NOTE: From v1.5.0 onwards creating a schema is now optional, learn more about [Auto Schema here](/developers/weaviate/configuration/schema-configuration.md#auto-schema).
+:::note
+From v1.5.0 onwards creating a schema is optional. Learn more about [Auto Schema ](/developers/weaviate/configuration/schema-configuration.md#auto-schema).
+:::
 
-#### Method and URL
+### Method and URL
 
 ```js
 POST /v1/schema
 ```
 
-#### Parameters
+### Parameters
 
 Learn more about the schema configuration [here](/developers/weaviate/configuration/schema-configuration.md).
 
 | name | location | type | description |
-| ---- | ---- | ----------- |
-| `class` | body | string | The name of the class, multiple words should be concatenated in CamelCase like `ArticleAuthor`. |
+| ---- | ---- | ----------- | ---- |
+| `class` | body | string | The name of the class. Multiple words should be concatenated in CamelCase, e.g. `ArticleAuthor`. |
 | `description` | body | string | Description of the classname |
-| `vectorIndexType` | body | string | defaults to hnsw, can be omitted in schema definition since this is the only available type for now |
-| `vectorIndexConfig` | body | object | vector index type specific settings |
-| `vectorizer` | body | string | vectorizer to use for data objects added to this class, default can be set in Weaviate's environment variables |
-| `moduleConfig` > `text2vec-contextionary`  > `vectorizeClassName` | body | object | include the class name in vector calculation (default true). Learn more about how to regulate indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#regulate-semantic-indexing). |
+| `vectorIndexType` | body | string | Defaults to hnsw. Can be omitted in schema definition since this is the only available type for now. |
+| `vectorIndexConfig` | body | object | Vector index type specific settings |
+| `vectorizer` | body | string | Vectorizer to use for data objects added to this class. Default can be set via Weaviate environment variables. |
+| `moduleConfig` > `text2vec-contextionary`  > `vectorizeClassName` | body | object | Include the class name in vector calculation (default true). Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 | `properties` | body | array | An array of property objects |
-| `properties` > `dataType` | body | array | Click [here](/developers/weaviate/configuration/datatypes.md) for a list of available data types. |
+| `properties` > `dataType` | body | array | See the [available data types](/developers/weaviate/configuration/datatypes.md) |
 | `properties` > `description` | body | string | Description of the property |
-| `properties` > `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | if true, the whole property will NOT be included in vectorization. default is false, meaning that the object will be NOT be skipped |
-| `properties` > `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | whether name of the property is used in the calculation for the vector position of data objects. default is true. Learn more about how to regulate indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#regulate-semantic-indexing). |
-| `properties` > `name` | body | string | The name of the property, multiple words should be concatenated in camelCase like `nameOfAuthor`. |
-| `properties` > `indexInverted` | body | boolean | Should the the data stored in this property be indexed? Learn more about how to regulate indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#regulate-semantic-indexing). |
-| `properties` > `tokenization` | body | string | Only for `string`/`text` props. Introduced in `v1.12.0`. Control how a field is tokenized in the inverted index. Defaults to `"word"`, can be set to `"field"`. See [more details here](/developers/weaviate/configuration/schema-configuration.md#property-tokenization).|
+| `properties` > `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | If true, the whole property will NOT be included in vectorization. Default is false, meaning that the object will be NOT be skipped. |
+| `properties` > `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | Whether the name of the property is used in the calculation for the vector position of data objects. Default is true. Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `properties` > `name` | body | string | The name of the property. Multiple words should be concatenated in camelCase, e.g. `nameOfAuthor`. |
+| `properties` > `indexInverted` | body | boolean | Should the data stored in this property be indexed? Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `properties` > `tokenization` | body | string | Only for `string`/`text` props. Introduced in `v1.12.0`. Control how a field is tokenized in the inverted index. Defaults to `"word"`, can be set to `"field"`. Learn more about [property tokenization](/developers/weaviate/configuration/schema-configuration.md#property-tokenization).|
 | `invertedIndexConfig` > `stopwords` | body | object | Configure which words should be treated as stopwords and therefore be ignored on inverted indexing and querying. See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--stopwords-stopword-lists). |
 | `invertedIndexConfig` > `indexTimestamps` | body | boolean | Maintain an inverted index for each object by its internal timestamps, currently including `creationTimeUnix` and `lastUpdateTimeUnix` See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--indextimestamps). |
 | `replicationConfig` > `factor` | body | int | The replication factor, aka the number of copies in a replicated Weaviate setup |
 
-#### Example request for creating a class
+### Example request for creating a class
 
 import CodeSchemaCreate from '/_includes/code/schema.things.create.mdx';
 
@@ -277,13 +281,13 @@ import CodeSchemaCreateElaborate from '/_includes/code/schema.things.create.elab
 
 Retrieves the configuration of a single class in the schema. 
 
-#### Method and URL
+### Method and URL
 
 ```js
 GET /v1/schema/{className}
 ```
 
-#### Example request
+### Example request
 
 import CodeSchemaGetClass from '/_includes/code/schema.get.class.mdx';
 
@@ -293,19 +297,19 @@ import CodeSchemaGetClass from '/_includes/code/schema.get.class.mdx';
 
 Remove a class (and all data in the instances) from the schema.
 
-#### Method and URL
+### Method and URL
 
 ```js
 DELETE v1/schema/{class_name}
 ```
 
-#### Parameters
+### Parameters
 
 | name | location | type | description |
 | ---- | ---- | ----------- |
 | `{class_name}` | URL | string | The name of the class |
 
-#### Example request for deleting a class
+### Example request for deleting a class
 
 import CodeSchemaDelete from '/_includes/code/schema.things.delete.mdx';
 
@@ -315,17 +319,17 @@ import CodeSchemaDelete from '/_includes/code/schema.things.delete.mdx';
 
 Update settings of an existing schema class. 
 
-Use this endpoint to alter an existing class in the schema. Note that not all settings are mutable. If an error about immutable fields is returned and you still need to update this particular setting, you will have to delete the class (and the underlying data) and recreate. This endpoint cannot be used to modify properties. Instead use [`POST /v1/schema/{className}/properties`](#add-a-property). A typical use case for this endpoint is to update configuration, such as the `vectorIndexConfig`. Note that even in mutable sections, such as `vectorIndexConfig`, some fields may be immutable.
+Use this endpoint to alter an existing class in the schema. Note that not all settings are mutable. If an error about immutable fields is returned and you still need to update this particular setting, you will have to delete the class (and the underlying data) and recreate. This endpoint cannot be used to modify properties. Instead, use [`POST /v1/schema/{className}/properties`](#add-a-property). A typical use case for this endpoint is to update configuration, such as the `vectorIndexConfig`. Note that even in mutable sections, such as `vectorIndexConfig`, some fields may be immutable.
 
 You should attach a body to this PUT request with the **entire** new configuration of the class. 
 
-#### Method and URL
+### Method and URL
 
 ```js
 PUT v1/schema/{class_name}
 ```
 
-#### Parameters
+### Parameters
 
 Parameter in the PUT request:
 
@@ -336,21 +340,21 @@ Parameter in the PUT request:
 Parameter in the PUT body:
 
 | name | location | type | description |
-| ---- | ---- | ----------- |
-| `class` | body | string | The name of the class, multiple words should be concatenated in CamelCase like `ArticleAuthor`. |
+| ---- | ---- | ----------- | ---- |
+| `class` | body | string | The name of the class. Multiple words should be concatenated in CamelCase, e.g. `ArticleAuthor`. |
 | `description` | body | string | Description of the classname |
-| `vectorIndexType` | body | string | defaults to hnsw, can be omitted in schema definition since this is the only available type for now |
-| `vectorIndexConfig` | body | object | vector index type specific settings |
-| `vectorizer` | body | string | vectorizer to use for data objects added to this class, default can be set in Weaviate's environment variables |
-| `moduleConfig` > `text2vec-contextionary`  > `vectorizeClassName` | body | object | include the class name in vector calculation (default true). Learn more about how to regulate indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#regulate-semantic-indexing). |
+| `vectorIndexType` | body | string | Defaults to hnsw. Can be omitted in schema definition since this is the only available type for now. |
+| `vectorIndexConfig` | body | object | Vector index type specific settings |
+| `vectorizer` | body | string | Vectorizer to use for data objects added to this class. Default can be set via Weaviate environment variables. |
+| `moduleConfig` > `text2vec-contextionary`  > `vectorizeClassName` | body | object | Include the class name in vector calculation (default true). Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 | `properties` | body | array | An array of property objects |
-| `properties` > `dataType` | body | array | Click [here](/developers/weaviate/configuration/datatypes.md) for a list of available data types. |
+| `properties` > `dataType` | body | array | See the [available data types](/developers/weaviate/configuration/datatypes.md) |
 | `properties` > `description` | body | string | Description of the property |
-| `properties` > `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | if true, the whole property will NOT be included in vectorization. default is false, meaning that the object will be NOT be skipped |
-| `properties` > `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | whether name of the property is used in the calculation for the vector position of data objects. default is true. Learn more about how to regulate indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#regulate-semantic-indexing). |
-| `properties` > `name` | body | string | The name of the property, multiple words should be concatenated in camelCase like `nameOfAuthor`. |
-| `properties` > `indexInverted` | body | boolean | Should the the data stored in this property be indexed? Learn more about how to regulate indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#regulate-semantic-indexing). |
-| `properties` > `tokenization` | body | string | Only for `string`/`text` props. Introduced in `v1.12.0`. Control how a field is tokenized in the inverted index. Defaults to `"word"`, can be set to `"field"`. See [more details here](/developers/weaviate/configuration/schema-configuration.md#property-tokenization).|
+| `properties` > `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | If true, the whole property will NOT be included in vectorization. Default is false, meaning that the object will be NOT be skipped. |
+| `properties` > `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | Whether the name of the property is used in the calculation for the vector position of data objects. Default is true. Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `properties` > `name` | body | string | The name of the property. Multiple words should be concatenated in camelCase, e.g. `nameOfAuthor`. |
+| `properties` > `indexInverted` | body | boolean | Should the data stored in this property be indexed? Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `properties` > `tokenization` | body | string | Only for `string`/`text` props. Introduced in `v1.12.0`. Control how a field is tokenized in the inverted index. Defaults to `"word"`, can be set to `"field"`. Learn more about [property tokenization](/developers/weaviate/configuration/schema-configuration.md#property-tokenization).|
 | `invertedIndexConfig` > `stopwords` | body | object | Configure which words should be treated as stopwords and therefore be ignored on inverted indexing and querying. See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--stopwords-stopword-lists). |
 | `invertedIndexConfig` > `indexTimestamps` | body | boolean | Maintain an inverted index for each object by its internal timestamps, currently including `creationTimeUnix` and `lastUpdateTimeUnix` See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--indextimestamps). |
 
@@ -363,24 +367,24 @@ import CodeSchemaUpdate from '/_includes/code/schema.things.put.mdx';
 
 ## Add a property
 
-#### Method and URL
+### Method and URL
 
 ```js
 POST v1/schema/{class_name}/properties
 ```
 
-#### Parameters
+### Parameters
 
 | name | location | type | description |
 | ---- | ---- | ----------- |
 | `dataType` | body | array | Click [here](/developers/weaviate/configuration/datatypes.md) for a list of available data types. |
 | `description` | body | string | Description of the property |
 | `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | if true, the whole property will NOT be included in vectorization. default is false, meaning that the object will be NOT be skipped |
-| `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | whether name of the property is used in the calculation for the vector position of data objects. default is true. Learn more about how to regulate indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#regulate-semantic-indexing). |
+| `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | whether name of the property is used in the calculation for the vector position of data objects. default is true. Learn more about how to configure indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 | `name` | body | string | The name of the property, multiple words should be concatenated in camelCase like `nameOfAuthor`. |
-| `indexInverted` | body | boolean | Should the the data stored in this property be indexed? Learn more about how to regulate indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#regulate-semantic-indexing). |
+| `indexInverted` | body | boolean | Should the data stored in this property be indexed? Learn more about how to configure indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 
-#### Example request for adding a property
+### Example request for adding a property
 
 import CodeSchemaAddProperties from '/_includes/code/schema.things.properties.add.mdx';
 
@@ -392,21 +396,23 @@ As described in [Architecture > Storage](/developers/weaviate/concepts/storage.m
 
 You can view a list of all shards for a particular class:
 
-#### Method and URL
+### Method and URL
 
-*Note: This API was added in `v1.12.0`*
+:::note
+This API was added in `v1.12.0`.
+:::
 
 ```js
 GET v1/schema/{class_name}/shards
 ```
 
-#### Parameters
+### Parameters
 
 | name | location | type | description |
 | ---- | ---- | ----------- |
 | `{class_name}` | URL | string | The name of the class |
 
-#### Example request viewing shards of a class
+### Example request viewing shards of a class
 
 import CodeSchemaShardsGet from '/_includes/code/schema.shards.get.mdx';
 
@@ -416,7 +422,7 @@ import CodeSchemaShardsGet from '/_includes/code/schema.shards.get.mdx';
 
 A shard may have been marked as read-only, for example because the disk was full. You can manually set a shard to `READY` again using the following API. There is also a convenience function in each client to set the status of all shards of a class. 
 
-#### Method and URL
+### Method and URL
 
 :::note
 This API was added in `v1.12.0`
@@ -426,7 +432,7 @@ This API was added in `v1.12.0`
 PUT v1/schema/{class_name}/shards/{shard_name}
 ```
 
-#### Parameters
+### Parameters
 
 | name | location | type | description |
 | ---- | ---- | ----------- |
@@ -434,7 +440,7 @@ PUT v1/schema/{class_name}/shards/{shard_name}
 | `{shard_name}` | URL | string | The name/id of the shard |
 | `status` | body | string | The status to update the shard to. One of `READONLY`, `READY` |
 
-#### Example requests to update the status of a shard
+### Example requests to update the status of a shard
 
 import CodeSchemaShardsUpdate from '/_includes/code/schema.shards.put.mdx';
 

--- a/developers/weaviate/concepts/indexing.md
+++ b/developers/weaviate/concepts/indexing.md
@@ -17,30 +17,30 @@ import Badges from '/_includes/badges.mdx';
 
 Weaviate supports two types of indices.
 
-1. An **approximate nearest neighbor index (ANN)** - the ANN index is used to serve all vector-search queries.
+1. An **approximate nearest neighbor index (ANN)** - the ANN index is used to serve all vector-search queries.
 1. An **inverted index** - the inverted index allows for filtering by properties, as well as serve BM25 queries.
 
-You can configure indices in Weaviate per class. One of Weaviate's core strengths is combining the ANN index with an inverted index.
+You can configure indices in Weaviate per class. One of Weaviate's core strengths is combining the ANN index with an inverted index.
 
 Some things to bear in mind:
 
-* Especially for large datasets, configuring the indices is important because the more you index, the more storage is needed.
+* Especially for large datasets, configuring the indices is important because the more you index, the more storage is needed.
 * A rule of thumb -- if you don't query over a specific field or vector space, don't index it.
-* One of Weaviate's unique features is how the indices are regulated (learn more about this [here](../concepts/prefiltering.md)).
+* One of Weaviate's unique features is how the indices are configured (learn more about this [here](../concepts/prefiltering.md)).
 
 ### ANN indexing
 
 What's important to know, is that the "A" in ANN (i.e., the "approximate") comes with a trade-off. That is, the index is _approximate_ and, therefore _not_ always 100% accurate. This is what the experts mean when they talk about the "recall of the algorithm."
 
 :::tip
-There are different ANN algorithms, you can find a nice overview of them on <a href="http://ann-benchmarks.com/" data-proofer-ignore>this website</a>. Only those algorithms which support [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) can be used in Weaviate (we want that sweet database UX) and Weaviate's ANN system is [completely plug-and-playable](../concepts/index.md#weaviates-architecture-from-above) so that we can always add other algorithms in the future.
+There are different ANN algorithms, you can find a nice overview of them on <a href="http://ann-benchmarks.com/" data-proofer-ignore>this website</a>. Only those algorithms which support [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) can be used in Weaviate (we want that sweet database UX) and Weaviate's ANN system is [completely plug-and-playable](../concepts/index.md#weaviates-architecture-from-above) so that we can always add other algorithms in the future.
 :::
 
 <!-- TODO: Not sure if we need this here -->
 <!-- If you always want total recall (i.e., a 100% recall, not to be confused with the Arnold Schwarzenegger movie), you need brute-force vector comparisons that are super slow (as in, _really_ slow) and not useful for production settings (hence ANN algorithms exist). -->
 
 :::note
-Because vector search use cases are growing rapidly, more and more ANN-algorithm are produced. A "good" ANN algorithm means that the recall is high _and_ that it's fast. You can dive into the rabbit hole right [here](https://arxiv.org/search/?query=approximate+nearest+neighbor&searchtype=all). But! Don't be like Alice; just make sure to come back here.
+Because vector search use cases are growing rapidly, more and more ANN-algorithm are produced. A "good" ANN algorithm means that the recall is high _and_ that it's fast. You can dive into the rabbit hole right [here](https://arxiv.org/search/?query=approximate+nearest+neighbor&searchtype=all). But! Don't be like Alice; just make sure to come back here.
 :::
 
 Let's take a look a few ANN settings in an example schema.
@@ -80,7 +80,7 @@ Read more below on:
 - [Explanation of vector indices](../concepts/vector-index.md)
 
 :::note
-The [ANN benchmark page](/developers/weaviate/benchmarks/ann.md) contains a wide variety of vector search use cases and relative benchmarks. This page is ideal for finding a dataset similar to yours and learning what the most optimal settings are. 
+The [ANN benchmark page](/developers/weaviate/benchmarks/ann.md) contains a wide variety of vector search use cases and relative benchmarks. This page is ideal for finding a dataset similar to yours and learning what the most optimal settings are.
 :::
 
 ## Module configuration
@@ -102,7 +102,7 @@ An example configuration:
 }
 ```
 
-When using vectorizers, you need to set vectorization on the class and property level. In the case you use text vectorizers, the way the vectorizers work is explained [here](/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md#regulate-semantic-indexing).
+When using vectorizers, you need to set vectorization at the class and property level. If you use text vectorizers, the way the vectorizers work is explained [here](/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md#configure-semantic-indexing).
 
 ```js
 {

--- a/developers/weaviate/concepts/vector-index.md
+++ b/developers/weaviate/concepts/vector-index.md
@@ -20,7 +20,7 @@ This page explains what vector indices are, and what purpose they serve in Weavi
 :::info Related pages
 - [Concepts: Indexing](./indexing.md)
 - [Configuration: Indexes](../configuration/indexes.md)
-- [Configuration: Schema (Regulate semantic indexing)](../configuration/schema-configuration.md#regulate-semantic-indexing)
+- [Configuration: Schema (Configure semantic indexing)](../configuration/schema-configuration.md#configure-semantic-indexing)
 :::
 
 ## Introduction
@@ -73,7 +73,7 @@ Note that the vector index type only specifies how the vectors of data objects a
 [HNSW](https://arxiv.org/abs/1603.09320) is the first vector index type supported by Weaviate.
 
 ### What is HNSW?
-HNSW stands for Hierarchical Navigable Small World, a multilayered graph. Every object that is in the database, are captured in the lowest layer (layer 0 in the picture). These data objects are very well connected. On each layer on top of the lowest layer, there are fewer data points represented. These datapoints match with lower layers, but there are exponentially less points in each higher layer. If a search query comes in, the closest datapoints will be found in the highest layer. In the example below that is only one more datapoint. Then it goes one layer deeper, and finds the closest datapoints from the first found datapoint in the highest layer, and searches nearest neighbors from there. In the deepest layer, the actual closest data object to the search query will be found. 
+HNSW stands for Hierarchical Navigable Small World, a multilayered graph. Every object that is in the database, are captured in the lowest layer (layer 0 in the picture). These data objects are very well connected. On each layer on top of the lowest layer, there are fewer data points represented. These datapoints match with lower layers, but there are exponentially fewer points in each higher layer. If a search query comes in, the closest datapoints will be found in the highest layer. In the example below that is only one more datapoint. Then it goes one layer deeper, and finds the closest datapoints from the first found datapoint in the highest layer, and searches nearest neighbors from there. In the deepest layer, the actual closest data object to the search query will be found. 
 
 If there were no hierarchical layers in this approach, only the deepest layer (0) would be present and significantly more datapoints would have needed to be explored from the search query, since all data objects are present there. In higher layers, with less datapoints, fewer hops between datapoints need to be made, over larger distances. HNSW is a very fast and memory efficient approach of similarity search, because only the highest layer (top layer) is kept in cache instead of all the datapoints in the lowest layer. Only the datapoints that are closest to the search query are loaded once they are requested by a higher layer, which means that only a small amount of memory needs to be reserved.
 

--- a/developers/weaviate/configuration/schema-configuration.md
+++ b/developers/weaviate/configuration/schema-configuration.md
@@ -39,13 +39,12 @@ It has the following characteristics:
 * When a previously seen class is imported, which contains a property that Weaviate has not seen yet, the module alters the schema before importing the object. See section "DataTypes" below for details on how a property should be created.
 * When a previously seen class is imported, which contains a property which conflicts with the current schema type, an error is thrown. (e.g. trying to import a `string` into a field that exists in the schema as `int`).
 * When a previously unseen class is imported, the class is created alongside all the properties.
-* Also Weaviate automatically recognizes array datatypes, such as `string[]`, `int[]`, `text[]`, `number[]`, `boolean[]` and `date[]`. 
+* Weaviate also automatically recognizes array datatypes, such as `string[]`, `int[]`, `text[]`, `number[]`, `boolean[]` and `date[]`. 
 
 ### Class
 
 A class describes a data object in the form of a noun (e.g., *Person*,
-*Product*, *Timezone*, etcetera) or a verb (e.g., *Move*, *Buy*, *Eat*,
-etcetera). If you are using the `text2vec-contextionary` vectorizer module,
+*Product*, *Timezone*) or a verb (e.g., *Move*, *Buy*, *Eat*). If you are using the `text2vec-contextionary` vectorizer module,
 then Weaviate will always validate if it contextually understands the words in
 the name you include in the schema. If you add a Class name that it can't
 recognize, it will not accept the schema.
@@ -112,25 +111,29 @@ An example of a complete class object including properties:
 }
 ```
 
-#### vectorizer
+### vectorizer
 
 The vectorizer (`"vectorizer": "..."`) can be specified per class in the schema object. Check the [modules page](/developers/weaviate/modules/index.md) for available vectorizer modules.
 
 In case you don't want to use a vectorization module to calculate vectors from data objects, and want to enter the vectors per data object yourself when adding data objects, make sure to set `"vectorizer": "none"`.
 
-__Regulate semantic indexing__
+__Configure semantic indexing__
 
-With the [`text2vec-contextionary`](/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md) vectorizer module you can specify whether class names, property names or entire properties are included in the calculation of the data object's vector. Read [here](/developers/weaviate/configuration/schema-configuration.md#regulate-semantic-indexing) how this works.
+With the [`text2vec-contextionary`](/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md) vectorizer module you can specify whether class names, property names or entire properties are included in the calculation of the data object's vector. Read [here](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing) how this works.
 
-#### vectorIndexType
+### vectorIndexType
 
 The vectorIndexType defaults to [`hnsw`](/developers/weaviate/concepts/vector-index.md#hnsw) since this is the only available vector indexing algorithm implemented at the moment.
 
-#### vectorIndexConfig
+### vectorIndexConfig
 
 Check the [`hnsw` page](/developers/weaviate/configuration/indexes.md#how-to-configure-hnsw) for `hnsw` parameters that you can configure. This includes setting the distance metric to be used with Weaviate.
 
-#### shardingConfig (introduced in v1.8.0)
+### shardingConfig
+
+:::note
+Introduced in v1.8.0.
+:::
 
 The `"shardingConfig"` controls how a class should be [sharded and distributed across multiple nodes](/developers/weaviate/concepts/cluster.md). All values are optional and default to the following settings:
 
@@ -188,9 +191,11 @@ The meaning of the individual fields in detail:
   target (virtual - and therefore physical) shard. `"murmur3"` creates a 64bit
   hash making hash collisions very unlikely.
 
-#### invertedIndexConfig > stopwords (Stopword lists)
+### invertedIndexConfig > stopwords (stopword lists)
 
-*Note: This feature was introduced in `v1.12.0`.*
+:::note
+This feature was introduced in `v1.12.0`.
+:::
 
 Properties of type `text` and `string` may contain words that are very common
 and have no meaning. In this case you may want to remove them entirely from
@@ -218,19 +223,22 @@ preset and adding all your desired stopwords as additions.
 This configuration allows stopwords to be configured by class. If not set, these values are set to the following defaults:
 
 | Parameter | Default value | Acceptable values |
-| --- | --- | --- | 
+| --- | --- | --- |
 | `"preset"` | `"en"` | `"en"`, `"none"` |
 | `"additions"` | `[]` | *any list of custom words* |
 | `"removals"` | `[]` | *any list of custom words* |
 
 
-**Notes**
+:::note
 - If none is the selected preset, then the class' stopwords will consist entirely of the additions list.
 - If the same item is included in both additions and removals, then an error is returned
+:::
 
-#### invertedIndexConfig > indexTimestamps
+### invertedIndexConfig > indexTimestamps
 
-*Note: This feature was introduced in `v1.13.0`.*
+:::note
+This feature was introduced in `v1.13.0`.
+:::
 
 To perform queries which are filtered by timestamps, the target class must first be configured to maintain an inverted index for each object by their internal timestamps -- currently these include `creationTimeUnix` and `lastUpdateTimeUnix`. This configuration is done by setting the `indexTimestamps` field of the `invertedIndexConfig` object to `true`.
 
@@ -240,9 +248,11 @@ To perform queries which are filtered by timestamps, the target class must first
   }
 ```
 
-#### invertedIndexConfig > indexNullState
+### invertedIndexConfig > indexNullState
 
-*Note: This feature was introduced in `v1.16.0`.*
+:::note
+This feature was introduced in `v1.16.0`.
+:::
 
 To perform queries which are filtered by being null or not null, the target class must first be configured to maintain an inverted index for each property of a class that tracks if objects are null or not. This configuration is done by setting the `indexNullState` field of the `invertedIndexConfig` object to `true`.
 
@@ -252,9 +262,11 @@ To perform queries which are filtered by being null or not null, the target clas
   }
 ```
 
-#### invertedIndexConfig > indexPropertyLength
+### invertedIndexConfig > indexPropertyLength
 
-*Note: This feature was introduced in `v1.16.0`.*
+:::note
+This feature was introduced in `v1.16.0`.
+:::
 
 To perform queries which are filtered by the length of a property, the target class must first be configured to maintain an inverted index for this. This configuration is done by setting the `indexPropertyLength` field of the `invertedIndexConfig` object to `true`.
 
@@ -265,8 +277,9 @@ To perform queries which are filtered by the length of a property, the target cl
 ```
 
 
-**Notes**
-- Using these features requires more resources, as the additional inverted indices must be created/maintained for the lifetime of the Class
+:::note
+Using these features requires more resources, as the additional inverted indices must be created/maintained for the lifetime of the class.
+:::
 
 ## Property object
 
@@ -323,9 +336,11 @@ Author
   writesFor
 ```
 
-### Property Tokenization
+### Property tokenization
 
-*Note: This feature was introduced in `v1.12.0`.*
+:::note
+This feature was introduced in `v1.12.0`.
+:::
 
 Properties of type `text` and `string` use tokenization when indexing and
 searching through the inverted index. Text is always tokenized at the `word`
@@ -346,20 +361,22 @@ would not return the object mentioned above, but only the exact string `"hello
 If no values are provided, properties of type `text` and `string` default to
 `"word"` level tokenization for backward-compatibility.
 
-## Regulate semantic indexing
+## Configure semantic indexing
 
-* Only for `text2vec` module
+:::info
+Only for `text2vec-*` modules
+:::
 
 In the schema you can define advanced settings for how data is stored and used by Weaviate. 
 
-In some cases, you want to be able to regulate specific parts of the schema to optimise indexing.
+In some cases, you want to be able to configure specific parts of the schema to optimize indexing.
 
 For example, a data object with the following schema:
 
 ```yaml
 Article:
   title: Cows lose their jobs as milk prices drop
-  summary: As his 100 diary cows lumberred over for their Monday...
+  summary: As his 100 diary cows lumbered over for their Monday...
 ```
 
 which will be vectorized as:
@@ -367,15 +384,15 @@ which will be vectorized as:
 ```md
 article cows lose their
 jobs as milk prices drop summary
-as his diary cows lumberred
+as his diary cows lumbered
 over for their monday
 ```
 
-By default, the `class name` and all property `values` *will* be taken in the calculation, but the property `names` *will not* be indexed. There are four ways in which you can regulate the indexing.
+By default, the `class name` and all property `values` *will* be taken in the calculation, but the property `names` *will not* be indexed. There are four ways in which you can configure the indexing.
 
-#### Datatypes
+### Datatypes
 
-Weaviate needs to guess the datatypes based on the objects it sees, for this you can set some preferences. e.g.
+Weaviate needs to guess the datatypes based on the objects it sees. For this you can set some preferences. e.g.
 
 * `AUTOSCHEMA_DEFAULT_STRING=text` would tell Weaviate that when it sees a prop of type `string`, it should treat it as `text` (as opposed to `string`)
 * `AUTOSCHEMA_DEFAULT_NUMBER=number` would tell Weaviate that when its sees a numerical value, it should treat it as number as opposed to `int`, etc.
@@ -387,7 +404,7 @@ In addition, we need to catch types we do not support at all:
 * Any map type is forbidden, unless it clearly matches one of the two supported types `phoneNumber` or `geoCoordinates`.
 * Any array type is forbidden, unless it is clearly a reference-type. In this case, Weaviate needs to resolve the beacon and see what the class of the resolved beacon is, since it needs the ClassName to be able to alter the schema.
 
-#### Default distance metric
+### Default distance metric
 
 Weaviate allows you to configure the `DEFAULT_VECTOR_DISTANCE_METRIC` which will be applied to every class unless overridden individually. You can choose from: `cosine` (default), `dot`, `l2-squared`, `manhattan`, `hamming`.
 

--- a/developers/weaviate/installation/docker-compose.md
+++ b/developers/weaviate/installation/docker-compose.md
@@ -25,7 +25,7 @@ import DocsConfigGen from '/_includes/docs-config-gen.mdx';
 If you are new to Docker (Compose) and containerization, check out our [Docker Introduction for Weaviate Users](https://medium.com/semi-technologies/what-weaviate-users-should-know-about-docker-containers-1601c6afa079).
 :::
 
-To start Weaviate with docker-compose, you need a docker-compose configuration file, typically called `docker-compose.yml`. You can obtain it from the configuration tool above or alternatively pick one of the examples below. Additional [environment variables](#environment-variables) can be set in this file, which regulate your Weaviate setup, authentication and authorization, module settings, and data storage settings.
+To start Weaviate with docker-compose, you need a docker-compose configuration file, typically called `docker-compose.yml`. You can obtain it from the configuration tool above or alternatively pick one of the examples below. Additional [environment variables](#environment-variables) can be set in this file, which control your Weaviate setup, authentication and authorization, module settings, and data storage settings.
 
 ## Persistent volume
 

--- a/developers/weaviate/tutorials/import.md
+++ b/developers/weaviate/tutorials/import.md
@@ -132,7 +132,7 @@ Our rules of thumb are:
 * You should always use batch import.
 * As mentioned above, max out your CPUs (on the Weaviate cluster). Often your import script is the bottleneck.
 * Process error messages.
-* Some clients (especially Python) have some built-in logic to efficiently regulate batch importing.
+* Some clients (especially Python) have some built-in logic to efficiently control batch importing.
 
 ### Error handling
 


### PR DESCRIPTION
### Why:

Started by replacing "regulate" with "configure" or "control". Found out that tables in the [Schema page](https://weaviate.io/developers/weaviate/api/rest/schema#parameters) had missing columns.

### What's being changed:

* properly cascading headings (level 2 -> 3 instead of 2 -> 4)
* semantic links instead of "click here"
* "note" admonitions
* replace NBSPs with regular spaces