### PR TITLE
[docs:fix] replaced link.semi.technology links

### DIFF
--- a/blog/2022-09-13-why-is-vector-search-so-fast/index.mdx
+++ b/blog/2022-09-13-why-is-vector-search-so-fast/index.mdx
@@ -15,8 +15,12 @@ description: "Vector Search engines can run semantic queries on multi-million da
 
 Whenever I talk about vector search, I like to demonstrate it with an example of a semantic search. To add the wow factor, I like to run my queries on a Wikipedia dataset, which is populated with over 28 million paragraphs sourced from Wikipedia.
 
-For example, I can ask: "What is the tallest building in Berlin?", and the Vector Search engine (in the case of my demo – [Weaviate](/developers/weaviate/)) responds with "Fernsehturm Berlin".<br/>
-You can try it for yourself by following this [link](https://link.semi.technology/3QYy9xX), which is already pre-populated with the above question. Press the play button, to see the magic happen.
+<!-- For example, I can ask: "What is the tallest building in Berlin?", and the Vector Search engine (in the case of my demo – [Weaviate](/developers/weaviate/)) responds with "Fernsehturm Berlin".<br/>
+You can try it for yourself by following this [link](https://link.semi.technology/3QYy9xX), which is already pre-populated with the above question. Press the play button, to see the magic happen. -->
+<!-- The above is commented out as old link outdated. Restore if possible. -->
+
+For example, I can query Weaviate for articles related to: "urban planning in Europe", and the Vector Search engine (in the case of my demo – [Weaviate](/developers/weaviate/)) responds with a series of articles about the topic, such as "The cities designed to be capitals".<br/>
+You can try it for yourself by following this [link](https://link.weaviate.io/3LiVxqp), which is already pre-populated with the above question. Press the play button, to see the magic happen.
 
 Here is the thing, finding the correct answer in a gigantic repository of unstructured data is not the most impressive part of this demonstration (I mean, it is very impressive), but it is the 🚀 speed at which it all happens. It takes a fraction of a second for the UI to show the results.
 

--- a/blog/2023-01-03-hybrid-search-explained/index.mdx
+++ b/blog/2023-01-03-hybrid-search-explained/index.mdx
@@ -77,7 +77,7 @@ There are five parameters needed to run the hybrid search query (some are option
 * `vector` (optional): optional to supply your own vector 
 * `score`(optional): additional information on how much the sparse and dense method contributed to the result
 
-With just a few lines of code, you can start using hybrid search. You can run a test query in the [Weaviate console](https://link.semi.technology/3IhrVbB) using GraphQL. The query is, “Fisherman that catches salmon” (similar to the example above). When we set the alpha to 0.5 it is equally weighing the dense and sparse vector results. 
+With just a few lines of code, you can start using hybrid search. You can run a test query in the [Weaviate console](https://link.weaviate.io/3JyBYZR) using GraphQL. The query is, “Fisherman that catches salmon” (similar to the example above). When we set the alpha to 0.5 it is equally weighing the dense and sparse vector results. 
 
 ```
 {

--- a/developers/weaviate/api/graphql/vector-search-parameters.md
+++ b/developers/weaviate/api/graphql/vector-search-parameters.md
@@ -345,7 +345,7 @@ import GraphQLFiltersNearText from '/_includes/code/graphql.filters.nearText.mdx
 
 ### Example II
 
-You can also bias results toward other data objects' vector representations. For example, in this dataset, we have an ambiguous query on our news article dataset, which we bias towards an article called: ["Tohoku: A Japan destination for all seasons."](https://link.semi.technology/3Czhg9p)
+You can also bias results toward other data objects' vector representations. For example, in this dataset, we have an ambiguous query on our news article dataset, which we bias towards an article called: ["Tohoku: A Japan destination for all seasons."](https://link.weaviate.io/3l8T738)
 
 import GraphQLFiltersNearText2Obj from '/_includes/code/graphql.filters.nearText.2obj.mdx';
 

--- a/developers/weaviate/tutorials/console.md
+++ b/developers/weaviate/tutorials/console.md
@@ -41,11 +41,11 @@ When you're connected, you can use the [GraphiQL](#graphiql) interface to intera
 
 ## GraphiQL
 
-GraphiQL is a graphical interface that allows you to manually write GraphQL queries. Within Weaviate we use it a lot, the auto-fill functionality allows you to easily navigate through your own dataset. Curious? Try out the console [right now](https://link.semi.technology/3J8aB73) with the Wikipedia dataset.
+GraphiQL is a graphical interface that allows you to manually write GraphQL queries. Within Weaviate we use it a lot, the auto-fill functionality allows you to easily navigate through your own dataset. Curious? Try out the console [right now](https://link.weaviate.io/3ThS9hG) with the news publication dataset.
 
 ## Try out the console
 
-1. Go to: [https://link.semi.technology/3CUuDgQ](https://link.semi.technology/3CUuDgQ)
+1. Go to: [this link](https://link.weaviate.io/3ThS9hG)
 2. Start querying :)
 
 ## Try out the console with your own instance

--- a/developers/weaviate/tutorials/modules.md
+++ b/developers/weaviate/tutorials/modules.md
@@ -85,7 +85,7 @@ If you [look at the schema](https://demo.dataset.playground.semi.technology/v1/s
 
 Let's take a look at the schema item for the Article class. Look for the `"moduleConfig"` entries on the class and on the property level.
 
-You will see that the class and property names are not indexed, but the article _itself_ is. So if you now retrieve a single article (like you can do [here](https://link.semi.technology/3AGybFr)), you know that the vector comes from the transformers module.
+You will see that the class and property names are not indexed, but the article _itself_ is. So if you now retrieve a single article (like you can do [here](https://link.weaviate.io/3FeIwKU)), you know that the vector comes from the transformers module.
 
 ```json
 {


### PR DESCRIPTION
### Why:

This PR replaces broken links from `link.semi.technology` with new ones.

### Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
