### PR TITLE
[docs] note that Explore not available w WCS and similar

### DIFF
--- a/developers/weaviate/api/graphql/explore.md
+++ b/developers/weaviate/api/graphql/explore.md
@@ -8,6 +8,14 @@ import Badges from '/_includes/badges.mdx';
 
 <Badges/>
 
+:::note Vector spaces and Expore{}
+
+The `Explore` function is currently not available on Weaviate Cloud Services (WCS) instances, or others where it is likely that multiple vector spaces will exist. 
+
+As WCS by default enables multiple inference-API modules and therefore multiple vector spaces, `Explore` is disabled by default by Weaviate.
+
+::: 
+
 ## Explore{} query structure and syntax
 
 The `Explore{}` function is always defined based on the following principle:


### PR DESCRIPTION
### What's being changed:

Add note that `Explore` is not available w WCS and similar; as it was not previously clear.

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)
