### PR TITLE
fix: link to JavaScript test after TS migration

### DIFF
--- a/blog/2022-09-07-weaviate-1-15-release/index.mdx
+++ b/blog/2022-09-07-weaviate-1-15-release/index.mdx
@@ -342,7 +342,7 @@ For a deeper dive into the Hamming and Manhattan distances, check out this [amaz
 ## New Weaviate modules
 
 <!-- TODO: add an image for Weaviate modules -->
-![New Weavaite modules](./img/weaviate-modules.png)
+![New Weaviate modules](./img/weaviate-modules.png)
 
 The list of the new goodies included with Weaviate `v1.15` goes on. Courtesy of a fantastic community contribution from [Dasith Edirisinghe](https://github.com/DasithEdirisinghe), we have two new Weaviate modules for you: Summarization and Hugging Face modules.
 

--- a/developers/contributor-guide/weaviate-clients/index.md
+++ b/developers/contributor-guide/weaviate-clients/index.md
@@ -29,10 +29,10 @@ These clients, and all future clients are and will be developed according to the
 As a rule of thumb it is more important that a client feels native to
 developers used to a specific language than it is to have all clients exaclty
 identical. When developers make their first contact with a Weaviate client,
-they should think "This feels like proper Java [Go/Pytho/Javascript...]", as
+they should think "This feels like proper Java [Go/Python/JavaScript...]", as
 opposed to "I guess it was designed like this to be consistent with other
-language clients". Therefore you should design a client in a way that it feels
-native to those with experience in the langauge.
+language clients". Therefore you should design clients in a way that feels
+native to those with experience in that language.
 
 This can also mean that specific patterns deviate from one client to another.
 For example, python has keyword arguments next to positional arguments. This
@@ -58,12 +58,12 @@ Tests](../weaviate-core/tests.md#unit-tests) as they make sense, e.g. for
 edge cases or language-speficic sources of error. As a rule of thumb, a
 dynamically typed language will probably require more unit-level testing than a
 statically typed one. Note, however, that we can only use Journey tests
-involving an actual Weavaite instance to verify if a client is 100% compatible
+involving an actual Weaviate instance to verify if a client is 100% compatible
 with Weaviate in general and a specific Weaviate version.
 
 For inspiration of how to write great tests for your client, take a look at the
-tests of the Javascript client
-([Example](https://github.com/weaviate/weaviate-javascript-client/blob/master/data/journey.test.js))
+tests of the JavaScript client
+([Example](https://github.com/weaviate/weaviate-javascript-client/blob/main/data/journey.test.ts))
 or Go client
 ([Example](https://github.com/weaviate/weaviate-go-client/tree/master/test)).
 

--- a/developers/weaviate/client-libraries/index.md
+++ b/developers/weaviate/client-libraries/index.md
@@ -11,10 +11,10 @@ import Badges from '/_includes/badges.mdx';
 ## Overview
 You can interact with Weaviate by using the GraphQL or RESTful API directly, or with one of the available client libraries.
 
-Currently Weaviate supports:
+Currently, Weaviate supports:
 
 - [Python](/developers/weaviate/client-libraries/python.md)
-- [Javascript](/developers/weaviate/client-libraries/javascript.md)
+- [JavaScript](/developers/weaviate/client-libraries/javascript.md)
 - [Go](/developers/weaviate/client-libraries/go.md)
 - [Java](/developers/weaviate/client-libraries/java.md)
 

--- a/developers/weaviate/configuration/authentication.md
+++ b/developers/weaviate/configuration/authentication.md
@@ -279,7 +279,7 @@ For example, you can use a CURL command as shown below:
 $ curl http://localhost:8080/v1/objects -H "Authorization: Bearer {Bearer}"
 ```
 
-If using a Weaviate client library, click on the relevant link for [Python](../client-libraries/python.md#authentication), [Javascript](../client-libraries/javascript.md#authentication), [Java](../client-libraries/java.md#authentication) or [Go](../client-libraries/go.md#authentication) to find instructions on how to attach a token with that client.
+If using a Weaviate client library, click on the relevant link for [Python](../client-libraries/python.md#authentication), [JavaScript](../client-libraries/javascript.md#authentication), [Java](../client-libraries/java.md#authentication) or [Go](../client-libraries/go.md#authentication) to find instructions on how to attach a token with that client.
 
 ## Anonymous access
 By default, Weaviate is configured to accept requests without any


### PR DESCRIPTION
Broken link to JS test file caused build to fail.

Plus drive-by related fixes:
+ proper "JavaScript" capitalization
+ fix misspelled Weaviate