### PR TITLE
[docs:feat] clarify when embeddings recalculated on object update

### DIFF
--- a/developers/weaviate/api/rest/objects.md
+++ b/developers/weaviate/api/rest/objects.md
@@ -351,6 +351,10 @@ PATCH /v1/objects/{id}
 
 <RestObjectsCRUDClassnameNote/>
 
+:::info Vector inference at object update
+Where Weaviate is configured with a vectorizer, it will only obtain a new vector if an object update changes the underlying text to be vectorized.
+:::
+
 #### Parameters
 
 The URL has two required path parameters and supports an optional query parameter for the [consistency level](../../concepts/replication-architecture/consistency.md#tunable-write-consistency):

--- a/developers/weaviate/modules/retriever-vectorizer-modules/index.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/index.md
@@ -28,3 +28,7 @@ Unless specified otherwise, the default behavior is to:
 - Prepend the class name to the value
 - Join properties with spaces, and
 - Convert the produced string to lowercase
+
+:::info Vector inference at object update
+Where Weaviate is configured with a vectorizer, it will only obtain a new vector if an object update changes the underlying text to be vectorized.
+:::


### PR DESCRIPTION
### What's being changed:

Clarify that embeddings are only recalculated on object updates if the relevant text changes.

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)