### PR TITLE
copyedit(replication): readability fixes

### DIFF
--- a/_includes/code/replication.get.object.by.id.mdx
+++ b/_includes/code/replication.get.object.by.id.mdx
@@ -18,9 +18,9 @@ data_object = (
   )
 )
 
-# The parameter "consistency_level" can be one of ConsistencyLevel.ALL, ConsistencyLevel.QUORUM,
-# or ConsistencyLevel.ONE. Determines how many replicas must acknowledge a request before it is
-# considered successful.
+# The parameter "consistency_level" can be one of ConsistencyLevel.ALL,
+# ConsistencyLevel.QUORUM, or ConsistencyLevel.ONE. Determines how many
+# replicas must acknowledge a request before it is considered successful.
 
 print(data_object)
 ```
@@ -50,8 +50,14 @@ client
         console.error(err)
     });
 
-// The parameter "withConsistencyLevel" can be one of weaviate.replication.ConsistencyLevel.ALL, weaviate.replication.ConsistencyLevel.QUORUM, or weaviate.replication.ConsistencyLevel.ONE. Determines how many replicas must acknowledge a request before it is considered successful.
-    
+// The parameter passed to `withConsistencyLevel` can be one of:
+// * weaviate.replication.ConsistencyLevel.ALL,
+// * weaviate.replication.ConsistencyLevel.QUORUM, or
+// * weaviate.replication.ConsistencyLevel.ONE.
+//
+// It determines how many replicas must acknowledge a request
+// before it is considered successful.
+
 ```
 
 </TabItem>
@@ -87,7 +93,13 @@ func main() {
     fmt.Printf("%v", data)
 }
 
-// The parameter "WithConsistencyLevel" can be one of weaviate.replication.ConsistencyLevel.ALL, weaviate.replication.ConsistencyLevel.QUORUM, or weaviate.replication.ConsistencyLevel.ONE. Determines how many replicas must acknowledge a request before it is considered successful.
+// The parameter passed to "WithConsistencyLevel" can be one of:
+// * weaviate.replication.ConsistencyLevel.ALL,
+// * weaviate.replication.ConsistencyLevel.QUORUM, or
+// * weaviate.replication.ConsistencyLevel.ONE.
+//
+// It determines how many replicas must acknowledge a request
+// before it is considered successful.
 
 ```
 
@@ -123,7 +135,13 @@ public class App {
   }
 }
 
-// The parameter "withConsistencyLevel" can be one of ConsistencyLevel.ALL, ConsistencyLevel.QUORUM, or ConsistencyLevel.ONE. Determines how many replicas must acknowledge a request before it is considered successful.
+// The parameter passed to `withConsistencyLevel` can be one of:
+// * weaviate.replication.ConsistencyLevel.ALL,
+// * weaviate.replication.ConsistencyLevel.QUORUM, or
+// * weaviate.replication.ConsistencyLevel.ONE.
+//
+// It determines how many replicas must acknowledge a request
+// before it is considered successful.
 
 ```
 
@@ -133,7 +151,8 @@ public class App {
 ```bash
 $ curl http://localhost:8080/v1/objects/MyClass/36ddd591-2dee-4e7e-a3cc-eb86d30a4303?consistency_level=QUORUM
 
-# The parameter "consistency_level" can be one of ALL, QUORUM, or ONE. Determines how many replicas must acknowledge a request before it is considered successful.
+# The parameter "consistency_level" can be one of ALL, QUORUM, or ONE. Determines how many
+# replicas must acknowledge a request before it is considered successful.
 # curl /v1/objects/{className}/{id}?consistency_level=ALL
 ```
 

--- a/_includes/code/schema.things.create.replication.mdx
+++ b/_includes/code/schema.things.create.replication.mdx
@@ -38,28 +38,21 @@ const client = weaviate.client({
   host: 'localhost:8080',
 });
 
-let classObj = {
-    'class': 'Article',
-    'properties': [
+const classObj = {
+    class: 'Article',
+    properties: [
         {
-            'dataType': [
+            dataType: [
                 'string'
             ],
-            'description': 'Title of the article',
-            'name': 'title',
-            'indexInverted': true,
-            'moduleConfig': {
-                'text2vec-contextionary': {
-                  'skip': false,                   
-                  'vectorizePropertyName': false
-                }
-              }
+            description: 'Title of the article',
+            name: 'title'
         }
     ],
-    'replicationConfig': {
-      'factor': 3
+    replicationConfig: {
+      factor: 3
     }
-}
+};
 
 client
   .schema
@@ -174,14 +167,7 @@ $ curl \
                 "string"
             ],
             "description": "Title of the article",
-            "name": "title",
-            "indexInverted": true,
-            "moduleConfig": {
-                "text2vec-contextionary": {
-                  "skip": false,                   
-                  "vectorizePropertyName": true
-                }
-              }
+            "name": "title"
         },
     ],
     "replicationConfig": {

--- a/_includes/code/schema.things.create.replication.mdx
+++ b/_includes/code/schema.things.create.replication.mdx
@@ -38,7 +38,7 @@ const client = weaviate.client({
   host: 'localhost:8080',
 });
 
-const classObj = {
+let classObj = {
     class: 'Article',
     properties: [
         {

--- a/developers/weaviate/concepts/replication-architecture/cluster-architecture.md
+++ b/developers/weaviate/concepts/replication-architecture/cluster-architecture.md
@@ -8,7 +8,7 @@ import Badges from '/_includes/badges.mdx';
 
 <Badges/>
 
-This page describes how the nodes or clusters in Weaviate's replication are designed in a leaderless fashion. 
+This page describes how the nodes or clusters in Weaviate's replication design behave in a leaderless fashion. 
 
 ## Leaderless Design
 
@@ -20,12 +20,14 @@ The following illustration shows a leaderless replication design in Weaviate. Th
 
 <p align="center"><img src="/img/docs/replication-architecture/replication-main-quorum.png" alt="Replication Architecture" width="75%"/></p>
 
-The main advantage of a leaderless replication design is improved fault-tolerance. Without a leader that handles all requests, a leaderless design offers better availability. In a single-leader design, all writes need to be processed by this leader. If this node cannot be reached or goes down, no writes can be processed. With a leaderless design, all nodes can receive write operations, so there is no risk of one master node failing.
+The main advantage of a leaderless replication design is improved fault tolerance. Without a leader that handles all requests, a leaderless design offers better availability. In a single-leader design, all writes need to be processed by this leader. If this node cannot be reached or goes down, no writes can be processed. With a leaderless design, all nodes can receive write operations, so there is no risk of one master node failing.
 
 On the flipside of high availability, a leaderless database tends to be less consistent. Because there is no leader node, data on different nodes may temporarily be out of date. Leaderless databases tend to be eventually consistent. Consistency in Weaviate is [tunable](./consistency.md), but this occurs at the expense of availability. 
 
 
 ## Replication Factor
+
+In Weaviate, replication is enabled and controlled per class. This means you can have different replication factors for different classes.
 
 The replication factor (RF or n) determines how many copies of data are stored in the distributed setup. A replication factor of 1 means that there is only 1 copy of each data entry in the database setup, in other words there is no replication. A replication factor of 2 means that there are two copies of each data entry, which are present on two different nodes (replicas). Naturally, the replication factor cannot be higher than the number of nodes. Any node in the cluster can act as a coordinating node to lead queries to the correct target node(s). 
 
@@ -41,7 +43,7 @@ On a write operation, the client’s request will be sent to any node in the clu
 **Steps**
 1. The client sends data to any node, which will be assigned as the coordinator node
 2. The coordinator node sends the data to more than one replica node in the cluster
-3. The coordinator node waits for acknowledgement from x nodes. Starting with v1.18, x is [configurable](./consistency.md), and defaults to ALL nodes.
+3. The coordinator node waits for acknowledgement from x nodes. Starting with v1.18, x is [configurable](./consistency.md), and defaults to `ALL` nodes.
 4. When x ACKs are received by the coordinator node, the write is successful.
 
 As an example, consider a cluster size of 3 with replication factor of 3. So, all nodes in the distributed setup contain a copy of the data. When the client sends new data, this will be replicated to all three nodes.
@@ -59,7 +61,7 @@ Read operations are also coordinated by a coordinator node, which directs a quer
 **Steps**
 1. The client sends a query to Weaviate, any node in the cluster that receives the request first will act as the coordinator node
 2. The coordinator node sends the query to more than one replica node in the cluster
-3. The coordinator waits for a response from x nodes. *x is [configurable](./consistency.md) (ALL, QUORUM or ONE, available from v1.18, Get-Object-By-ID type requests have tunable consistency from v1.17).*
+3. The coordinator waits for a response from x nodes. *x is [configurable](./consistency.md) (`ALL`, `QUORUM` or `ONE`, available from v1.18, Get-Object-By-ID type requests have tunable consistency from v1.17).*
 4. The coordinator node resolves conflicting data using some metadata (e.g. timestamp, id, version number)
 5. The coordinator returns the latest data to the client
 

--- a/developers/weaviate/concepts/replication-architecture/consistency.md
+++ b/developers/weaviate/concepts/replication-architecture/consistency.md
@@ -41,7 +41,7 @@ Data objects in Weaviate have **eventual consistency**, which means that all nod
 
 Eventual consistency is chosen over strong consistency, to ensure high availability. Nevertheless, write and read consistency are tunable, so you have some influence on the tradeoff between availability and consistency. 
 
-*The animation below is an example of how a write or a read is performed with Weaviate with a replication factor of 3 and 8 nodes. The blue node acts as coordinator node. The consistency level is set to QUORUM, so the coordinator node only waits for two out of three responses before sending the result back to the client.*
+*The animation below is an example of how a write or a read is performed with Weaviate with a replication factor of 3 and 8 nodes. The blue node acts as coordinator node. The consistency level is set to `QUORUM`, so the coordinator node only waits for two out of three responses before sending the result back to the client.*
 
 <p align="center"><img src="/img/docs/replication-architecture/replication-quorum-animation.gif" alt="Write consistency QUORUM" width="75%"/></p>
 
@@ -50,12 +50,12 @@ Eventual consistency is chosen over strong consistency, to ensure high availabil
 Adding or changing data objects are **write** operations.  
 
 :::note
-Write operations are tunable starting with Weaviate v1.18, to ONE, QUORUM or ALL. In v1.17, write operations are always set to ALL (highest consistency).
+Write operations are tunable starting with Weaviate v1.18, to `ONE`, `QUORUM` or `ALL`. In v1.17, write operations are always set to `ALL` (highest consistency).
 :::
 
-The main reason for introducing configurable write consistency in v1.18 is because that is also when automatic repairs are introduced. A write will always be written to n (replication factor) nodes, regardless of the chosen consistency level. The coordinator node however waits for acknowledgements from ONE, QUORUM or ALL nodes before it returns. To guarantee that a write is applied everywhere without the availability of repairs on read requests, write consistency is set to ALL for now. Possible settings in v1.18+ are:
+The main reason for introducing configurable write consistency in v1.18 is because that is also when automatic repairs are introduced. A write will always be written to n (replication factor) nodes, regardless of the chosen consistency level. The coordinator node however waits for acknowledgements from `ONE`, `QUORUM` or `ALL` nodes before it returns. To guarantee that a write is applied everywhere without the availability of repairs on read requests, write consistency is set to `ALL` for now. Possible settings in v1.18+ are:
 * **ONE** - a write must receive an acknowledgement from at least one replica node. This is the fastest (most available), but least consistent option. 
-* **QUORUM** - a write must receive an acknowledgement from at least QUORUM replica nodes. QUORUM is calculated as _n / 2 + 1_, where _n_ is the number of replicas (replication factor). For example, using a replication factor of 6, the quorum is 4, which means the cluster can tolerate 2 replicas down.
+* **QUORUM** - a write must receive an acknowledgement from at least `QUORUM` replica nodes. `QUORUM` is calculated as _n / 2 + 1_, where _n_ is the number of replicas (replication factor). For example, using a replication factor of 6, the quorum is 4, which means the cluster can tolerate 2 replicas down.
 * **ALL** - a write must receive an acknowledgement from all replica nodes. This is the most consistent, but 'slowest' (least available) option.
 
 
@@ -63,27 +63,27 @@ The main reason for introducing configurable write consistency in v1.18 is becau
 
 <p align="center"><img src="/img/docs/replication-architecture/replication-rf3-c-ONE.png" alt="Write consistency ONE" width="60%"/></p>
 
-*Figure below: a replicated Weaviate setup with Write Consistency of QUORUM (n/2+1). There are 8 nodes in total, out of which 3 replicas.*
+*Figure below: a replicated Weaviate setup with Write Consistency of `QUORUM` (n/2+1). There are 8 nodes in total, out of which 3 replicas.*
 
 
 <p align="center"><img src="/img/docs/replication-architecture/replication-rf3-c-QUORUM.png" alt="Write consistency QUORUM" width="60%"/></p>
 
-*Figure below: a replicated Weaviate setup with Write Consistency of ALL. There are 8 nodes in total, out of which 3 replicas.*
+*Figure below: a replicated Weaviate setup with Write Consistency of `ALL`. There are 8 nodes in total, out of which 3 replicas.*
 
 <p align="center"><img src="/img/docs/replication-architecture/replication-rf3-c-ALL.png" alt="Write consistency ALL" width="60%"/></p>
 
 
 ### Tunable Read Consistency
 
-Read operations are GET queries to data objects in Weaviate. Like write, read consistency is tunable, to ONE, QUORUM or ALL.
+Read operations are GET queries to data objects in Weaviate. Like write, read consistency is tunable, to `ONE`, `QUORUM` or `ALL`.
 
 :::note
-With v1.17, read consistency is tunable only for Get-Objects-By-ID type requests. All read requests (including searches) will be added in v1.18. Read requests other than Get-Objects-By-ID have a read consistency of ALL.
+With v1.17, read consistency is tunable only for Get-Objects-By-ID type requests. All read requests (including searches) will be added in v1.18. Read requests other than Get-Objects-By-ID have a read consistency of `ALL`.
 :::
 
 Possible Read Consistency levels are:
 * **ONE** - a read response must be returned by at least one replica. This is the fastest (most available), but least consistent option. 
-* **QUORUM** - a response must be returned by QUORUM amount of replica nodes. QUORUM is calculated as _n / 2 + 1_, where _n_ is the number of replicas (replication factor). For example, using a replication factor of 6, the quorum is 4, which means the cluster can tolerate 2 replicas down.
+* **QUORUM** - a response must be returned by `QUORUM` amount of replica nodes. `QUORUM` is calculated as _n / 2 + 1_, where _n_ is the number of replicas (replication factor). For example, using a replication factor of 6, the quorum is 4, which means the cluster can tolerate 2 replicas down.
 * **ALL** - a read response must be returned by all replicas. The read operation will fail if at least one replica fails to respond. This is the most consistent, but 'slowest' (least available) option.
 
 Examples:
@@ -93,20 +93,20 @@ Examples:
   <p align="center"><img src="/img/docs/replication-architecture/replication-rf3-c-ONE.png" alt="Write consistency ONE" width="60%"/></p>
 
 * **QUORUM**<br/>
-  In a single datacenter with a replication factor of 3 and a read consistency level of QUORUM, the coordinator node will wait for n / 2 + 1 = 3 / 2 + 1 = 2 replicas nodes to return a response.
+  In a single datacenter with a replication factor of 3 and a read consistency level of `QUORUM`, the coordinator node will wait for n / 2 + 1 = 3 / 2 + 1 = 2 replicas nodes to return a response.
 
   <p align="center"><img src="/img/docs/replication-architecture/replication-rf3-c-QUORUM.png" alt="Write consistency QUORUM" width="60%"/></p>
 
 
 * **ALL**<br/>
-  In a single datacenter with a replication factor of 3 and a read consistency level of ALL, the coordinator node will wait for all 3 replicas nodes to return a response.
+  In a single datacenter with a replication factor of 3 and a read consistency level of `ALL`, the coordinator node will wait for all 3 replicas nodes to return a response.
 
   <p align="center"><img src="/img/docs/replication-architecture/replication-rf3-c-ALL.png" alt="Write consistency ALL" width="60%"/></p>
 
   
 ## Repairs
 
-Repairs can be executed by Weaviate in case of a discovered inconsistency. A scenario where a repair could be necessary is the following: The user writes with a consistency level of ONE. The node dies before it can contact some of the other nodes. The node comes back up with the latest data. Some other nodes may now be out of sync and need to be repaired.
+Repairs can be executed by Weaviate in case of a discovered inconsistency. A scenario where a repair could be necessary is the following: The user writes with a consistency level of `ONE`. The node dies before it can contact some of the other nodes. The node comes back up with the latest data. Some other nodes may now be out of sync and need to be repaired.
 
 Repairs can happen in the background, for example when a read operation is done. Repairs (and more information about them) will be available starting with v1.18 (Q1 2023).
 

--- a/developers/weaviate/concepts/replication-architecture/motivation.md
+++ b/developers/weaviate/concepts/replication-architecture/motivation.md
@@ -21,15 +21,15 @@ Examples of applications where High Availability is desired are emergency servic
 
 
 High Availability can be illustrated by the following configuration examples:
-1. Write ALL, Read ONE - There is no High Availability during writing because ALL nodes need to respond to write requests. There is High Availability on read requests: all nodes can go down except one while reading and the read operations are still available.
-2. Write QUORUM, Read QUORUM (n/2+1) - A minority of nodes could go down, the majority of nodes should be up and running, and you can still do both reading and writing. 
-3. Write ONE, Read ONE - This is the most available configuration. All but one node can go down and both read and write operations are still possible. Note that this super High Availability comes with a cost of Low Consistency guarantees. Due to eventual consistency, your application must be able to deal with temporarily showing out-of-date data.
+1. Write `ALL`, Read `ONE` - There is no High Availability during writing because `ALL` nodes need to respond to write requests. There is High Availability on read requests: all nodes can go down except one while reading and the read operations are still available.
+2. Write `QUORUM`, Read `QUORUM` (n/2+1) - A minority of nodes could go down, the majority of nodes should be up and running, and you can still do both reading and writing. 
+3. Write `ONE`, Read `ONE` - This is the most available configuration. All but one node can go down and both read and write operations are still possible. Note that this super High Availability comes with a cost of Low Consistency guarantees. Due to eventual consistency, your application must be able to deal with temporarily showing out-of-date data.
 
 
 ## Increased (Read) Throughput
 When you have many read requests on your Weaviate instance, for example because you're building an application for many users, the database setup should be able to support high throughput. Throughput is measured in Queries Per Second (QPS). Adding extra server nodes to your database setup means that the throughput scales with it. The more server nodes, the more users (read operations) the system will be able to handle. Thus, replicating your Weaviate instance increases throughput. 
 
-When reading is set to a low consistency level (e.g. ONE), then scaling the replication factor (i.e. the number of database server nodes) increases the throughput linearly. For example, when the read consistency level is ONE, if one node can reach 10,000 QPS, then a setup with 3 replica nodes can receive 30,000 QPS.
+When reading is set to a low consistency level (i.e. `ONE`), then scaling the replication factor (i.e. the number of database server nodes) increases the throughput linearly. For example, when the read consistency level is `ONE`, if one node can reach 10,000 QPS, then a setup with 3 replica nodes can receive 30,000 QPS.
 
 <p align="center"><img src="/img/docs/replication-architecture/replication-increased-throughput.png" alt="Increased Throughput" width="75%"/></p>
 

--- a/developers/weaviate/configuration/replication.md
+++ b/developers/weaviate/configuration/replication.md
@@ -8,21 +8,21 @@ import Badges from '/_includes/badges.mdx';
 
 <Badges/>
 
-:::info Related pages
+:::info Prerequisites
 - [Concepts: Replication Architecture](../concepts/replication-architecture/index.md)
 :::
 
 Weaviate instances can be replicated to increase availability, read throughput and enable zero downtime upgrades. On this page, you will learn how to set replication for your Weaviate instance.
 
 :::caution Note:
-From v1.17, you can set the Replication Factor per class in the schema. Consistency levels are tunable in queries, which will be available from v1.18 (except for [read consistency for objects by ID](../concepts/replication-architecture/consistency.md#tunable-read-consistency), which is tunable from v1.17). 
+Starting with v1.17, you can set the Replication Factor per class in the schema. Consistency levels are tunable in queries, which will be available from v1.18 (except for [read consistency for objects by ID](../concepts/replication-architecture/consistency.md#tunable-read-consistency), which is tunable from v1.17). 
 :::
 
-Read more about how Replication is designed and built in Weaviate on the [Replication Architecture](../concepts/replication-architecture/index.md) pages.
+For more about how replication is designed and built in Weaviate, see the [Replication Architecture](../concepts/replication-architecture/index.md) pages.
 
 ## How to configure: Schema
 
-Replication is enabled per data class in the [data schema](./schema-configuration.md). This means you can set different replication factors per class in your dataset. To enable replication on a class (this is disabled by default), the replication factor has to be set. In a class in the schema, this looks like the following. `"replicationConfig": {“factor”: 3”}` can be specified per class in the schema object.
+Replication is enabled per data class in the [data schema](./schema-configuration.md). This means you can set different replication factors per class in your dataset. To enable replication on a class (this is disabled by default), the replication factor has to be set. In a class in the schema, this looks like the following: `"replicationConfig": {"factor": 3"}` can be specified per class in the schema object.
 
 
 ```json
@@ -33,16 +33,16 @@ Replication is enabled per data class in the [data schema](./schema-configuratio
       "name": "exampleProperty", 
       "dataType": [                         
         "string"
-      ],
+      ]
     }
   ],
   "replicationConfig": {
-    "factor": 3     // Integer, default is 1. Replication Factor is the amount of copies of this class that will be stored.
+    "factor": 3   // Integer, default 1. How many copies of this class will be stored.
   }
 }
 ```
 
-Here's an example for all the clients:
+Here's an example for all clients:
 
 import SchemaReplication from '/_includes/code/schema.things.create.replication.mdx';
 
@@ -54,17 +54,17 @@ When you set this replication factor in the data schema before you add data, you
 Changing the replication factor after adding data is an **experimental feature** as of v1.17 and will become more stable in the future.
 :::
 
-The data schema has a write consistency level of `ALL`, which means when you upload or update a schema, this will be sent to `ALL` nodes (via a coordinator node). The coordinator node waits for a successful acknowledgement from `ALL` nodes before sending a success message back to the client. This ensures a high consistent schema in your distributed Weaviate setup.
+The data schema has a write consistency level of `ALL`, which means when you upload or update a schema, this will be sent to `ALL` nodes (via a coordinator node). The coordinator node waits for a successful acknowledgement from `ALL` nodes before sending a success message back to the client. This ensures a highly consistent schema in your distributed Weaviate setup.
 
 
 ## How to use: Queries
 
-When you add (write) or query (read) data, one or more replica nodes in the cluster will respond to the request. How many nodes need to send a successful response and acknowledgement to the coordinator node depends on the `consistency_level`. Available consistency levels are ONE, QUORUM (n/2+1) and ALL. Read more about consistency level [here](../concepts/replication-architecture/consistency.md).
+When you add (write) or query (read) data, one or more replica nodes in the cluster will respond to the request. How many nodes need to send a successful response and acknowledgement to the coordinator node depends on the `consistency_level`. Available consistency levels are `ONE`, `QUORUM` (n/2+1) and `ALL`. Read more about consistency level [here](../concepts/replication-architecture/consistency.md).
 
 The `consistency_level` can be specified at query time. 
 
 :::caution Note:
-In v1.17, only read queries that get data by ID have a tunable consistency level. All other queries have a consistency level of ALL. From v1.18, all write and read queries are tunable to either ONE, QUORUM or ALL.
+In v1.17, only read queries that get data by ID have a tunable consistency level. All other queries have a consistency level of `ALL`. Starting with v1.18, all write and read queries are tunable to either `ONE`, `QUORUM` or `ALL`.
 :::
 
 ```bash


### PR DESCRIPTION
* simplify or wrap comments in code snippets for readability
* remove extraneous config params in JS and curl examples
* format consistency levels as `code`
* grammar improvements
