### PR TITLE
fix(hybrid): example syntax errors, esp. curl

### DIFF
--- a/_includes/code/graphql.filters.hybrid.vector.mdx
+++ b/_includes/code/graphql.filters.hybrid.vector.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
     Article (
       hybrid: {
         query: "Fisherman that catches salmon"
-        alpha: 0.5 
+        alpha: 0.5
         vector: [1, 2, 3] # optional. Not needed if Weaviate handles the vectorization. If you provide your own embeddings, put the vector query here.
       })
      {
@@ -44,10 +44,9 @@ client.graphql
   .withFields('title summary  _additional{score}')
   .withHybrid({
       query: 'Fisherman that catches salmon',
-      vector: [1, 2, 3]  // optional. Not needed if weaviate handles the vectorization.
+      vector: [1, 2, 3],  // optional. Not needed if Weaviate handles the vectorization.
       alpha: 0.5, // optional, defaults to 0.75
-     }
-  })
+     })
   .do()
   .then(console.log)
   .catch(console.error);
@@ -88,14 +87,15 @@ Result<GraphQLResponse> result = client.graphQL().get().withClassName("Article")
 <TabItem value="curl" label="Curl">
 
 ```bash
-$ echo '{ 
+# The `vector` below is optional. Not needed if Weaviate handles the vectorization. If you provide your own embeddings, put the vector query there.
+echo '{
   "query": "{
       Get {
         Article(
           hybrid: {
-            query: "Fisherman that catches salmon"
+            query: \"Fisherman that catches salmon\"
             alpha: 0.5
-            vector: [1, 2, 3] # Optional. Not needed if Weaviate handles the vectorization. If you provide your own embeddings, put the vector query here.  
+            vector: [1, 2, 3]
           })
         {
           title


### PR DESCRIPTION
Fix errors in hybrid examples: JS, and in particular curl:
* unescaped double quotes
* [comments in the query JSON are not valid](https://github.com/weaviate/weaviate/issues/2745) due to `curl -d @-` stripping newlines