### PR TITLE
[docs: fix] further clarifications for oidc yaml config

### DIFF
--- a/developers/weaviate/configuration/authentication.md
+++ b/developers/weaviate/configuration/authentication.md
@@ -69,7 +69,11 @@ Any "OpenID Connect" compatible token issuer implementing OpenID Connect Discove
 
 - For simple use-cases such as for a single user, you can use [Weaviate Cloud Services (WCS)](https://auth.wcs.api.weaviate.io) as the OIDC token issuer. 
     - Make sure you have a WCS account (you can [sign up here](https://console.weaviate.io/)). 
-    - Specify `https://auth.wcs.api.weaviate.io/auth/realms/SeMI` as the issuer and your WCS account email as the user in the OIDC configuration .
+    - In the Weaviate configuration file (e.g. `docker-compose.yaml`), specify: 
+      - `https://auth.wcs.api.weaviate.io/auth/realms/SeMI` as the issuer (in `AUTHENTICATION_OIDC_ISSUER`),
+      - `wcs` as the client id (in `AUTHENTICATION_OIDC_CLIENT_ID`), and
+      - your WCS account email as the user (in `AUTHENTICATION_OIDC_USERNAME_CLAIM`).
+
 - If you need a more customizable setup you can use commercial OIDC providers like [Okta](https://www.okta.com/).
 - As another alternative, you can run your own OIDC token issuer server, which may be the most complex but also configurable solution. Popular open-source solutions include Java-based [Keycloak](https://www.keycloak.org/) and Golang-based [dex](https://github.com/dexidp/dex).
 


### PR DESCRIPTION
### What's being changed:

Clarifies what settings are needed to configure WCS as the token issuer with a local Weaviate deployment.

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)
