### PR TITLE
[docs:fix] broken link due to tutorial code change

### DIFF
--- a/blog/2022-12-12-cohere-multilingual-with-weaviate/index.mdx
+++ b/blog/2022-12-12-cohere-multilingual-with-weaviate/index.mdx
@@ -131,7 +131,7 @@ If you have interesting data project ideas, give me a shout on [Weaviate communi
 ### Project in github
 You can find the test project on [GitHub](https://github.com/weaviate-tutorials/cohere-multilingual-test). Follow the readme instructions on how to set it up for yourself.
 
-Probably the most interesting part is the [query code](https://github.com/weaviate-tutorials/cohere-multilingual-test/blob/main/_query_base.py), which is made of 3 parts:
+Probably the most interesting part is the [query code](https://github.com/weaviate-tutorials/cohere-multilingual-test/blob/main/_tools.py), which is made of 3 parts:
 
 * `nearText` – parameters where we pass in the query from the user
 * `properties` – a list of properties we want back from the database


### PR DESCRIPTION
### Why:

This PR fixes: A broken link to the tutorial code

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)
