### PR TITLE
Pre 1.18 fixes

### DIFF
--- a/_includes/code/getting.started.schema.crossreference.2.mdx
+++ b/_includes/code/getting.started.schema.crossreference.2.mdx
@@ -12,7 +12,7 @@ client = weaviate.Client("https://some-endpoint.weaviate.network/")
 
 add_prop = {
   "dataType": [
-      "Author" # <== note how the name of the class is the cross-reference
+    "Author" # <== note how the name of the class is the cross-reference
   ],
   "name": "has"
 }
@@ -34,9 +34,9 @@ print(json.dumps(schema, indent=4))
 const weaviate = require('weaviate-client');
 
 const client = weaviate.client({
-    scheme: 'https',
-    host: 'some-endpoint.weaviate.network/',
-  });
+  scheme: 'https',
+  host: 'some-endpoint.weaviate.network/',
+});
 
 const className = 'Publication';
 const prop = {
@@ -57,7 +57,7 @@ client.schema
   });
 
 // get and print the schema
-  client
+client
     .schema
     .getter()
     .do()

--- a/_includes/datatypes.mdx
+++ b/_includes/datatypes.mdx
@@ -1,18 +1,18 @@
-| Weaviate Type | Exact Data Type | Formatting |
-| ---------|--------|-----------|
-| string   | string | `"string"` |
-| string[]   | list of strings | `["string", "second string"]` |
-| int      | int64 (*) | `0` |
-| int[]      | list of int64 (*) | `[0, 1]` |
-| boolean  | boolean | `true`/`false` |
-| boolean[]  | list of booleans | `[true, false]` |
-| number   | float64 | `0.0` |
-| number[]   | list of float64 | `[0.0, 1.1]` |
-| date     | string | [more info](/developers/weaviate/configuration/datatypes#datatype-date) |
-| date[]     | list of string | [more info](/developers/weaviate/configuration/datatypes#datatype-date) |
-| text     | text   | `string` |
-| text[]     | list of texts   | `["string one", "string two"]` |
-| geoCoordinates | string | [more info](/developers/weaviate/configuration/datatypes#datatype-geocoordinates) |
-| phoneNumber | string | [more info](/developers/weaviate/configuration/datatypes#datatype-phonenumber) |
-| blob | base64 encoded string | [more info](/developers/weaviate/configuration/datatypes#datatype-blob) |
-| *cross reference* | string | [more info](/developers/weaviate/configuration/datatypes#datatype-cross-reference) |
+| Weaviate Type     | Exact Data Type       | Formatting                                                                         |
+|-------------------|-----------------------|------------------------------------------------------------------------------------|
+| string            | string                | `"string"`                                                                         |
+| string[]          | list of strings       | `["string", "second string"]`                                                      |
+| int               | int64 (*)             | `0`                                                                                |
+| int[]             | list of int64 (*)     | `[0, 1]`                                                                           |
+| boolean           | boolean               | `true`/`false`                                                                     |
+| boolean[]         | list of booleans      | `[true, false]`                                                                    |
+| number            | float64               | `0.0`                                                                              |
+| number[]          | list of float64       | `[0.0, 1.1]`                                                                       |
+| date              | string                | [more info](/developers/weaviate/configuration/datatypes#datatype-date)            |
+| date[]            | list of string        | [more info](/developers/weaviate/configuration/datatypes#datatype-date)            |
+| text              | text                  | `string`                                                                           |
+| text[]            | list of texts         | `["string one", "string two"]`                                                     |
+| geoCoordinates    | string                | [more info](/developers/weaviate/configuration/datatypes#datatype-geocoordinates)  |
+| phoneNumber       | string                | [more info](/developers/weaviate/configuration/datatypes#datatype-phonenumber)     |
+| blob              | base64 encoded string | [more info](/developers/weaviate/configuration/datatypes#datatype-blob)            |
+| *cross reference* | string                | [more info](/developers/weaviate/configuration/datatypes#datatype-cross-reference) |

--- a/blog/2022-12-20-weaviate-1-17-release/index.mdx
+++ b/blog/2022-12-20-weaviate-1-17-release/index.mdx
@@ -50,7 +50,7 @@ Weaviate has a [leaderless replication design](/developers/weaviate/concepts/rep
 ### Roadmap
 With `v1.17`, the foundations of replication are built into Weaviate. In `v1.18` and later releases, more features will be added:
 
-| Weaviate version | Expected release | Feature
+| Weaviate version | Expected release | Feature |
 | --- | --- | --- |
 | `v1.17` | Live | * Leaderless Replication<br />* Tunable Read Consistency for Get-by-ID requests |
 | `v1.18` | Feb 2023 | * Tunable Write Consistency<br />* Tunable Read Consistency for all requests<br />* Repairs – Read-Repairs or Background/Async Repairs |

--- a/blog/2022-12-20-weaviate-1-17-release/index.mdx
+++ b/blog/2022-12-20-weaviate-1-17-release/index.mdx
@@ -25,16 +25,16 @@ If you like your content brief and to the point, here is the TL;DR of this relea
 Read below to learn more about each of these points in more detail.
 
 ## Replication
-![replication animation](./img/weaviate-replications-animation.gif) 
+![replication animation](./img/weaviate-replications-animation.gif)
 
-Weaviate's `v1.17` release introduces **replication**. Replication enables you to set up your Weaviate environment in a cluster with multiple server nodes. Weaviate will automatically replicate data across nodes in the background. 
+Weaviate's `v1.17` release introduces **replication**. Replication enables you to set up your Weaviate environment in a cluster with multiple server nodes. Weaviate will automatically replicate data across nodes in the background.
 
 ### Use Cases
 This enables a variety of [use cases](/developers/weaviate/concepts/replication-architecture/motivation). For example, if a Weaviate node goes down, another node can shoulder the load without losing availability or data. Data in Weaviate will thus have a **higher availability** for its users.
 
 Secondly, Replication can improve the **throughput of read requests**, as you can use all additional nodes to spread the load of queries. Adding extra database nodes can serve more users simultaneously.
 
-Thirdly, database replication enables **zero downtime upgrades**, because only a single node has to stop at a time while other replicas can continue serving. 
+Thirdly, database replication enables **zero downtime upgrades**, because only a single node has to stop at a time while other replicas can continue serving.
 
 A final motivation for using database replication is **regional proximity**. With Multi-DataCenter replication, you can put Weaviate servers in different locations, which can decrease latency for users spread out geographically. The Multi-DataCenter feature is not implemented yet, [but we are already working on it](https://github.com/weaviate/weaviate/issues/2436).
 
@@ -57,7 +57,7 @@ With `v1.17`, the foundations of replication are built into Weaviate. In `v1.18`
 | TBD | TBD | * Multi-Datacenter replication (upvote it [here](https://github.com/weaviate/weaviate/issues/2436)) |
 
 ### Learn More
-To learn more, visit the documentation pages for [Replication Architecture](/developers/weaviate/concepts/replication-architecture) and/or [Usage](/developers/weaviate/configuration/replication), where all concepts are explained in detail, supported by illustrations! 
+To learn more, visit the documentation pages for [Replication Architecture](/developers/weaviate/concepts/replication-architecture) and/or [Usage](/developers/weaviate/configuration/replication), where all concepts are explained in detail, supported by illustrations!
 
 ## Hybrid Search
 ![Hybrid Search](./img/hybrid-search.png)
@@ -86,7 +86,7 @@ Here is an example of how to run a hybrid search query in GraphQL:
 Similar to how you use `nearText`, `hybrid` is passed as an argument to a Weaviate class object. `hybrid` has two parameters: `query` and `alpha`. `query` is fairly straightforward, whereas `alpha` is a new idea. `alpha` describes the weighting between dense and sparse search methods. An alpha closer to 0 weighs sparse search more than dense, and an alpha closer to 1 weighs dense search more than sparse. Additionally, if alpha is set to 0, it only uses sparse search, and if alpha equals 1, then it uses dense search only.
 
 ### What's next in Hybrid
-Work on hybrid search is not over! We will continue to make improvements and introduce new features in the future. For example, there is already something in the [backlog](https://github.com/weaviate/weaviate/issues/2393) to add where filters to hybrid search (give it a thumbs up while you're there). 🙂 
+Work on hybrid search is not over! We will continue to make improvements and introduce new features in the future. For example, there is already something in the [backlog](https://github.com/weaviate/weaviate/issues/2393) to add where filters to hybrid search (give it a thumbs up while you're there). 🙂
 
 ### Learn More
 The hybrid operator is available through GraphQL, REST and all Weaviate client languages. Check out the [documentation](/developers/weaviate/api/graphql/vector-search-parameters#hybrid) for more information and learn how to write the query in the other client programming languages.
@@ -100,7 +100,7 @@ BM25 ("Best Match #25" - it took quite a few iterations to arrive at the current
 In Weaviate v1.17, we introduce a search operator called [`bm25`](/developers/weaviate/api/graphql/vector-search-parameters#bm25), which performs a case-insensitive keyword search, then ranks the results using the BM25F ranking function - **B**est **M**atch **25** with Extension to Multiple Weighted **F**ields, a variant of BM25 that can take into account different weights for different properties (fields) of the document, in order to produce more accurate results.
 
 ### Core Concept
-The basic idea behind BM25 is to score a document based on the number of times a particular term appears in the document, as well as the overall length of the document - one occurrence in a tweet is much more significant than one occurrence in a book. Essentially, this is done using a combination of term frequency (TF - the more times the term appears, the higher the score) and inverse document frequency (IDF - if a term occurs rarely in the documents in the corpus, then whenever it does occur, that occurrence is probably significant). 
+The basic idea behind BM25 is to score a document based on the number of times a particular term appears in the document, as well as the overall length of the document - one occurrence in a tweet is much more significant than one occurrence in a book. Essentially, this is done using a combination of term frequency (TF - the more times the term appears, the higher the score) and inverse document frequency (IDF - if a term occurs rarely in the documents in the corpus, then whenever it does occur, that occurrence is probably significant).
 
 [TF-IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) is in fact the name of a ranking function [upon which BM25 builds](https://kmwllc.com/index.php/2020/03/20/understanding-tf-idf-and-bm-25/). The idea has been refined to codify numerous information retrieval intuitions such as, if a term appears three times in a document and six times in another, that doesn't automatically mean the second document is twice as relevant.
 
@@ -108,7 +108,7 @@ The basic idea behind BM25 is to score a document based on the number of times a
 BM25 is best used when an exact match for the query keywords is desired (and the order of the words in the query is not important) and in out-of-domain searches (when the model is not specifically trained on the corpus of documents). If stemming or semantic similarity are desired, Weaviate's [vector search](/developers/weaviate/api/graphql/vector-search-parameters#hybrid) will be better suited.
 
 ### BM25 Query Example
-The `bm25` operator takes one mandatory parameter, a string `query`, and an optional `properties` parameter - an array of property names, each of which being optionally weighted by a factor placed after a `^` character.
+The `bm25` operator takes one required parameter, a string `query`, and an optional `properties` parameter - an array of property names, each of which being optionally weighted by a factor placed after a `^` character.
 
 Here is a GraphQL example using the `bm25` argument:
 
@@ -174,6 +174,6 @@ For a more detailed breakdown of the fixes please see the release notes:
 [v1.16.1](https://github.com/weaviate/weaviate/releases/tag/v1.16.1), [v1.16.2](https://github.com/weaviate/weaviate/releases/tag/v1.16.2), [v1.16.3](https://github.com/weaviate/weaviate/releases/tag/v1.16.3), [v1.16.4](https://github.com/weaviate/weaviate/releases/tag/v1.16.4), [v1.16.5](https://github.com/weaviate/weaviate/releases/tag/v1.16.5), [v1.16.6](https://github.com/weaviate/weaviate/releases/tag/v1.16.6), [v1.16.7](https://github.com/weaviate/weaviate/releases/tag/v1.16.7).
 
 ## Stay Connected
-Thank you so much for reading! If you would like to talk to us more about this topic, please connect with us on [Slack](https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw) or [Twitter](https://twitter.com/weaviate_io). 
+Thank you so much for reading! If you would like to talk to us more about this topic, please connect with us on [Slack](https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw) or [Twitter](https://twitter.com/weaviate_io).
 
 Weaviate is open-source, you can follow the project on [GitHub](https://github.com/weaviate/weaviate). Don't forget to give us a ⭐️ while you are there.

--- a/blog/2023-01-31-weaviate-podcast-search/index.mdx
+++ b/blog/2023-01-31-weaviate-podcast-search/index.mdx
@@ -92,7 +92,7 @@ We can get even better results by filtering our searches with the `speaker` and 
 }
 ```
 
-We can also filter on podcast numbers. Weviate podcast #30 “The Future of Search” with Bob van Luijt, Chris Dossman, and Marco Bianco was the first podcast to come out after ChatGPT was released!
+We can also filter on podcast numbers. Weaviate podcast #30 “The Future of Search” with Bob van Luijt, Chris Dossman, and Marco Bianco was the first podcast to come out after ChatGPT was released!
 
 ```graphql
 {

--- a/developers/weaviate/api/graphql/get.md
+++ b/developers/weaviate/api/graphql/get.md
@@ -79,7 +79,7 @@ For every Get{} request you can get additional information about the returned da
 
 To combine `Get { }` with a vector search argument, here is an overview of the supported arguments and links to their detailed documentation:
 
-| Argument | Description | Required Modules (at least one of) | Learn More |
+| Argument | Description | Required modules (at least one of) | Learn more |
 | --- | --- | --- | --- |
 | `nearObject` | Find the nearest neighbors of an object referenced by its id | *none - works out of the box* | [Learn more](./vector-search-parameters.md#nearobject) |
 | `nearVector` | Find the nearest neighbors to any vector | *none - works out of the box* | [Learn more](./vector-search-parameters.md#nearvector) |

--- a/developers/weaviate/api/graphql/vector-search-parameters.md
+++ b/developers/weaviate/api/graphql/vector-search-parameters.md
@@ -20,16 +20,31 @@ import GraphQLFiltersExample from '/_includes/code/graphql.filters.example.mdx';
 
 ## Built-in parameters
 
-Built-in search parameters are available in all Weaviate instances and don't require any modules. 
+Built-in search parameters are available in all Weaviate instances and don't require any modules.
 
-### nearVector
+Weaviate provides the following built-in parameters:
+* [nearVector](#nearvector)
+* [nearObject](#nearobject)
+* [hybrid](#hybrid)
+* [bm25](#bm25)
+* [group](#group)
+
+## Module-specific parameters
+
+Module-specific search parameters are made available in certain Weaviate modules.
+
+By adding relevant modules, you can use the following parameters:
+* [nearText](#neartext)
+* [ask](#ask)
+
+## nearVector
 
 This filter allows you to find data objects in the vicinity of an input vector. It's supported by the `Get{}` function.
 
 * Note: this argument is different from the [GraphQL `Explore{}` function](./explore.md)
 * Note: Cannot use multiple `'near'` arguments, or a `'near'` argument along with an [`'ask'`](/developers/weaviate/modules/reader-generator-modules/qna-transformers.md) filter
 
-#### Variables
+### Variables
 
 | Variables | Required | Type | Description |
 | --- | --- | --- | --- |
@@ -37,7 +52,7 @@ This filter allows you to find data objects in the vicinity of an input vector. 
 | `distance` | no | `float` | The required degree of similarity between an object's characteristics and the provided filter values. Can't be used together with the `certainty` variable. The interpretation of the value of the distance field depends on the [distance metric used](/developers/weaviate/configuration/distances.md). |
 | `certainty` | no | `float` | Normalized Distance between the result item and the search vector. Normalized to be between 0 (perfect opposite) and 1 (identical vectors).. Can't be used together with the `distance` variable. |
 
-#### Example
+### Example
 
 import GraphQLFiltersNearVector from '/_includes/code/graphql.filters.nearVector.mdx';
 
@@ -55,7 +70,7 @@ represents a perfect opposite (cosine distance of 2) and 1 represents vectors
 with an identical angle (cosine distance of 0). Certainty is not available on
 non-cosine distance metrics.
 
-### nearObject
+## nearObject
 
 This filter allows you to find data objects in the vicinity of other data objects by UUID. It's supported by the `Get{}` function.
 
@@ -64,7 +79,7 @@ This filter allows you to find data objects in the vicinity of other data object
 * Note that the first result will always be the object in the filter itself.
 * Near object search can also be combined with `text2vec` modules.
 
-#### Variables
+### Variables
 
 | Variables | Required | Type | Description |
 | --- | --- | --- | --- |
@@ -73,7 +88,7 @@ This filter allows you to find data objects in the vicinity of other data object
 | `distance` | no | `float` | The required degree of similarity between an object's characteristics and the provided filter values. Can't be used together with the `certainty` variable. The interpretation of the value of the distance field depends on the [distance metric used](/developers/weaviate/configuration/distances.md). |
 | `certainty` | no | `float` | Normalized Distance between the result item and the search vector. Normalized to be between 0 (perfect opposite) and 1 (identical vectors).. Can't be used together with the `distance` variable. |
 
-#### Example
+### Example
 
 import GraphQLFiltersNearObject from '/_includes/code/graphql.filters.nearObject.mdx';
 
@@ -154,7 +169,7 @@ The settings for BM25 are the [free parameters `k1` and `b`](https://en.wikipedi
 ```
 
 ### Variables
-The `bm25` operator supports two variables:
+The `bm25` operator supports the following variables:
 
 | Variables | Required | Description |
 | --------- | -------- | ----------- |
@@ -276,11 +291,7 @@ This results in the following. Note that publications `International New York Ti
 }
 ```
 
-## Module-specific parameters
-
-Module-specific search parameters are made available in certain Weaviate modules. 
-
-### nearText
+## nearText
 
 Enabled by the modules: 
 - [text2vec-openai](../../modules/retriever-vectorizer-modules/text2vec-openai.md), 
@@ -292,7 +303,7 @@ Enabled by the modules:
 
 This filter allows you to find data objects in the vicinity of the vector representation of a single or multiple concepts. It's supported by the `Get{}` function.
 
-#### Variables
+### Variables
 
 | Variables | Required | Type | Description |
 | --- | --- | --- | --- |
@@ -309,7 +320,7 @@ This filter allows you to find data objects in the vicinity of the vector repres
 | `moveAwayFrom{objects}`| no | `[UUID]` | Object IDs to move the results to. This is used to "bias" NLP search results into a certain direction in vector space | 
 | `moveAwayFrom{force}`| no | `float` | The force to apply for a particular movements. Must be between 0 and 1 where 0 is equivalent to no movement and 1 is equivalent to largest movement possible | 
 
-#### Example I
+### Example I
 
 This example shows a basic overview of using the `nearText` filter.
 
@@ -319,7 +330,7 @@ import GraphQLFiltersNearText from '/_includes/code/graphql.filters.nearText.mdx
 
 <MoleculeGQLDemo query='%7B%0D%0A++Get%7B%0D%0A++++Publication%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22fashion%22%5D%2C%0D%0A++++++++certainty%3A+0.7%2C%0D%0A++++++++moveAwayFrom%3A+%7B%0D%0A++++++++++concepts%3A+%5B%22finance%22%5D%2C%0D%0A++++++++++force%3A+0.45%0D%0A++++++++%7D%2C%0D%0A++++++++moveTo%3A+%7B%0D%0A++++++++++concepts%3A+%5B%22haute+couture%22%5D%2C%0D%0A++++++++++force%3A+0.85%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%29%7B%0D%0A++++++name%0D%0A++++++_additional+%7B%0D%0A++++++++certainty%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
 
-#### Example II
+### Example II
 
 You can also bias results toward other data objects' vector representations. For example, in this dataset, we have an ambiguous query on our news article dataset, which we bias towards an article called: ["Tohoku: A Japan destination for all seasons."](https://link.semi.technology/3Czhg9p)
 
@@ -373,13 +384,13 @@ import GraphQLUnderscoreSemanticpath from '/_includes/code/graphql.underscorepro
 
 <GraphQLUnderscoreSemanticpath/>
 
-### Ask
+## ask
 
 Enabled by the module: [Question Answering](/developers/weaviate/modules/reader-generator-modules/qna-transformers.md).
 
 This filter allows you to return answers to questions by running the results through a Q&A model.
 
-#### Variables
+### Variables
 
 | Variables | Required | Type | Description |
 | --- | --- | --- | --- |
@@ -388,7 +399,7 @@ This filter allows you to return answers to questions by running the results thr
 | `properties` 	| no 	| `[string]` | The properties of the queries Class which contains text. If no properties are set, all are considered.	|
 | `rerank` 	| no 	| `boolean`	| If enabled, the qna module will rerank the result based on the answer score. For example, if the 3rd result - as determined by the previous (semantic) search contained the most likely answer, result 3 will be pushed to position 1, etc. *Not supported prior to v1.10.0* |
 
-#### Example
+### Example
 
 import QNATransformersAsk from '/_includes/code/qna-transformers.ask.mdx';
 
@@ -396,7 +407,7 @@ import QNATransformersAsk from '/_includes/code/qna-transformers.ask.mdx';
 
 <MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++ask%3A+%7B%0D%0A++++++++question%3A+%22Who+is+the+king+of+the+Netherlands%3F%22%2C%0D%0A++++++++properties%3A+%5B%22summary%22%5D%0D%0A++++++%7D%2C+%0D%0A++++++limit%3A1%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++_additional+%7B%0D%0A++++++++answer+%7B%0D%0A++++++++++hasAnswer%0D%0A++++++++++certainty%0D%0A++++++++++property%0D%0A++++++++++result%0D%0A++++++++++startPosition%0D%0A++++++++++endPosition%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
 
-#### Additional information
+### Additional information
 
 The `_additional{}` property is extended with the answer and a certainty of the answer.
 

--- a/developers/weaviate/api/graphql/vector-search-parameters.md
+++ b/developers/weaviate/api/graphql/vector-search-parameters.md
@@ -121,10 +121,10 @@ The search is case-insensitive, and case matching does not confer a score advant
 ### Schema configuration
 The settings for BM25 are the [free parameters `k1` and `b`](https://en.wikipedia.org/wiki/Okapi_BM25#The_ranking_function), and they are optional. The defaults (`k1` = 1.2 and `b` = 0.75) work well for most cases. If necessary, they can be configured in the schema per class, and can optionally be overridden per property:
 
-```json
+```yaml
 {
   "class": "string",
-  // Configuration of the sparse index
+  # Configuration of the sparse index
   "invertedIndexConfig": {
     "bm25": {
       "b": 0.75,
@@ -138,7 +138,7 @@ The settings for BM25 are the [free parameters `k1` and `b`](https://en.wikipedi
       "dataType": [
         "string"
       ],
-      // Property-level settings override the class-level settings
+      # Property-level settings override the class-level settings
       "invertedIndexConfig": {
         "bm25": {
           "b": 0.75,
@@ -168,12 +168,12 @@ import GraphQLFiltersBM25 from '/_includes/code/graphql.filters.bm25.mdx';
 
 The `_additional` object in the GraphQL result exposes the score:
 
-```json
+```yaml
 {
   "_additional": {
     "score": "5.3201",
-    "distance": null,  // always null
-    "certainty": null  // always null
+    "distance": null,  # always null
+    "certainty": null  # always null
   }
 }
 ```

--- a/developers/weaviate/api/graphql/vector-search-parameters.md
+++ b/developers/weaviate/api/graphql/vector-search-parameters.md
@@ -84,6 +84,8 @@ import GraphQLFiltersNearObject from '/_includes/code/graphql.filters.nearObject
 ## hybrid
 This filter allows you to combine dense and sparse vectors to get the best of both search methods. It's supported by the `Get{}` function.  
 
+### Variables
+
 | Variables | Required | Description |
 | --- | --- | --- |
 | `hybrid` | yes | need to specify that you want to use hybrid search |
@@ -153,8 +155,15 @@ The settings for BM25 are the [free parameters `k1` and `b`](https://en.wikipedi
 
 ### Variables
 The `bm25` operator supports two variables:
-* `query` (required) - the keyword search query
-* `properties` (optional) - array of properties (fields) to search in, defaulting to all properties in the class. Specific properties can be boosted by a factor specified as a number after the caret sign, for example `properties: ["title^3", "summary"]`.
+
+| Variables | Required | Description |
+| --------- | -------- | ----------- |
+| `query`   | yes      | the keyword search query |
+| `properties` | no    | array of properties (fields) to search in, defaulting to all properties in the class| 
+
+:::info Boosting properties
+Specific properties can be boosted by a factor specified as a number after the caret sign, for example `properties: ["title^3", "summary"]`.
+:::
 
 ### Example query
 

--- a/developers/weaviate/api/graphql/vector-search-parameters.md
+++ b/developers/weaviate/api/graphql/vector-search-parameters.md
@@ -31,7 +31,7 @@ This filter allows you to find data objects in the vicinity of an input vector. 
 
 #### Variables
 
-| Variables | Mandatory | Type | Description |
+| Variables | Required | Type | Description |
 | --- | --- | --- | --- |
 | `vector` | yes | `[float]` | This variable takes a vector embedding in the form of an array of floats. The array should have the same length as the vectors in this class. |
 | `distance` | no | `float` | The required degree of similarity between an object's characteristics and the provided filter values. Can't be used together with the `certainty` variable. The interpretation of the value of the distance field depends on the [distance metric used](/developers/weaviate/configuration/distances.md). |
@@ -66,7 +66,7 @@ This filter allows you to find data objects in the vicinity of other data object
 
 #### Variables
 
-| Variables | Mandatory | Type | Description |
+| Variables | Required | Type | Description |
 | --- | --- | --- | --- |
 | `id` | yes | `UUID` | Data object identifier in the uuid format. |
 | `beacon` | yes | `url` | Data object identifier in the beacon URL format. E.g., `weaviate://<hostname>/<kind>/id`. |
@@ -84,7 +84,7 @@ import GraphQLFiltersNearObject from '/_includes/code/graphql.filters.nearObject
 ## hybrid
 This filter allows you to combine dense and sparse vectors to get the best of both search methods. It's supported by the `Get{}` function.  
 
-| Variables | Mandatory | Description |
+| Variables | Required | Description |
 | --- | --- | --- |
 | `hybrid` | yes | need to specify that you want to use hybrid search |
 | `query` | yes | search query |
@@ -153,7 +153,7 @@ The settings for BM25 are the [free parameters `k1` and `b`](https://en.wikipedi
 
 ### Variables
 The `bm25` operator supports two variables:
-* `query` (mandatory) - the keyword search query
+* `query` (required) - the keyword search query
 * `properties` (optional) - array of properties (fields) to search in, defaulting to all properties in the class. Specific properties can be boosted by a factor specified as a number after the caret sign, for example `properties: ["title^3", "summary"]`.
 
 ### Example query
@@ -207,7 +207,7 @@ You can use a group operator to combine similar concepts (aka _entity merging_).
 
 ### Variables
 
-| Variables | Mandatory | Type | Description |
+| Variables | Required | Type | Description |
 | --- | --- | --- | --- |
 | `type` | yes | `string` | You can only show the closest concept (`closest`) or merge all similar entities into one single string (`merge`). |
 | `force` | yes | `float` | The force to apply for a particular movements. Must be between 0 and 1 where 0 is equivalent to no movement and 1 is equivalent to largest movement possible. |
@@ -285,7 +285,7 @@ This filter allows you to find data objects in the vicinity of the vector repres
 
 #### Variables
 
-| Variables | Mandatory | Type | Description |
+| Variables | Required | Type | Description |
 | --- | --- | --- | --- |
 | `concepts` | yes | `[string]` | An array of strings, this can be natural language queries or single words. If multiple strings are used, a centroid is calculated and used. Learn more about how the concepts are parsed [here](#concept-parsing) |
 | `certainty` | no | `float` | The required degree of similarity between an object's characteristics and the provided filter values.<br/>Values can be between 0 (no match) and 1 (perfect match).<br/><i className="fas fa-triangle-exclamation"/> Can't be used together with the `distance` variable. |
@@ -372,7 +372,7 @@ This filter allows you to return answers to questions by running the results thr
 
 #### Variables
 
-| Variables | Mandatory | Type | Description |
+| Variables | Required | Type | Description |
 | --- | --- | --- | --- |
 | `question` 	| yes	| `string` | The question to be answered. 	|
 | `certainty` 	| no 	| `float` | Desired minimal certainty or confidence of answer to the question. The higher the value, the stricter the search becomes. The lower the value, the fuzzier the search becomes. If no certainty is set, any answer that could be extracted will be returned|

--- a/developers/weaviate/api/rest/batch.md
+++ b/developers/weaviate/api/rest/batch.md
@@ -14,15 +14,17 @@ For sending data objects to Weaviate in bulk.
 
 ### Performance
 
-💡 Import speeds, especially for large datasets, will drastically improve when using the batching endpoint. 
+:::tip
+Import speeds, especially for large datasets, will drastically improve when using the batching endpoint.
+:::
 
 A few points to bear in mind:
 
-1. If you use a vectorizer that improves with GPU support, make sure to enable it if possible, it will drastically improve import.
+1. If you use a vectorizer that improves with GPU support, make sure to enable it if possible, as it will drastically improve import.
 1. Avoid duplicate vectors for multiple data objects.
-1. Handle your errors, if you ignore them, it might lead to significant delays on import.
-1. If import slows down after a particular number of objects (e.g. 2M), check to see if the [`vectorCacheMaxObjects`](../../configuration/indexes.md#how-to-configure-hnsw) in your schema is larger than the number of objects. Also, see [this example](https://github.com/weaviate/semantic-search-through-wikipedia-with-weaviate/blob/d4711f2bdc75afd503ff70092c3c5303f9dd1b3b/step-2/import.py#L58-L59).
-1. There are ways to improve your setup when using vectorizers. Like in the Wikipedia demo dataset. We will keep publishing about this, sign up for our [Slack channel](https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw) to keep up to date.
+1. Handle your errors. If you ignore them, it might lead to significant delays on import.
+1. If your import slows down after a particular number of objects (e.g. 2M), check to see if the [`vectorCacheMaxObjects`](../../configuration/indexes.md#how-to-configure-hnsw) in your schema is larger than the number of objects. Also, see [this example](https://github.com/weaviate/semantic-search-through-wikipedia-with-weaviate/blob/d4711f2bdc75afd503ff70092c3c5303f9dd1b3b/step-2/import.py#L58-L59).
+1. There are ways to improve your setup when using vectorizers, as we've shown in the Wikipedia demo dataset. Sign up for our [Slack channel](https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw) to keep up-to-date as we publish more on this topic.
 
 ### Method and URL
 
@@ -34,9 +36,9 @@ POST /v1/batch/objects
 
 The body requires the following field:
 
-| name | type | required | description |
-| ---- | ---- | ---- | ---- |
-| `objects` | list of data objects | yes | a list of data objects, which correspond to the data [object body](./objects.md#parameters-1) |
+| Name | Type | Required | Description |
+| ---- | ---- | -------- | ----------- |
+| `objects` | list of data objects | yes | A list of data objects, which correspond to the data [object body](./objects.md#parameters-1) |
 
 ### Example request
 
@@ -44,14 +46,14 @@ import BatchObjects from '/_includes/code/batch.objects.mdx';
 
 <BatchObjects/>
 
-## Batching objects with the Python Client
+## Batching objects with the Python client
 
 Specific documentation for the Python client
 
 ### Additional documentation
 
-* Additional documentation can be found on [weaviate-python-client.readthedocs.io](https://weaviate-python-client.readthedocs.io/en/stable/weaviate.batch.html)
-* Additional documentation on different types of batching and tip &amp; tricks can be found [here](/developers/weaviate/client-libraries/python.md)
+* Additional documentation can be found at [weaviate-python-client.readthedocs.io](https://weaviate-python-client.readthedocs.io/en/stable/weaviate.batch.html).
+* Learn more about different types of batching and tip&tricks on the [Weaviate Python client page](/developers/weaviate/client-libraries/python.md).
 
 ## Batch references
 
@@ -67,23 +69,27 @@ POST /v1/batch/references
 
 The body of the data object for a new object is a list of objects containing:
 
-| name | type | required | description |
-| ---- | ---- | ---- | ---- |
-| `from` | Weaviate Beacon (long-form) | yes | The beacon, in the form of `weaviate://localhost/{Classname}/{id}/{cref_property_name}` |
-| `to` | Weaviate Beacon (regular) | yes | The beacon, in the form of `weaviate://localhost/{className}/{id}` |
+| Name | Type | Required | Description |
+| ---- | ---- | -------- | ----------- |
+| `from` | Weaviate Beacon (long-form) | yes | The beacon, formatted as `weaviate://localhost/{Classname}/{id}/{cref_property_name}` |
+| `to` | Weaviate Beacon (regular) | yes | The beacon, formatted as `weaviate://localhost/{className}/{id}` |
 
-*Note: In the beacon format, you need to always use `localhost` as the host,
+:::caution
+In the beacon format, you need to always use `localhost` as the host,
 rather than the actual hostname. `localhost` refers to the fact that the
 beacon's target is on the same Weaviate instance, as opposed to a foreign
-instance.*
+instance.
+:::
 
-*Note: For backward compatibility, you can omit the class name in the
+:::note
+For backward compatibility, you can omit the class name in the
 short-form beacon format that is used for `to`. You can specify it as
 `weaviate://localhost/{id}`. This is, however, considered deprecated and will be
 removed with a future release, as duplicate IDs across classes could mean that
 this beacon is not uniquely identifiable. For the long-form beacon - used as part
 of `from` - you always need to specify the full beacon, including the reference
-property name.*
+property name.
+:::
 
 ### Example request
 
@@ -92,17 +98,17 @@ import BatchReferences from '/_includes/code/batch.references.mdx';
 <BatchReferences/>
 
 
-For detailed information and instructions of batching in Python, click [here](https://weaviate-python-client.readthedocs.io/en/v3.0.0/weaviate.batch.html#weaviate.batch.Batch).
+For detailed information and instructions of batching in Python, see the [weaviate.batch.Batch](https://weaviate-python-client.readthedocs.io/en/latest/weaviate.batch.html#weaviate.batch.Batch) documentation.
 
-## Batch Delete By Query
+## Batch delete by query
 
-You can use the `/v1/batch/objects` endpoint with the HTTP Verb `DELETE` to delete all objects that match a particular expression. To determine if an object is a match [a where-Filter is used](../graphql/filters.md#where-filter). The request body takes a single filter, but will delete all objects matched. It returns the number of matched objects as well as any potential errors. Note that there is a limit to how many objects can be deleted using this filter at once which is explained below.
+You can use the `/v1/batch/objects` endpoint with the HTTP verb `DELETE` to delete all objects that match a particular expression. To determine if an object is a match [a where-Filter is used](../graphql/filters.md#where-filter). The request body takes a single filter, but will delete all objects matched. It returns the number of matched objects as well as any potential errors. Note that there is a limit to how many objects can be deleted using this filter at once, which is explained below.
 
 ### Maximum number of deletes per query
 
-There is an upper limit to how many objects can be deleted using a single query. This protects against unexpected memory surges and very-long running requests which would be prone to client-side timeouts or network interruptions. If a filter matches many objects, only the first `n` elements are deleted. You can configure the amount `n` by setting `QUERY_MAXIMUM_RESULTS` in Weaviate's config. The default value is 10,000. Objects are deleted in the same order that they would be returned using the same filter in a a Get-Query. To delete more objects than the limit, run the same query multiple times, until no objects are matched anymore.
+There is an upper limit to how many objects can be deleted using a single query. This protects against unexpected memory surges and very long-running requests which would be prone to client-side timeouts or network interruptions. If a filter matches many objects, only the first `n` elements are deleted. You can configure `n` by setting `QUERY_MAXIMUM_RESULTS` in Weaviate's config. The default value is 10,000. Objects are deleted in the same order that they would be returned using the same filter in a Get query. To delete more objects than the limit, run the same query multiple times, until no objects are matched anymore.
 
-### Dry-Run before Deletion
+### Dry-run before deletion
 
 You can use the dry-run option to see which objects would be deleted using your specified filter without deleting any objects yet. Depending on the verbosity set, you will either receive the total count of affected objects or a list of the affected IDs.
 
@@ -116,11 +122,11 @@ DELETE /v1/batch/objects
 
 The body requires the following field:
 
-| name | type | required | description |
-| ---- | ---- | ---- | ---- |
-| `match` | object | yes | an object outlining how to find the objects to be deleted, see an example below |
-| `output` | string | no | optional, controls the verbosity of the output, see possible values below. Defaults to `"minimal"` |
-| `dryRun` | bool | no | optional, if true, objects will not be deleted yet, but merely listed. Defaults to `false` |
+| Name | Type | Required | Description |
+| ---- | ---- | -------- | ----------- |
+| `match` | object | yes | An object outlining how to find the objects to be deleted. See an example below. |
+| `output` | string | no | Optional, controls the verbosity of the output. See possible values below. Defaults to `"minimal"`. |
+| `dryRun` | bool | no | Optional. If true, objects will not be deleted yet, but merely listed. Defaults to `false`. |
 
 #### A request body in detail
 
@@ -130,17 +136,17 @@ The body requires the following field:
     "class": "<ClassName>", # required
     "where": { /* where filter object */ },  # required
   },
-  "output": "<output verbosity>" # Optional, one of "minimal", "verbose". Defaults to "minimal"
-  "dryRun": <bool> # Optional, if true, objects will not be deleted yet, but merely listed. Defaults to "false"
+  "output": "<output verbosity>",  # Optional, one of "minimal", "verbose". Defaults to "minimal".
+  "dryRun": <bool>  # Optional, if true, objects will not be deleted yet, but merely listed. Defaults to "false".
 }
 ```
 
 Possible values for `output`
 
-| value | effect |
-| --- | --- |
-| `minimal` | The result only includes counts. Information about objects is omitted if the deletes were successful. Only if an error occurred will the object be described. |
-| `verbose` | The result lists all affected objects with their ID and deletion status, including both successful and unsuccessful deletes |
+| Value | Effect |
+| ----- | ------ |
+| `minimal` | The result only includes counts. Information about objects is omitted if the deletes were successful. Only if an error occurred, will the object be described. |
+| `verbose` | The result lists all affected objects with their ID and deletion status, including both successful and unsuccessful deletes. |
 
 
 #### A response body in detail
@@ -148,29 +154,29 @@ Possible values for `output`
 ```yaml
 {
   "match": {
-    "class": "<ClassName>",      # matches the request
+    "class": "<ClassName>",        # matches the request
     "where": { /* where filter object */ },  # matches the request
   },
-  "output": "<output verbosity>" # matches the request
-  "dryRun": <bool>
+  "output": "<output verbosity>",  # matches the request
+  "dryRun": <bool>,
   "results": {
-    "matches": "<int>"           # how many objects were matched by the filter
-    "limit": "<int>"             # the most amount of objects that can be deleted in a single query, matches QUERY_MAXIMUM_RESULTS
-    "successful": "<int>"        # how many objects were successfully deleted in this round
-    "failed": "<int>"            # how many objects should have been deleted but could not be deleted
-    "objects": [{                # one json object per weaviate object
-      "id": "<id>",              # This successfully deleted object would be omitted with output=minimal
-      "status": "SUCCESS",       # Possible status values are: "SUCCESS", "FAILED", "DRYRUN"
+    "matches": "<int>",            # how many objects were matched by the filter
+    "limit": "<int>",              # the most amount of objects that can be deleted in a single query, matches QUERY_MAXIMUM_RESULTS
+    "successful": "<int>",         # how many objects were successfully deleted in this round
+    "failed": "<int>",             # how many objects should have been deleted but could not be deleted
+    "objects": [{                  # one JSON object per Weaviate object
+      "id": "<id>",                # this successfully deleted object would be omitted with output=minimal
+      "status": "SUCCESS",         # possible status values are: "SUCCESS", "FAILED", "DRYRUN"
       "error": null
     }, {
-      "id": "<id>",              # This error'd object will always be listed, even with output=minimal
+      "id": "<id>",                # this error'd object will always be listed, even with output=minimal
       "status": "FAILED",
       "errors": {
          "error": [{
              "message": "<error-string>"
          }]
       }
-    ]}
+    }]
   }
 }
 ```
@@ -188,7 +194,7 @@ When sending a batch request to your Weaviate instance, it could be the case tha
 
 You can check if an error and what kind has occurred. 
 
-A batch request will always return a HTTP `200` status code when a the batch request was successful. That means that the batch was successfully sent to Weaviate, and there were no issues with the connection or processing of the batch and no malformed request (`4xx` status code). However, with a `200` status code, there might still be individual failures of the data objects which are not contained in the response. Thus, a `200` status code does not guarantee that each batch item is added/created. An example of an error on an individual data object that might be unnoticed by sending a batch request without checking the individual results is: Adding an object to the batch that is in conflict with the schema (for example a non existing class name).
+A batch request will always return an HTTP `200` status code when the batch request was successful. That means that the batch was successfully sent to Weaviate, and there were no issues with the connection or processing of the batch and no malformed request (`4xx` status code). However, with a `200` status code, there might still be individual failures of the data objects which are not contained in the response. Thus, a `200` status code does not guarantee that each batch item is added/created. An example of an error on an individual data object that might be unnoticed by sending a batch request without checking the individual results is this: adding an object to the batch that is in conflict with the schema (for example a non-existing class name).
 
 The following Python code can be used to handle errors on individual data objects in the batch. 
 
@@ -225,10 +231,10 @@ with client.batch(batch_size=100, callback=check_batch_result) as batch:
   batch.add_data_object(object_to_add, "Author", "36ddd591-2dee-4e7e-a3cc-eb86d30a4303")
 ```
 
-This can also be applied to adding references in batch. Note that sending batches, especially references, skips some validation on object and reference level. Adding this validation on single data objects like above makes it less likely for errors to pass without discovering. 
+This can also be applied to adding references in batch. Note that sending batches, especially references, skips some validations at the object and reference level. Adding this validation on single data objects like above makes it less likely for errors to go undiscovered.
 
 
-## More Resources
+## More resources
 
 import DocsMoreResources from '/_includes/more-resources-docs.md';
 

--- a/developers/weaviate/api/rest/objects.md
+++ b/developers/weaviate/api/rest/objects.md
@@ -99,13 +99,13 @@ The response of a `GET` query of a data object will give you information about a
 
 ### Object fields
 
-| field name | datatype | required `include` or `additional` field |  description |
-| ---------- | -------- | ---------------------------------------- | ------------ |
-| `class` | string | none | The class name |
-| `creationTimeUnix` | unix timestamp | none | The time stamp of creation of the data object |
-| `id` | uuid | none | The uuid of the data object |
-| `lastUpdateTimeUnix` | unix timestamp | none | the time stamp when the data object was last updated |
-| `properties` > `{property_name}` | dataType | none | The name and value of an individual property |
+| Field name | Data type | Required `include` or `additional` field | Description |
+| ---------- | --------- | ---------------------------------------- | ----------- |
+| `class` | string | none | The class name. |
+| `creationTimeUnix` | unix timestamp | none | The time stamp of creation of the data object. |
+| `id` | uuid | none | The uuid of the data object. |
+| `lastUpdateTimeUnix` | unix timestamp | none | The time stamp when the data object was last updated. |
+| `properties` > `{property_name}` | dataType | none | The name and value of an individual property. |
 | `properties` > `{cref_property_name}` > `classification` > `closestLosingDistance` | float | `classification` | The lowest distance of a neighbor in the losing group. Optional. If `k` equals the size of the winning group, there is no losing group. |
 | `properties` > `{cref_property_name}` > `classification` > `closestOverallDistance` | float | `classification` | The lowest distance of any neighbor, regardless of whether they were in the winning or losing. |
 | `properties` > `{cref_property_name}` > `classification` > `closestWinningDistance` | float | `classification` | Closest distance of a neighbor from the winning group. |
@@ -114,24 +114,24 @@ The response of a `GET` query of a data object will give you information about a
 | `properties` > `{cref_property_name}` > `classification` > `meanWinningDistance` | float | `classification` | The mean distance of the winning group. It is a normalized distance (between 0 and 1), where 0 means equal and 1 would mean a perfect opposite. |
 | `properties` > `{cref_property_name}` > `classification` > `overallCount` | integer | `classification` | Overall neighbors checked as part of the classification. In most cases this will equal `k`, but could be lower than `k` - for example if not enough data was present. |
 | `properties` > `{cref_property_name}` > `classification` > `winningCount` | integer | `classification` | Size of the winning group, a number between 1 and `k`. |
-| `vector` | list of floats | `vector` | the long vector of the location of the object in the 300 dimensional space | 
-| `classification` > `basedOn` | string |  `classification` | the property name where the classification was based on |
-| `classification` > `classifiedFields` | string |  `classification` | the classified property |
-| `classification` > `completed` | timestamp |  `classification` | the time of classification completion |
-| `classification` > `id` | uuid |  `classification` | the classification id |
-| `classification` > `scope` | list of strings |  `classification` | the initial fields to classify |
-| `featureProjection` > `vector` | list of floats |  `featureProjection` | the 2D or 3D vector coordinates of the feature projection |
+| `vector` | list of floats | `vector` | The long vector of the location of the object in the 300-dimensional space. | 
+| `classification` > `basedOn` | string |  `classification` | The property name where the classification was based on. |
+| `classification` > `classifiedFields` | string |  `classification` | The classified property. |
+| `classification` > `completed` | timestamp |  `classification` | The time of classification completion. |
+| `classification` > `id` | uuid |  `classification` | The classification id. |
+| `classification` > `scope` | list of strings |  `classification` | The initial fields to classify. |
+| `featureProjection` > `vector` | list of floats |  `featureProjection` | The 2D or 3D vector coordinates of the feature projection. |
 
 ### Status codes and error cases
 
 | Cause | Description | Result |
 | ----- | ----------- | ------ |
 | No objects present | No `?class` is provided. There are no objects present in the entire Weaviate instance. | `200 OK` - No error |
-| Valid class, no objects present | `?class` is provided, class exists. There are no objects present for this class | `200 OK` - No error |
-| Invalid class | `?class` is provided, class does not exist | `404 Not Found` |
-| Validation | Otherwise invalid user request | `422 Unprocessable Entity` |
-| Authorization | Not allowed to view resource | `403 Forbidden` | 
-| Server-Side error | Correct user input, but request failed for another reason | `500 Internal Server Error` - contains detailed error message |
+| Valid class, no objects present | `?class` is provided, class exists. There are no objects present for this class. | `200 OK` - No error |
+| Invalid class | `?class` is provided, class does not exist. | `404 Not Found` |
+| Validation | Otherwise invalid user request. | `422 Unprocessable Entity` |
+| Authorization | Not allowed to view resource. | `403 Forbidden` | 
+| Server-Side error | Correct user input, but request failed for another reason. | `500 Internal Server Error` - contains detailed error message |
 
 #### Example request
 
@@ -145,7 +145,9 @@ Create a new data object. The provided meta-data and schema values are validated
 
 ### Performance
 
-💡 This endpoint is meant for individual object creations.
+:::tip
+This endpoint is meant for individual object creations.
+:::
 
 If you plan on importing an entire dataset, it's much more efficient to use the [`/v1/batch`](./batch.md) endpoint. Otherwise, sending multiple single requests sequentially would incur a large performance penalty:
 
@@ -168,7 +170,7 @@ The class name is not specified in the URL, as it is part of the request body.
 
 The request body for a new object has the following fields:
 
-| name | type | required | description |
+| Name | Type | Required | Description |
 | ---- | ---- | -------- |------------ |
 | `class` | string | yes | The class name as defined in the schema |
 | `properties` | array | yes | An object with the property values of the new data object |
@@ -237,17 +239,17 @@ import RestObjectsCRUDClassnameNote from '/_includes/rest-objects-crud-classname
 
 <RestObjectsCRUDClassnameNote/>
 
-#### Parameters
+### URL parameters
 
-| name | location | type | description |
+| Name | Location | Type | Description |
 | ---- |----------| ---- | ----------- |
-| `{className}` | URL Path | string | The name of the class that the object belongs to. |
-| `{id}` | URL Query param | uuid | The uuid of the data object to retrieve. |
-| `include` | URL Query param | string | Include additional information, such as classification info. Allowed values include: `classification`, `vector` |
+| `{className}` | path | string | The name of the class that the object belongs to. |
+| `{id}` | query param | uuid | The uuid of the data object to retrieve. |
+| `include` | query param | string | Include additional information, such as classification info. Allowed values include: `classification`, `vector`. |
 
 #### Example request
 
-See [here](#response-fields) the explanation of the response fields.
+The [response fields](#response-fields) are explained in the corresponding section above.
 
 import SemanticKindObjectGet from '/_includes/code/semantic-kind.object.get.mdx';
 
@@ -278,12 +280,12 @@ HEAD /v1/objects/{id}
 
 <RestObjectsCRUDClassnameNote/>
 
-#### Parameters
+#### URL parameters
 
-| name | location | type | description |
+| Name | Location | Type | Description |
 | ---- | -------- | ---- | ----------- |
-| `{className}` |  URL Path | string | The name of the class that the object belongs to. |
-| `{id}` | URL | uuid | The uuid of the data object to retrieve. |
+| `{className}` | path | string | The name of the class that the object belongs to |
+| `{id}` | path | uuid | The uuid of the data object to retrieve |
 
 #### Example request
 
@@ -315,18 +317,20 @@ PATCH /v1/objects/{id}
 
 #### Parameters
 
-| name | location | type | description |
+The URL must contain the following parameters:
+
+| Name | Location | Type | Description |
 | ---- | -------- | ---- | ----------- |
-| `{className}` |  URL Path | string | The name of the class that the object belongs to. |
-| `{id}` | URL | uuid | The uuid of the data object to update. |
+| `{className}` | path | string | The name of the class that the object belongs to |
+| `{id}` | path | uuid | The uuid of the data object to update |
 
-The body of the data object for replacing (some) properties of an object takes the following fields:
+The request body for replacing (some) properties of an object has the following fields:
 
-| name | type | required | description |
+| Name | Type | Required | Description |
 | ---- | ---- | -------- | ----------- |
-| `class` | string | yes | the class name as defined in the schema |
-| `properties` | array | yes | an object with the property values of the new data object |
-| `properties` > `{property_name}` | dataType | yes | the property and its value according to the set dataType |
+| `class` | string | yes | The class name as defined in the schema |
+| `properties` | array | yes | An object with the property values of the new data object |
+| `properties` > `{property_name}` | dataType | yes | The property and its value according to the set dataType |
 
 #### Example request
 
@@ -342,7 +346,7 @@ Delete an individual data object from Weaviate.
 
 #### Method and URL
 
-Available since `v1.14` and preferred way:
+Available since `v1.14` and the preferred way:
 ```js
 DELETE /v1/objects/{className}/{id}
 ```
@@ -354,12 +358,12 @@ DELETE /v1/objects/{id}
 
 <RestObjectsCRUDClassnameNote/>
 
-#### Parameters
+#### URL parameters
 
-| name | location | type | description |
+| Name | Location | Type | Description |
 | ---- | -------- | ---- | ----------- |
-| `{className}` |  URL Path | string | The name of the class that the object belongs to. |
-| `{id}` | URL | uuid | The uuid of the data object to delete. |
+| `{className}` |  path | string | The name of the class that the object belongs to |
+| `{id}` | path | uuid | The uuid of the data object to delete |
 
 #### Example request
 
@@ -371,7 +375,7 @@ If the deletion was successful, no content will be returned.
 
 ## Validate a data object
 
-You can validate a data object's schema and meta data. 
+You can validate an object's schema and metadata without creating it. If the schema of the object is valid, the request should return `True`/`true` in case of the clients, and nothing with a plain RESTful request. Otherwise, an error object will be returned.
 
 #### Method and URL
 
@@ -379,19 +383,20 @@ You can validate a data object's schema and meta data.
 POST /v1/objects/validate
 ```
 
-*Note: As with creating an object, the className is not specified through the
-URL, as it is part of the request body.*
+:::note
+As with creating an object, the class name is not specified through the URL, as it is part of the request body.
+:::
 
 #### Parameters
 
-The body of the data object for a new data object is an object taking the following field:
+The request body for validating an object has the following fields:
 
-| name | type | required | description |
+| Name | Type | Required | Description |
 | ---- | ---- | -------- | ----------- |
 | `class` | string | yes | The class name as defined in the schema |
 | `properties` | array | yes | An object with the property values of the new data object |
 | `properties` > `{property_name}` | dataType | yes | The property and its value according to the set dataType |
-| `id` | v4 uuid | no<sup>*</sup> | The id of the data object. <sup>*</sup>An ID is required by the clients. |
+| `id` | v4 uuid | no<sup>*</sup> | The id of the data object.<br/><sup>*An ID is required by the clients.</sup> |
 
 #### Example request
 
@@ -399,15 +404,18 @@ import SemanticKindValidate from '/_includes/code/semantic-kind.validate.mdx';
 
 <SemanticKindValidate/>
 
-If the schema of the object is valid, this request should return `True`/`true` in case of the clients and nothing with a plain RESTful request. 
 
 ## Cross-references
 
+[Cross-references](../../configuration/datatypes.md#datatype-cross-reference) are object properties of type array, in which each element points from the source object to another object via a [beacon](../../more-resources/glossary.md).
+
 ### Add a cross-reference
+
+`POST` request that adds a reference to the array of cross-references specified by the property name in the source object specified by its class name and id.
 
 #### Method and URL
 
-Available since `v1.14` and preferred way:
+Available since `v1.14` and the preferred way:
 ```js
 POST /v1/objects/{className}/{id}/references/{property_name}
 ```
@@ -421,17 +429,19 @@ POST /v1/objects/{id}/references/{property_name}
 
 #### Parameters
 
-| name | location | type | description |
+The URL must contain the following parameters:
+
+| Name | Location | Type | Description |
 | ---- | -------- | ---- | ----------- |
-| `{className}` |  URL Path | string | The name of the class that the object belongs to. |
-| `{id}` | URL | uuid | The uuid of the data object to add the reference to. |
-| `{property_name}` | URL | yes | The name of the cross-reference property |
+| `{className}` |  path | string | The name of the class that the object belongs to, e.g. `Article` |
+| `{id}` | path | uuid | The uuid of the object to add the reference to |
+| `{property_name}` | path | string | The name of the cross-reference property, e.g. `author` |
 
-The body of the data object for a new data object is an object taking the following field:
+The request body is an object with the following field:
 
-| name | type | required | description |
+| Name | Type | Required | Description |
 | ---- | ---- | -------- | ----------- |
-| `beacon` | Weaviate Beacon | yes | the beacon URL of the reference, in the format of `weaviate://localhost/<ClassName>/<id>` |
+| `beacon` | Weaviate Beacon | yes | The beacon URL of the reference, in the format `weaviate://localhost/<ClassName>/<id>` |
 
 :::caution
 In the beacon format, you need to always use `localhost` as the host,
@@ -457,7 +467,7 @@ If the addition was successful, no content will be returned.
 
 ### Update a cross-reference
 
-A `PUT` request updates *all* references of a property of a data object.
+`PUT` request that updates *all* references in a specified property of an object specified by its class name and id.
 
 #### Method and URL
 
@@ -475,17 +485,19 @@ PUT /v1/objects/{id}/references/{property_name}
 
 #### Parameters
 
-| name | location | type | description |
+The URL must contain the following parameters:
+
+| Name | Location | Type | Description |
 | ---- | -------- | ---- | ----------- |
-| `{className}` |  URL Path | string | The name of the class that the object belongs to. |
-| `{id}` | URL | uuid | The uuid of the data object to add the reference to. |
-| `{property_name}` | URL | yes | The name of the cross-reference property |
+| `{className}` | path | string | The name of the class that the object belongs to |
+| `{id}` | path | uuid | The uuid of the object to update the reference(s) of |
+| `{property_name}` | path | string | The name of the cross-reference property |
 
-The body of the data object for a new data object is a list of beacons:
+The `PUT` request body is a list of beacons:
 
-| name | type | required | description |
+| Name | Type | Required | Description |
 | ---- | ---- | -------- | ----------- |
-| `beacon` | Weaviate Beacon | yes | the beacon URL of the reference, in the format of `weaviate://localhost/<ClassName>/<id>` |
+| `beacon` | Weaviate Beacon array | yes | Array of beacons in the format `weaviate://localhost/<ClassName>/<id>` |
 
 :::caution
 In the beacon format, you need to always use `localhost` as the host,
@@ -512,7 +524,7 @@ If the update was successful, no content will be returned.
 
 ### Delete a cross-reference
 
-Delete the single reference that is given in the body from the list of references that this property of a data object has.
+Delete the single reference that is given in the body from the list of references that the specified property of a given object has, if it exists in the list. Returns 204 No Content either way.
 
 #### Method and URL
 
@@ -530,14 +542,16 @@ DELETE /v1/objects/{id}/references/{property_name}
 
 #### Parameters
 
-| name | location | type | description |
+The URL must contain the following parameters:
+
+| Name | Location | Type | Description |
 | ---- | -------- | ---- | ----------- |
-| `{id}` | URL | uuid | The uuid of the data object to delete the reference from. |
-| `{property_name}` | URL | yes | The name of the cross-reference property |
+| `{id}` | path | uuid | The uuid of the object to delete the reference from |
+| `{property_name}` | path | string | The name of the cross-reference property |
 
-The body of the data object for a new data object is a list of beacons:
+The request body is a beacon object:
 
-| name | type | required | description |
+| Name | Type | Required | Description |
 | ---- | ---- | -------- | ----------- |
 | `beacon` | Weaviate Beacon | yes | The beacon URL of the reference, formatted as `weaviate://localhost/<ClassName>/<id>` |
 

--- a/developers/weaviate/api/rest/schema.md
+++ b/developers/weaviate/api/rest/schema.md
@@ -9,7 +9,7 @@ import Badges from '/_includes/badges.mdx';
 <Badges/>
 
 :::note
-From v1.5.0 onwards creating a schema is optional. Learn more about [Auto Schema](/developers/weaviate/configuration/schema-configuration.md#auto-schema).
+From `v1.5.0` onwards, creating a schema is optional. Learn more about [Auto Schema](/developers/weaviate/configuration/schema-configuration.md#auto-schema).
 :::
 
 ## Get the schema
@@ -231,7 +231,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
 Create a new data object class in the schema.
 
 :::note
-From v1.5.0 onwards creating a schema is optional. Learn more about [Auto Schema ](/developers/weaviate/configuration/schema-configuration.md#auto-schema).
+From `v1.5.0` onwards, creating a schema is optional. Learn more about [Auto Schema](/developers/weaviate/configuration/schema-configuration.md#auto-schema).
 :::
 
 ### Method and URL
@@ -244,17 +244,17 @@ POST /v1/schema
 
 Learn more about the schema configuration [here](/developers/weaviate/configuration/schema-configuration.md).
 
-| name | location | type | description |
-| ---- | ---- | ----------- | ---- |
+| Name | Location | Type | Description |
+| ---- | -------- | ---- | ----------- |
 | `class` | body | string | The name of the class. Multiple words should be concatenated in CamelCase, e.g. `ArticleAuthor`. |
-| `description` | body | string | Description of the classname |
+| `description` | body | string | Description of the class. |
 | `vectorIndexType` | body | string | Defaults to hnsw. Can be omitted in schema definition since this is the only available type for now. |
-| `vectorIndexConfig` | body | object | Vector index type specific settings |
+| `vectorIndexConfig` | body | object | Vector index type specific settings. |
 | `vectorizer` | body | string | Vectorizer to use for data objects added to this class. Default can be set via Weaviate environment variables. |
 | `moduleConfig` > `text2vec-contextionary`  > `vectorizeClassName` | body | object | Include the class name in vector calculation (default true). Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
-| `properties` | body | array | An array of property objects |
-| `properties` > `dataType` | body | array | See the [available data types](/developers/weaviate/configuration/datatypes.md) |
-| `properties` > `description` | body | string | Description of the property |
+| `properties` | body | array | An array of property objects. |
+| `properties` > `dataType` | body | array | See the [available data types](/developers/weaviate/configuration/datatypes.md). |
+| `properties` > `description` | body | string | Description of the property. |
 | `properties` > `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | If true, the whole property will NOT be included in vectorization. Default is false, meaning that the object will be NOT be skipped. |
 | `properties` > `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | Whether the name of the property is used in the calculation for the vector position of data objects. Default is true. Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 | `properties` > `name` | body | string | The name of the property. Multiple words should be concatenated in camelCase, e.g. `nameOfAuthor`. |
@@ -262,7 +262,7 @@ Learn more about the schema configuration [here](/developers/weaviate/configurat
 | `properties` > `tokenization` | body | string | Only for `string`/`text` props. Introduced in `v1.12.0`. Control how a field is tokenized in the inverted index. Defaults to `"word"`, can be set to `"field"`. Learn more about [property tokenization](/developers/weaviate/configuration/schema-configuration.md#property-tokenization).|
 | `invertedIndexConfig` > `stopwords` | body | object | Configure which words should be treated as stopwords and therefore be ignored on inverted indexing and querying. See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--stopwords-stopword-lists). |
 | `invertedIndexConfig` > `indexTimestamps` | body | boolean | Maintain an inverted index for each object by its internal timestamps, currently including `creationTimeUnix` and `lastUpdateTimeUnix` See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--indextimestamps). |
-| `replicationConfig` > `factor` | body | int | The replication factor, aka the number of copies in a replicated Weaviate setup |
+| `replicationConfig` > `factor` | body | int | The replication factor, aka the number of copies in a replicated Weaviate setup. |
 
 ### Example request for creating a class
 
@@ -303,11 +303,11 @@ Remove a class (and all data in the instances) from the schema.
 DELETE v1/schema/{class_name}
 ```
 
-### Parameters
+### URL parameters
 
-| name | location | type | description |
-| ---- | ---- | ----------- |
-| `{class_name}` | URL | string | The name of the class |
+| Name | Location | Type | Description |
+| ---- | -------- | ---- | ----------- |
+| `{class_name}` | path | string | The name of the class |
 
 ### Example request for deleting a class
 
@@ -331,30 +331,30 @@ PUT v1/schema/{class_name}
 
 ### Parameters
 
-Parameter in the PUT request:
+The URL must contain the following parameter:
 
-| name | location | type | description |
-| ---- | ---- | ----------- |
-| `{class_name}` | URL | string | The name of the class |
+| Name | Location | Type | Description |
+| ---- | -------- | ---- | ----------- |
+| `{class_name}` | path | string | The name of the class |
 
-Parameter in the PUT body:
+Parameters in the PUT body:
 
-| name | location | type | description |
-| ---- | ---- | ----------- | ---- |
+| Name | Location | Type | Description |
+| ---- | -------- | ---- | ----------- |
 | `class` | body | string | The name of the class. Multiple words should be concatenated in CamelCase, e.g. `ArticleAuthor`. |
-| `description` | body | string | Description of the classname |
+| `description` | body | string | Description of the class. |
 | `vectorIndexType` | body | string | Defaults to hnsw. Can be omitted in schema definition since this is the only available type for now. |
-| `vectorIndexConfig` | body | object | Vector index type specific settings |
+| `vectorIndexConfig` | body | object | Vector index type specific settings. |
 | `vectorizer` | body | string | Vectorizer to use for data objects added to this class. Default can be set via Weaviate environment variables. |
 | `moduleConfig` > `text2vec-contextionary`  > `vectorizeClassName` | body | object | Include the class name in vector calculation (default true). Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
-| `properties` | body | array | An array of property objects |
+| `properties` | body | array | An array of property objects. |
 | `properties` > `dataType` | body | array | See the [available data types](/developers/weaviate/configuration/datatypes.md) |
-| `properties` > `description` | body | string | Description of the property |
+| `properties` > `description` | body | string | Description of the property. |
 | `properties` > `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | If true, the whole property will NOT be included in vectorization. Default is false, meaning that the object will be NOT be skipped. |
 | `properties` > `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | Whether the name of the property is used in the calculation for the vector position of data objects. Default is true. Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 | `properties` > `name` | body | string | The name of the property. Multiple words should be concatenated in camelCase, e.g. `nameOfAuthor`. |
 | `properties` > `indexInverted` | body | boolean | Should the data stored in this property be indexed? Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
-| `properties` > `tokenization` | body | string | Only for `string`/`text` props. Introduced in `v1.12.0`. Control how a field is tokenized in the inverted index. Defaults to `"word"`, can be set to `"field"`. Learn more about [property tokenization](/developers/weaviate/configuration/schema-configuration.md#property-tokenization).|
+| `properties` > `tokenization` | body | string | Only for `string`/`text` props. Introduced in `v1.12.0`. Control how a field is tokenized in the inverted index. Defaults to `"word"`, can be set to `"field"`. Learn more about [property tokenization](/developers/weaviate/configuration/schema-configuration.md#property-tokenization). |
 | `invertedIndexConfig` > `stopwords` | body | object | Configure which words should be treated as stopwords and therefore be ignored on inverted indexing and querying. See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--stopwords-stopword-lists). |
 | `invertedIndexConfig` > `indexTimestamps` | body | boolean | Maintain an inverted index for each object by its internal timestamps, currently including `creationTimeUnix` and `lastUpdateTimeUnix` See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--indextimestamps). |
 
@@ -375,14 +375,14 @@ POST v1/schema/{class_name}/properties
 
 ### Parameters
 
-| name | location | type | description |
-| ---- | ---- | ----------- |
-| `dataType` | body | array | Click [here](/developers/weaviate/configuration/datatypes.md) for a list of available data types. |
-| `description` | body | string | Description of the property |
-| `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | if true, the whole property will NOT be included in vectorization. default is false, meaning that the object will be NOT be skipped |
-| `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | whether name of the property is used in the calculation for the vector position of data objects. default is true. Learn more about how to configure indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
-| `name` | body | string | The name of the property, multiple words should be concatenated in camelCase like `nameOfAuthor`. |
-| `indexInverted` | body | boolean | Should the data stored in this property be indexed? Learn more about how to configure indexing in Weaviate [here](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| Name | Location | Type | Description |
+| ---- | -------- | -----| ----------- |
+| `dataType` | body | array | An available [data type](/developers/weaviate/configuration/datatypes.md). |
+| `description` | body | string | Description of the property. |
+| `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | If true, the whole property will NOT be included in vectorization. Default is false, meaning that the object will be NOT be skipped. |
+| `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | Whether the name of the property is used in the calculation for the vector position of data objects. Default is true. Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `name` | body | string | The name of the property. Multiple words should be concatenated in camelCase like `nameOfAuthor`. |
+| `indexInverted` | body | boolean | Should the data stored in this property be indexed? Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 
 ### Example request for adding a property
 
@@ -408,9 +408,9 @@ GET v1/schema/{class_name}/shards
 
 ### Parameters
 
-| name | location | type | description |
-| ---- | ---- | ----------- |
-| `{class_name}` | URL | string | The name of the class |
+| Name | Location | Type | Description |
+| ---- | -------- | ---- | ----------- |
+| `{class_name}` | URL path | string | The name of the class |
 
 ### Example request viewing shards of a class
 
@@ -434,11 +434,11 @@ PUT v1/schema/{class_name}/shards/{shard_name}
 
 ### Parameters
 
-| name | location | type | description |
-| ---- | ---- | ----------- |
-| `{class_name}` | URL | string | The name of the class |
-| `{shard_name}` | URL | string | The name/id of the shard |
-| `status` | body | string | The status to update the shard to. One of `READONLY`, `READY` |
+| Name | Location | Type | Description |
+| ---- | -------- | ---- | ----------- |
+| `{class_name}` | URL path | string | The name of the class. |
+| `{shard_name}` | URL path | string | The name/id of the shard. |
+| `status` | body | string | The status to update the shard to. One of `READONLY`, `READY`. |
 
 ### Example requests to update the status of a shard
 

--- a/developers/weaviate/concepts/replication-architecture/consistency.md
+++ b/developers/weaviate/concepts/replication-architecture/consistency.md
@@ -33,7 +33,7 @@ A clean (without fails) execution has two phases:
 
 ## Data objects 
 
-Data objects in Weaviate have **eventual consistency**, which means that all nodes will eventually contain the most updated data if the data is not updated for a while. It might happen that after a data update, not all nodes are updated yet, but there is a guarantee that all nodes will be up to date after some time. Eventual consistency provides BASE semantics: 
+Data objects in Weaviate have **eventual consistency**, which means that all nodes will eventually contain the most updated data if the data is not updated for a while. It might happen that after a data update, not all nodes are updated yet, but there is a guarantee that all nodes will be up-to-date after some time. Eventual consistency provides BASE semantics: 
 
 * **Basically available**: reading and writing operations are as available as possible
 * **Soft-state**: there are no consistency guarantees since updates might not yet have converged
@@ -45,12 +45,12 @@ Eventual consistency is chosen over strong consistency, to ensure high availabil
 
 <p align="center"><img src="/img/docs/replication-architecture/replication-quorum-animation.gif" alt="Write consistency QUORUM" width="75%"/></p>
 
-### Tunable Write Consistency
+### Tunable write consistency
 
 Adding or changing data objects are **write** operations.  
 
 :::note
-Write operations are tunable starting with Weaviate v1.18, to `ONE`, `QUORUM` or `ALL`. In v1.17, write operations are always set to `ALL` (highest consistency).
+Write operations are tunable starting with Weaviate v1.18, to `ONE`, `QUORUM` or `ALL` (default). In v1.17, write operations are always set to `ALL` (highest consistency).
 :::
 
 The main reason for introducing configurable write consistency in v1.18 is because that is also when automatic repairs are introduced. A write will always be written to n (replication factor) nodes, regardless of the chosen consistency level. The coordinator node however waits for acknowledgements from `ONE`, `QUORUM` or `ALL` nodes before it returns. To guarantee that a write is applied everywhere without the availability of repairs on read requests, write consistency is set to `ALL` for now. Possible settings in v1.18+ are:
@@ -59,7 +59,7 @@ The main reason for introducing configurable write consistency in v1.18 is becau
 * **ALL** - a write must receive an acknowledgement from all replica nodes. This is the most consistent, but 'slowest' (least available) option.
 
 
-*Figure below: a replicated Weaviate setup with Write Consistency of ONE. There are 8 nodes in total out of which 3 replicas.*
+*Figure below: a replicated Weaviate setup with write consistency of ONE. There are 8 nodes in total out of which 3 replicas.*
 
 <p align="center"><img src="/img/docs/replication-architecture/replication-rf3-c-ONE.png" alt="Write consistency ONE" width="60%"/></p>
 
@@ -73,15 +73,15 @@ The main reason for introducing configurable write consistency in v1.18 is becau
 <p align="center"><img src="/img/docs/replication-architecture/replication-rf3-c-ALL.png" alt="Write consistency ALL" width="60%"/></p>
 
 
-### Tunable Read Consistency
+### Tunable read consistency
 
-Read operations are GET queries to data objects in Weaviate. Like write, read consistency is tunable, to `ONE`, `QUORUM` or `ALL`.
+Read operations are GET queries to data objects in Weaviate. Like write, read consistency is tunable, to `ONE`, `QUORUM` or `ALL` (default).
 
 :::note
-With v1.17, read consistency is tunable only for Get-Objects-By-ID type requests. All read requests (including searches) will be added in v1.18. Read requests other than Get-Objects-By-ID have a read consistency of `ALL`.
+Prior to `v1.18`, read consistency was tunable only for requests that [obtained an object by id](../../api/rest/objects.md#get-a-data-object), and all other read requests had a read consistency of `ALL`.
 :::
 
-Possible Read Consistency levels are:
+Possible read consistency levels are:
 * **ONE** - a read response must be returned by at least one replica. This is the fastest (most available), but least consistent option. 
 * **QUORUM** - a response must be returned by `QUORUM` amount of replica nodes. `QUORUM` is calculated as _n / 2 + 1_, where _n_ is the number of replicas (replication factor). For example, using a replication factor of 6, the quorum is 4, which means the cluster can tolerate 2 replicas down.
 * **ALL** - a read response must be returned by all replicas. The read operation will fail if at least one replica fails to respond. This is the most consistent, but 'slowest' (least available) option.
@@ -103,7 +103,7 @@ Examples:
 
   <p align="center"><img src="/img/docs/replication-architecture/replication-rf3-c-ALL.png" alt="Write consistency ALL" width="60%"/></p>
 
-  
+
 ## Repairs
 
 Repairs can be executed by Weaviate in case of a discovered inconsistency. A scenario where a repair could be necessary is the following: The user writes with a consistency level of `ONE`. The node dies before it can contact some of the other nodes. The node comes back up with the latest data. Some other nodes may now be out of sync and need to be repaired.
@@ -111,9 +111,7 @@ Repairs can be executed by Weaviate in case of a discovered inconsistency. A sce
 Repairs can happen in the background, for example when a read operation is done. Repairs (and more information about them) will be available starting with v1.18 (Q1 2023).
 
 
-
-
-## More Resources
+## More resources
 
 import DocsMoreResources from '/_includes/more-resources-docs.md';
 

--- a/developers/weaviate/configuration/datatypes.md
+++ b/developers/weaviate/configuration/datatypes.md
@@ -26,7 +26,7 @@ import DataTypes from '/_includes/datatypes.mdx';
 
 ## DataType: string vs. text
 
-There are two datatypes dedicated to saving textual information: string and text. `string` values are indexed as one token, whereas `text` values are indexed after applying tokenization. `"jane.doe@foobar.com"` as string would be indexed as `"jane.doe@foobar.com"` and also only match that in a GraphQL where filter, whereas as text it would be indexed as `['jane', 'doe', 'foobar', 'com']` and also match the individual words.
+There are two data types dedicated to saving textual information: string and text. `string` values are indexed as one token, whereas `text` values are indexed after applying tokenization. `"jane.doe@foobar.com"` as string would be indexed as `"jane.doe@foobar.com"` and also only match that in a GraphQL where filter, whereas as text it would be indexed as `['jane', 'doe', 'foobar', 'com']` and also match the individual words.
 
 ## DataType: date
 
@@ -61,7 +61,7 @@ An example of how geo coordinates are used in a data object:
 
 There is a special, primitive data type `phoneNumber`. When a phone number is added to this field, the input will be normalized and validated, unlike the single fields as `number` and `string`. The data field is an object, as opposed to a flat type similar to `geoCoordinates`. The object has multiple fields:
 
-```json
+```yaml
 {
   "phoneNumber": {
     "input": "020 1234567",                       // Required. Raw input in string format
@@ -129,12 +129,13 @@ $ curl \
 
 ## DataType: cross-reference
 
-The `cross-reference` type is the graph element of Weaviate: you can create a link from one object to another. In the schema you can define multiple classes to which a property can point, in a list of strings. The strings in the `dataType` list of are names of classes that exist elsewhere in the schema. For example:
+The [`cross-reference`](../more-resources/glossary.md) type is the graph element of Weaviate: you can create a link from one object to another. In the schema you can define multiple classes to which a property can point, in a list of strings. The strings in the `dataType` list of are names of classes that exist elsewhere in the schema. For example:
 
 ```json
 {
   "properties": [
     {
+      "name": "hasWritten",
       "dataType": [
         "Article",
         "Blog"
@@ -145,13 +146,14 @@ The `cross-reference` type is the graph element of Weaviate: you can create a li
 ```
 
 ### Number of linked instances
-The `cross-reference` type objects are `arrays` by default. This allows you to link to any number `(0..n)` of instances of a given class.
+
+The `cross-reference` type objects are `arrays` by default. This allows you to link to any number of instances of a given class (including zero).
 
 In the above example, our objects can be linked to:
 * **0** Articles and **1** Blog
 * **1** Article and **3** Blogs
 * **2** Articles and **5** Blogs
-* etc
+* etc.
 
 ## More Resources
 

--- a/developers/weaviate/configuration/replication.md
+++ b/developers/weaviate/configuration/replication.md
@@ -59,7 +59,7 @@ The data schema has a write consistency level of `ALL`, which means when you upl
 
 ## How to use: Queries
 
-When you add (write) or query (read) data, one or more replica nodes in the cluster will respond to the request. How many nodes need to send a successful response and acknowledgement to the coordinator node depends on the `consistency_level`. Available consistency levels are `ONE`, `QUORUM` (n/2+1) and `ALL`. Read more about consistency levels [here](../concepts/replication-architecture/consistency.md).
+When you add (write) or query (read) data, one or more replica nodes in the cluster will respond to the request. How many nodes need to send a successful response and acknowledgement to the coordinator node depends on the `consistency_level`. Available [consistency levels](../concepts/replication-architecture/consistency.md) are `ONE`, `QUORUM` (n/2+1) and `ALL`.
 
 The `consistency_level` can be specified at query time: 
 

--- a/developers/weaviate/modules/reader-generator-modules/qna-openai.md
+++ b/developers/weaviate/modules/reader-generator-modules/qna-openai.md
@@ -111,8 +111,8 @@ This module adds a search parameter to GraphQL `Get{...}` queries: `ask{}`. This
 
 | Field | Data Type | Required | Example value | Description |
 |- |- |- |- |- |
-| `question`  | string | yes | `"What is the name of the Dutch king?"`  | The question to be answered. |
-| `properties`  | list of strings | no | `["summary"]`  | The properties of the queries Class which contains text. If no properties are set, all are considered. |
+| `question`  | string | yes | `"What is the name of the Dutch king?"` | The question to be answered. |
+| `properties`  | list of strings | no | `["summary"]` | The properties of the queries Class which contains text. If no properties are set, all are considered. |
 
 Notes:
 

--- a/developers/weaviate/more-resources/_architecture.md
+++ b/developers/weaviate/more-resources/_architecture.md
@@ -15,26 +15,26 @@ import Badges from '/_includes/badges.mdx';
 The following are some bullet points, that need to be converted to proper text.
 I tried to be quite detailed, if there are details in there that should not be
 published, feel free to remove them, as long as the general message still makes
-sense. Simiarly all bullet points are brutally honest, for some there might be
+sense. Similarly, all bullet points are brutally honest, for some there might be
 a more marketing-suited way of saying the same things. Feel free to adopt.
 
 ## 0.22.x ("Third-party setup")
 
-### 10,000 feet few
-* The "Core" Weaviate application (not to be confused with the Weviate Stack)
-  itself is statelss and stores its data in third-party databases
+### 10,000 feet view
+* The "Core" Weaviate application (not to be confused with the Weaviate Stack)
+  itself is stateless and stores its data in third-party databases
 * The two databases used are `etcd` and `Elasticsearch`. 
 * `Etcd` has mostly historic reasons and is currently used to store
   configuration, the schema and contextionary extensions
 * `Elasticsearch` stores all data objects and provides search functionalities
-* The "Core" Weaviate application handles converting text-to-vector, enrichting
-  the schema in dataobjects, building and resolving of cross-references,
+* The "Core" Weaviate application handles converting text-to-vector, enriching
+  the schema in data objects, building and resolving of cross-references,
   validation and the APIs
 
 ### Vector Search
 * When a vector search happens, Core uses the Contextionary to convert the
   query text to a vector and passes it to Elasticsearch. 
-* Elasticsearch does a consine similarity comparison using the OSS plugin
+* Elasticsearch does a cosine similarity comparison using the OSS plugin
   `lior-k/fast-elasticsearch-vector-scoring`
 * This is a primitive, exhaustive approach, in other words, the query vector is
   compared to every other vector in the index with O(n) time complexity
@@ -50,7 +50,7 @@ a more marketing-suited way of saying the same things. Feel free to adopt.
 * Etcd can be scaled horizontally, but it is unlikely that etcd will become the
   bottleneck in the stack.
 * The contextionary container (only present when the "Semantic Search
-  Extension" is enbaled), converts text to vectors, both on import, as well as
+  Extension" is enabled), converts text to vectors, both on import, as well as
   at query time.
 * During an import load typically peaks in both the contextionary containers,
   as well as in the Elasticsearch containers. They are usually the first
@@ -60,7 +60,7 @@ a more marketing-suited way of saying the same things. Feel free to adopt.
 
 ## 1.0.0 ("Standalone")
 
-### 10,000 feet few
+### 10,000 feet view
 * The "Core" Weaviate application handles all persistence, no third-party
   databases are involved.
 * Weaviate's persistence layer is built to be vector-native. At the same time
@@ -167,9 +167,8 @@ a more marketing-suited way of saying the same things. Feel free to adopt.
   which will become the standard in 1.0.0, standalone mode is **not a preview
   of 1.0.0**. In other words, the switch to 1.0.0 will probably contain
   breaking changes which are not currently reflected in 0.22.x standalone mode
-* As of 0.22.16, standalone mode is not feature complete, the limitations can
-  be seen in [link to limitations page in contributor docs]
-* Instead standalone mode in 0.22.x is meant as a preview to see what Weaviate
+* As of 0.22.16, standalone mode is not feature complete.
+* Instead, standalone mode in 0.22.x is meant as a preview to see what Weaviate
   will be like once it no longer depends on third-party DBs for its persistence
 * As of 0.22.16, standalone mode currently still requires `etcd` in the stack.
   This has no technical reasons, a replacement for the data currently stored

--- a/developers/weaviate/more-resources/glossary.md
+++ b/developers/weaviate/more-resources/glossary.md
@@ -9,9 +9,9 @@ import Badges from '/_includes/badges.mdx';
 <Badges/>
 
 | Term | Description |
-| --- | --- |
-| **Beacon** | A beacon is a reference to a particular data object in Weaviate or inside the knowledge network, this data object in turn has a position in the vector space. Often defined as follows: `weaviate://{peerName}/{className}/{UUID}` (For Weaviate version < v1.14.0 it is defined as follows: `weaviate://{peerName}/{UUID}`) |
-| **Class** | A class is a definition of a semantic kind. E.g., the Class Company or the Class Move. In Weaviate, classes can be recognized because they always have a capitalized first character. You can set as many classes with a naming you choose. |
+| ---- | ----------- |
+| **Beacon** | A beacon is a reference to a particular data object in Weaviate or inside the knowledge network. This data object in turn has a position in the vector space. Often defined as follows: `weaviate://{peerName}/{className}/{UUID}`. (For Weaviate version < `v1.14.0`, it is defined as follows: `weaviate://{peerName}/{UUID}`.) |
+| **Class** | A class is a definition of a semantic kind. E.g., the class `Company` or the class `Movie`. In Weaviate, classes can be recognized because they always start with an uppercase letter. |
 | **Concept** | Concepts are related to entities. Often you will use concepts to search in your datasets. If your dataset has data about _An Actor with the name Arnold Schwarzenegger_ and _an Actor with the name Al Pacino_, the concepts _Movie_ and _Terminator_ will find a closer relation to the first actor rather than the latter. |
 | **Contextionary** | Derived from *dictionary* with *context*. Pre-trained vector space which contains vectors for nearly all words used in a specific language. The Contextionary (text2vec-contextionary) gives context to the language used in the dataset, inspired by the [*Global Vectors for Word Representation*](https://github.com/stanfordnlp/GloVe) concept. Read more about the Contextionary [here](/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md). |
 | **Entity** | An entity refers to something -often- in the world around us. E.g., _a Company with the name Apple_ refers to an entity with a relation to _a Product with the name iPhone_. Weaviate's Contextionary tries to find as many entities in your data as possible. |

--- a/developers/weaviate/more-resources/write-great-bug-reports.md
+++ b/developers/weaviate/more-resources/write-great-bug-reports.md
@@ -11,12 +11,12 @@ import Badges from '/_includes/badges.mdx';
 ## Write great bug reports!
 
 This page outlines what an ideal bug report would look like. We know that it is
-not always possible to write a perfect bug report and we don't want to
+not always possible to write a perfect bug report, and we don't want to
 discourage you from reporting a bug just because you might not be able to
 provide all the info needed to make the report great. At the same time we want
 to provide you with the information to make the lives of our engineers a bit
 easier. Sometimes we also need to prioritize and decide about which bug ticket
-to pick up first. If a bug report is well prepared it has a greater chance of
+to pick up first. If a bug report is well-prepared, it has a greater chance of
 being picked up first.
 
 ### What makes a great bug report stand out?


### PR DESCRIPTION
This PR contains fixes impacting the v1.18 tunable consistency and repair-on-read docs (e.g. tables to which new parameters will be added) + minor drive-by fixes, that are not relevant for review by the core team. Separating them out of the way for a clean v1.18 PR.