### PR TITLE
[docs:fix] temporary fix for link.semi.technology links

### DIFF
--- a/_build_scripts/verify-links-build-dev.sh
+++ b/_build_scripts/verify-links-build-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net"
+URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net|link.semi.technology"
 GITHUB_IGNORES="github.com"
 DEV_BUILD_LINKS_TO_IGNORE="assets/files|https://weaviate.io"
 

--- a/_build_scripts/verify-links.sh
+++ b/_build_scripts/verify-links.sh
@@ -2,7 +2,7 @@
 set -e
 set -o errexit # stop script immediately on error
 
-URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net"
+URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net|link.semi.technology"
 DOCUSAURUS_IGNORES="github.com/.*github.com/|github.com/weaviate/weaviate-io"
 # Note #1 github.com/.*github.com/ - is to ignore meta links that include blog co-authors
 # Note #2 github.com/weaviate/weaviate-io/tree/ - is for edit on github links


### PR DESCRIPTION
### Why:

Existing `link.semi.technology` are broken which is causing site deployments to fail. 

### What's being changed:

Ignoring these links for now as a bandaid solution.

### Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)