### PR TITLE
Document BACKUP_GCS_USE_AUTH

### DIFF
--- a/developers/weaviate/configuration/backups.md
+++ b/developers/weaviate/configuration/backups.md
@@ -102,6 +102,7 @@ In addition to enabling the module, you need to configure it using environment v
 | Environment variable | Required | Description |
 | --- | --- | --- |
 | `BACKUP_GCS_BUCKET` | yes | The name of the GCS bucket for all backups. |
+| `BACKUP_GCS_USE_AUTH` | no | Whether or not credentials will be used for authentication. Defaults to `true`. A case for `false` would be for use with a local GCS emulator. |
 | `BACKUP_GCS_PATH` | no | The root path inside your bucket that all your backups will be copied into and retrieved from. <br/><br/>Optional, defaults to `""` which means that the backups will be stored in the bucket root instead of a sub-folder. |
 
 #### Google Application Default Credentials


### PR DESCRIPTION


### Why:

It is not currently documented.

### What's being changed:

Add `BACKUP_GCS_USE_AUTH` to the table of available GCS backup environment variables.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature or enhancements (non-breaking change which adds functionality)
- [x] Documentation updates (non-breaking change which updates documents)
