### PR TITLE
fix(docs) Update query tutorial

### DIFF
--- a/_includes/code/quickstart.autoschema.neartext.mdx
+++ b/_includes/code/quickstart.autoschema.neartext.mdx
@@ -65,8 +65,12 @@ client.graphql
   .withNearText({concepts: ["biology"]})
   .withLimit(2)
   .do()
-  .then(console.log)
-  .catch(console.error);
+  .then(res => {
+    console.log(JSON.stringify(res, null, 2))
+  })
+  .catch(err => {
+    console.error(err)
+  });
 ```
 
 </TabItem>

--- a/_includes/code/quickstart.import.questions.mdx
+++ b/_includes/code/quickstart.import.questions.mdx
@@ -28,7 +28,7 @@ with client.batch as batch:
     batch.batch_size=100
     # Batch import all Questions
     for i, d in enumerate(data):
-        print(f"importing question: {i+1}")
+        # print(f"importing question: {i+1}")  # To see imports
 
         properties = {
             "answer": d["Answer"],
@@ -50,11 +50,6 @@ const client = weaviate.client({
     host: 'some-endpoint.weaviate.network/',  // Replace with your endpoint
     headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your API key
   }); 
-
-let classObj = {
-    "class": "Question",
-    "vectorizer": "text2vec-openai"  // Or "text2vec-cohere" or "text2vec-huggingface"
-}
 
 async function getJsonData() {
     const file = await fetch('https://raw.githubusercontent.com/weaviate-tutorials/quickstart/main/data/jeopardy_tiny.json');

--- a/_includes/code/quickstart.query.aggregate.1.mdx
+++ b/_includes/code/quickstart.query.aggregate.1.mdx
@@ -50,7 +50,7 @@ client.graphql
     .withFields('meta { count }')
     .do()
     .then(res => {
-        console.log(res)
+        console.log(JSON.stringify(res, null, 2))
     })
     .catch(err => {
         console.error(err)

--- a/_includes/code/quickstart.query.aggregate.2.mdx
+++ b/_includes/code/quickstart.query.aggregate.2.mdx
@@ -23,9 +23,9 @@ client = weaviate.Client(
 )
 
 where_filter = {
-  "path": ["category"],
-  "operator": "Equal",
-  "valueString": "ANIMALS",
+    "path": ["category"],
+    "operator": "Equal",
+    "valueText": "ANIMALS",
 }
 
 result = (
@@ -54,7 +54,7 @@ const client = weaviate.client({
 const where_filter = {
     "path": ["category"],
     "operator": "Equal",
-    "valueString": "ANIMALS",
+    "valueText": "ANIMALS",
 }
 
 client.graphql

--- a/_includes/code/quickstart.query.aggregate.2.mdx
+++ b/_includes/code/quickstart.query.aggregate.2.mdx
@@ -64,7 +64,7 @@ client.graphql
     .withWhere(where_filter)    
     .do()
     .then(res => {
-        console.log(res)
+    console.log(JSON.stringify(res, null, 2))
     })
     .catch(err => {
         console.error(err)

--- a/_includes/code/quickstart.query.neartext.additional.mdx
+++ b/_includes/code/quickstart.query.neartext.additional.mdx
@@ -66,8 +66,12 @@ client.graphql
   .withNearText({concepts: ["biology"]})
   .withLimit(2)
   .do()
-  .then(console.log)
-  .catch(console.error);
+  .then(res => {
+    console.log(JSON.stringify(res, null, 2))
+  })
+  .catch(err => {
+    console.error(err)
+  });
 ```
 
 </TabItem>

--- a/_includes/code/quickstart.query.where.1.mdx
+++ b/_includes/code/quickstart.query.where.1.mdx
@@ -25,7 +25,7 @@ client = weaviate.Client(
 where_filter = {
     "path": ["category"],
     "operator": "Equal",
-    "valueString": "ANIMALS",
+    "valueText": "ANIMALS",
 }
 
 result = (
@@ -53,13 +53,14 @@ const client = weaviate.client({
 const where_filter = {
     "path": ["category"],
     "operator": "Equal",
-    "valueString": "ANIMALS",
+    "valueText": "ANIMALS",
 }
 
 client.graphql
     .get()
     .withClassName('Question')
     .withFields('question answer category')
+    .withNearText({concepts: ["biology"]})
     .withWhere(where_filter)
     .do()
     .then(res => {

--- a/_includes/code/quickstart.query.where.1.mdx
+++ b/_includes/code/quickstart.query.where.1.mdx
@@ -64,7 +64,7 @@ client.graphql
     .withWhere(where_filter)
     .do()
     .then(res => {
-        console.log(res)
+        console.log(JSON.stringify(res, null, 2))
     })
     .catch(err => {
         console.error(err)

--- a/_includes/code/quickstart.query.where.2.mdx
+++ b/_includes/code/quickstart.query.where.2.mdx
@@ -63,15 +63,16 @@ const where_filter = {
 client.graphql
     .get()
     .withClassName('Question')
-    .withFields('question answer category')
+    .withFields('question answer category _additional { id certainty }')
     .withNearText({concepts: ["biology"]})
     .withWhere(where_filter)
+    .withLimit(2)
     .do()
     .then(res => {
-        console.log(res)
+    console.log(JSON.stringify(res, null, 2))
     })
     .catch(err => {
-        console.error(err)
+    console.error(err)
     });
 ```
 

--- a/_includes/code/quickstart.query.where.2.mdx
+++ b/_includes/code/quickstart.query.where.2.mdx
@@ -26,7 +26,7 @@ nearText = {"concepts": ["biology"]}
 where_filter = {
     "path": ["category"],
     "operator": "Equal",
-    "valueString": "ANIMALS",
+    "valueText": "ANIMALS",
 }
 
 result = (
@@ -57,13 +57,14 @@ const client = weaviate.client({
 const where_filter = {
     "path": ["category"],
     "operator": "Equal",
-    "valueString": "ANIMALS",
+    "valueText": "ANIMALS",
 }
 
 client.graphql
     .get()
     .withClassName('Question')
     .withFields('question answer category')
+    .withNearText({concepts: ["biology"]})
     .withWhere(where_filter)
     .do()
     .then(res => {

--- a/_includes/code/quickstart.schema.create.mdx
+++ b/_includes/code/quickstart.schema.create.mdx
@@ -26,11 +26,12 @@ class_obj = {
             "name": "answer",
         },
         {
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "The category",
             "name": "category",
         },        
-    ]
+    ],
+    "vectorizer": "text2vec-openai",
 }
 
 # add the schema
@@ -76,7 +77,8 @@ let classObj = {
             "description": "The category",
             "name": "category",
         },        
-    ]
+    ],
+    "vectorizer": "text2vec-openai",
 }
 
 // add the schema

--- a/_includes/schema-delete-class.mdx
+++ b/_includes/schema-delete-class.mdx
@@ -9,7 +9,7 @@ Know that **deleting a class will also delete all associated objects**!
 
 Do not do this to a production database, or anywhere where you do not wish to delete your data. 
 
-Run this code to delete the relevant class and get an output confirming it;
+Run this code to delete the relevant class.
 :::
 
 import Tabs from '@theme/Tabs';
@@ -32,10 +32,7 @@ import json
 client = weaviate.Client("https://some-endpoint.weaviate.network/")  # Replace with your endpoint
 
 # delete class "YourClassName" - THIS WILL DELETE ALL DATA IN THIS CLASS
-client.schema.delete_class("YourClassName")  # Replace with your class name
-
-schema = client.schema.get()
-print(json.dumps(schema, indent=4))
+client.schema.delete_class("YourClassName")  # Replace with your class name - e.g. "Question"
 ```
 
 </TabItem>
@@ -55,18 +52,9 @@ client.schema
   .classDeleter()
   .withClassName(className)
   .do()
-  .then(
-    client
-      .schema
-      .getter()
-      .do()
-      .then(res => {
-        console.log(res);
-      })
-      .catch(err => {
-        console.error(err)
-      })
-  )
+  .then(res => {
+    console.log(res);
+  })
   .catch(err => {
     console.error(err)
   });

--- a/developers/weaviate/tutorials/import.md
+++ b/developers/weaviate/tutorials/import.md
@@ -35,11 +35,11 @@ We will use the below dataset. We suggest that you download it to your working d
 
 As mentioned in the [schema tutorial](./schema.md), the `schema` specifies the data structure for Weaviate. 
 
-So conversely, the data must be imported by matching properties of the relevant class, which in this case is the **Question** class defined in the previous section.
+So the data import must map properties of each record to those of the relevant class in the schema. In this case, the relevant class is **Question** as defined in the previous section.
 
 ### Data object structure
 
-The syntax of a data object is as follows:
+Each Weaviate data object is structured as below:
 
 ```json
 {
@@ -51,7 +51,9 @@ The syntax of a data object is as follows:
 }
 ```
 
-Most commonly, Weaviate users import data through a Weaviate client library. But it's worth noting that data is ultimately added through the RESTful API, either through the [`objects` endpoint](../api/rest/objects.md) or the [`batch` endpoint](../api/rest/batch.md). 
+Most commonly, Weaviate users import data through a Weaviate client library. 
+
+It is worth noting, however, that data is ultimately added through the RESTful API, either through the [`objects` endpoint](../api/rest/objects.md) or the [`batch` endpoint](../api/rest/batch.md). 
 
 As the names suggest, the use of these endpoints depend on whether objects are being imported as batches or individually.
 
@@ -59,11 +61,11 @@ As the names suggest, the use of these endpoints depend on whether objects are b
 
 For importing data, we **strongly suggest that you use batch imports** unless you have a specific reason not to. Batch imports can greatly improve performance by sending multiple objects in a single request.
 
-We note that batch imports are carried out through the [`batch` REST endpoint](https://weaviate.io/developers/weaviate/api/rest/batch).
+We note that batch imports are carried out through the [`batch` REST endpoint](../api/rest/batch.md).
 
 ### Batch import process
 
-An import process generally looks like this:
+A batch import process generally looks like this:
 
 1. Connect to your Weaviate instance
 1. Load objects from the data file
@@ -81,11 +83,15 @@ import CodeImportQuestions from '/_includes/code/quickstart.import.questions.mdx
 
 There are a couple of things to note here. 
 
-One is the batch size. Some clients include this as a parameter (e.g. `batch_size` in the Python client), or it can be manually set by periodically flushing the batch. 
+#### Batch size
+
+Some clients include this as a parameter (e.g. `batch_size` in the Python client), or it can be manually set by periodically flushing the batch. 
 
 Typically, a size between 20 and 100 is a reasonable starting point, although this depends on the size of each data object. A smaller size may be preferable for larger data objects, such as if vectors are included in each object upload.
 
-Another is that we do not provide a vector. As a `vectorizer` is specified in our schema, Weaviate will send a request to the appropriate module (`text2vec-openai` in this case) to vectorize the data, and the vector in the response will be indexed and saved into Weaviate tied to the data object.
+#### Where are the vectors?
+
+You may have noticed that we do not provide a vector. As a `vectorizer` is specified in our schema, Weaviate will send a request to the appropriate module (`text2vec-openai` in this case) to vectorize the data, and the vector in the response will be indexed and saved as a part of the data object.
 
 ### Bring your own vector
 
@@ -124,7 +130,7 @@ The result should look something like this:
 When importing large datasets, it may be worth planning out an optimized import strategy. Here are a few things to keep in mind.
 
 1. The most likely bottleneck is the import script. Accordingly, aim to max out all the CPUs available. 
-    1. Use `htop` when importing to see if all CPUs are maxed out.
+  1. Use `htop` when importing to see if all CPUs are maxed out.
 1. Use [parallelization](https://www.computerhope.com/jargon/p/parallelization.htm#:~:text=Parallelization%20is%20the%20act%20of,the%20next%2C%20then%20the%20next.); if the CPUs are not maxed out, just add another import process.
 1. For Kubernetes, fewer large machines are faster than more small machines. Just because of network latency.
 
@@ -132,19 +138,17 @@ Our rules of thumb are:
 * You should always use batch import.
 * As mentioned above, max out your CPUs (on the Weaviate cluster). Often your import script is the bottleneck.
 * Process error messages.
-* Some clients (especially Python) have some built-in logic to efficiently control batch importing.
+* Some clients (e.g. Python) have some built-in logic to efficiently control batch importing.
 
 ### Error handling
 
-:::info `200` status code != 100% batch success
-A `200` status code for the batch request does not mean that all batch items have been added/created!
+We recommend that you implement error handling at an object level such as the [example laid out here](../api/rest/batch.md#error-handling).
+
+:::tip `200` status code != 100% batch success
+It is important to note that an HTTP `200` status code only indicates that the **request** has been successfully sent to Weaviate. In other words, there were no issues with the connection or processing of the batch and no malformed request. 
+
+A request with a `200` response may still include object level errors, which is why error handling is critical.
 :::
-
-An HTTP `200` status code does not mean that all individual data object imports have been successful. 
-
-Here, the `200` status code simply refers to the success of the **request** itself. In other words, the request was successfully sent to Weaviate, and there were no issues with the connection or processing of the batch and no malformed request.
-
-Accordingly, we recommend that you implement error handling at an object level such as the [example laid out here](../api/rest/batch.md#error-handling)
 
 ## Recap
 
@@ -154,10 +158,10 @@ Accordingly, we recommend that you implement error handling at an object level s
 
 ## Suggested reading
 
-- [Schemas in detail](./schema.md)
-- [Queries in detail](./query.md)
-- [Introduction to modules](./modules.md)
-- [Introduction to Weaviate Console](./console.md)
+- [Tutorial: Schemas in detail](./schema.md)
+- [Tutorial: Queries in detail](./query.md)
+- [Tutorial: Introduction to modules](./modules.md)
+- [Tutorial: Introduction to Weaviate Console](./console.md)
 
 ### Other object operations
 

--- a/developers/weaviate/tutorials/query.md
+++ b/developers/weaviate/tutorials/query.md
@@ -59,13 +59,13 @@ import CodeAutoschemaNeartext from '/_includes/code/quickstart.autoschema.nearte
 
 This might also look familiar, as it was used in the [Quickstart tutorial](../quickstart/end-to-end.md). But let's break it down a little.
 
-Here, we are using a `nearText` parameter. What we are doing is to provide Weaviate with a query `concept` of `famous scientist`. Weaviate then converts this into a vector through the inference API (OpenAI in this particular example) and uses that vector as the basis for a vector search.
+Here, we are using a `nearText` parameter. What we are doing is to provide Weaviate with a query `concept` of `biology`. Weaviate then converts this into a vector through the inference API (OpenAI in this particular example) and uses that vector as the basis for a vector search.
 
 Also note here that we pass the API key in the header. This is required as the inference API is used to vectorize the input query.
 
 Additionally, we use the `limit` argument to only fetch a maximum of two (2) objects. 
 
-If you run this query, you should see the entries on *"Albert Einstein"* and *"hot air balloons"* returned by Weaviate.
+If you run this query, you should see the entries on *"DNA"* and *"species"* returned by Weaviate.
 
 ### `Get` with `nearVector`
 
@@ -196,7 +196,7 @@ import CodeQueryWhere2 from '/_includes/code/quickstart.query.where.2.mdx'
 
 <CodeQueryWhere2 />
 
-This query asks Weaviate for **Question** objects that are closest to "famous scientist", but within the category of `HISTORY`. You should see a result like this:
+This query asks Weaviate for **Question** objects that are closest to "biology", but within the category of `ANIMALS`. You should see a result like this:
 
 ```json
 {

--- a/developers/weaviate/tutorials/query.md
+++ b/developers/weaviate/tutorials/query.md
@@ -18,22 +18,21 @@ By the end of this section, you will have performed vector and scalar searches s
 
 We recommend you complete the [Quickstart tutorial](../quickstart/index.md) first. 
 
-Before you start this tutorial, you should follow the steps in the tutorials to have:
+Before you start this tutorial, you should follow the steps in the Quickstart to have:
 
-At this point, you should have: 
 - An instance of Weaviate running (e.g. on the [Weaviate Cloud Services](https://console.weaviate.io)),
 - An API key for your preferred inference API, such as OpenAI, Cohere, or Hugging Face,
 - Installed your preferred Weaviate client library,
 - Set up a `Question` class in your schema, and
 - Imported the `jeopardy_tiny.json` data.
 
-:::note GraphQL
+## Object retrieval with `Get`
+
+:::tip GraphQL
 Weaviate's queries are built using GraphQL. If this is new to you, don't worry. We will take it step-by-step and build up from the basics. Also, in many cases, the GraphQL syntax is abstracted by the client.
-:::
 
 You can query Weaviate using one or a combination of a semantic (i.e. vector) search and a lexical (i.e. scalar) search. As you've seen, a vector search allows for similarity-based searches, while scalar searches allow filtering by exact matches. 
-
-## Object retrieval with `Get`
+:::
 
 First, we will start by making queries to Weaviate to retrieve **Question** objects that we imported earlier.
 
@@ -92,6 +91,8 @@ result = (
     .with_limit(2)
     .do()
 )
+
+print(json.dumps(result, indent=4))
 ```
 
 And it should return the same results as above. 
@@ -275,10 +276,10 @@ As you can see, the `Aggregate` function can return handy aggregated, or metadat
 
 ## Suggested reading
 
-- [Schemas in detail](./schema.md)
-- [Import in detail](./import.md)
-- [Introduction to modules](./modules.md)
-- [Introduction to Weaviate Console](./console.md)
+- [Tutorial: Schemas in detail](./schema.md)
+- [Tutorial: Import in detail](./import.md)
+- [Tutorial: Introduction to modules](./modules.md)
+- [Tutorial: Introduction to Weaviate Console](./console.md)
 
 ## Notes
 

--- a/developers/weaviate/tutorials/schema.md
+++ b/developers/weaviate/tutorials/schema.md
@@ -66,10 +66,13 @@ A collection of data in Weaviate is called a "class". We will be adding a class 
 
 ### About classes
 
-Weaviate classes:
-- Are always written with a capital letter first. This is to distinguish them from generic names for cross-referencing.
-- Have `property` values, and each `property` specifies the data types to store.
-- Can each have different vectorizers (e.g. one class can have a `text2vec-openai` vectorizer, and another might have `multi2vec-clip` vectorizer, or `none` if providing your own vectors).
+Here are some key considerations about classes:
+
+Each Weaviate class:
+- Is always written with a capital letter first. This is to distinguish them from generic names for cross-referencing.
+- Constitutes a distinct vector space. A search in Weaviate is always restricted to a class. 
+- Can have its own vectorizer. (e.g. one class can have a `text2vec-openai` vectorizer, and another might have `multi2vec-clip` vectorizer, or `none` if providing your own vectors).
+- Has `property` values, where each `property` specifies the data type to store.
 
 ### Create a basic class
 
@@ -79,7 +82,7 @@ Our **Question** class will:
 - Contain three properties:
     - name `answer`: type `text`
     - name `question`: type `text`
-    - name `category`: type `string`    
+    - name `category`: type `text`    
 - Use a `text2vec-openai` vectorizer
 
 Run the below code with your client to define the schema for the **Question** class and display the created schema information.
@@ -89,12 +92,13 @@ import CodeCreateSchema from '/_includes/code/quickstart.schema.create.mdx';
 <CodeCreateSchema />
 
 :::note Classes and Properties - best practice
-Notice that these words are *singular* (which is best practice, each data object is *one* of these classes).
-
-Classes always start with a capital letter. Properties always begin with a small letter. When you want to concatenate words into one class name or one property name, you can do that with camelCasing the words. Read more about schema classes, properties and data types [here](../configuration/schema-configuration.md#data-objects-and-structure).
+Classes always start with a capital letter. Properties always begin with a small letter. You can use `CamelCase` class names, and property names allow underscores. Read more about schema classes, properties and data types [here](../configuration/schema-configuration.md#data-objects-and-structure).
 :::
 
 The result should look something like this:
+
+<details>
+  <summary>See the returned schema</summary>
 
 ```json
 {
@@ -153,7 +157,7 @@ The result should look something like this:
                 },
                 {
                     "dataType": [
-                        "string"
+                        "text"
                     ],
                     "description": "The category",
                     "moduleConfig": {
@@ -199,6 +203,8 @@ The result should look something like this:
 }
 ```
 
+</details>
+
 We get back a lot of information here. 
 
 Some of it is what we specified, such as the class name (`class`), and `properties` including their `dataType` and `name`. But the others are inferred by Weaviate based on the defaults and the data provided. 
@@ -207,7 +213,7 @@ Some of it is what we specified, such as the class name (`class`), and `properti
 
 And depending on your needs, you might want to change any number of these. For example, you might change:
 
-- `dataType` to modify the type of data being saved. Above, classes with dataType `text` will be indexed after tokenization, whereas `string` classes will not be [read more](../configuration/datatypes.md#datatype-string-vs-text).
+- `dataType` to modify the type of data being saved. Above, classes with dataType `text` will be indexed after tokenization, whereas `string` classes will not be ([read more](../configuration/datatypes.md#datatype-string-vs-text)).
 - `moduleConfig` to modify how each module behaves. In this case, you could change the model and/or version for the OpenAI inference API, and the vectorization behavior such as whether the class name is used for vectorization.
 - `properties` / `moduleConfig` to further modify module behavior at a class data property level. You might choose to skip a particular property being included for vectorization.
 - `invertedIndexConfig` to add or remove particular stopwords, or change BM25 indexing constants.
@@ -221,12 +227,12 @@ So for example, you might specify a schema like the one below:
     "description": "Information from a Jeopardy! question",
     "moduleConfig": {
         "text2vec-openai": {
-            "vectorizeClassName": false
+            "vectorizeClassName": false  // Default: true
         }
     },
     "invertedIndexConfig": {
         "bm25": {
-            "k1": 1.5,
+            "k1": 1.5,  // Default: 1.2
             "b": 0.75
         }
     },    
@@ -236,26 +242,17 @@ So for example, you might specify a schema like the one below:
             "description": "The question",
             "moduleConfig": {
                 "text2vec-openai": {
-                    "vectorizePropertyName": true
+                    "vectorizePropertyName": true  // Default: false
                 }
             },             
             "name": "question",
         },
-        {
-            "dataType": ["text"],
-            "description": "The answer",
-            "name": "answer",
-        },
-        {
-            "dataType": ["string"],
-            "description": "The category",
-            "name": "category",
-        },           
+        ...
     ]
 }
 ```
 
-And with this you will have changed the specified properties from their defaults. 
+With this you will have changed the specified properties from their defaults. Note that in the rest of the tutorials, we assume that you have not done this.
 
 You can read more about various schema, data types, modules, and index configuration options in the pages below. 
 
@@ -275,11 +272,11 @@ You can read more about various schema, data types, modules, and index configura
 
 ## Suggested reading
 
-- [`schema` endpoint RESTful API reference](../api/rest/schema.md)
-- [Import in detail](./import.md)
-- [Queries in detail](./query.md)
-- [Introduction to modules](./modules.md)
-- [Introduction to Weaviate Console](./console.md)
+- [Reference: `schema` endpoint RESTful API](../api/rest/schema.md)
+- [Tutorial: Import in detail](./import.md)
+- [Tutorial: Queries in detail](./query.md)
+- [Tutorial: Introduction to modules](./modules.md)
+- [Tutorial: Introduction to Weaviate Console](./console.md)
 
 ## More Resources
 


### PR DESCRIPTION
### Why:

Feedback from the community.
- Leftovers from the refactor – we are still mentioning the science examples, while we query biology
- where clause is broken – as the auto schema sets the content at Text not String

### What's being changed:

Docs

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

Travis and local build
