### PR TITLE
[docs:fix] escape quotation marks inside python snippet

### DIFF
--- a/_includes/code/ner-transformers-module.mdx
+++ b/_includes/code/ner-transformers-module.mdx
@@ -40,7 +40,7 @@ client = weaviate.Client("http://localhost:8080")
 
 result = (
   client.query
-  .get("Article", ["title", "_additional {tokens ( properties: ["title"], limit: 1, certainty: 0.7) {entity property word certainty startPosition endPosition }}"])
+  .get("Article", ["title", "_additional {tokens ( properties: [\"title\"], limit: 1, certainty: 0.7) {entity property word certainty startPosition endPosition }}"])
   .do()
 )
 


### PR DESCRIPTION
### What's being changed:

Fix syntax in ner example by escaping quotation marks inside python snippet

### Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

