### PR TITLE
Fix import tutorials: syntax, links, grammar; add `vector` field to objects.md

### DIFF
--- a/_includes/code/semantic-kind.create.vector.mdx
+++ b/_includes/code/semantic-kind.create.vector.mdx
@@ -14,8 +14,8 @@ data_obj = {
 }
 
 data_uuid = client.data_object.create(
-  data_obj, 
-  "YourClass", 
+  data_obj,
+  "YourClass",
   uuid="36ddd591-2dee-4e7e-a3cc-eb86d30a0923", # optional, if not provided, one is going to be generated
   vector = [0.3, 0.2, 0.1, .... 0.9], # supported types are `list`, `numpy.ndarray`, `torch.Tensor` and `tf.Tensor`. Make sure the length matches with your Weaviate settings.
 )
@@ -145,9 +145,9 @@ $ curl \
     -H "Content-Type: application/json" \
     -d '{
       "class": "YourClass",
-      "vector": [0.3, 0.2, 0.1, .... 0.9],
+      "vector": [0.3, -0.012, 0.071, ..., -0.09],
       "properties": {
-          "foo": "bar",
+          "foo": "bar"
       }
   }' \
     http://localhost:8080/v1/objects

--- a/blog/2022-12-27-details-behind-the-sphere-dataset-in-weaviate/index.mdx
+++ b/blog/2022-12-27-details-behind-the-sphere-dataset-in-weaviate/index.mdx
@@ -18,12 +18,12 @@ In this post, we will pull back the curtains and go behind the scenes to show yo
 If you are:
 
 * Interested in ingesting a large dataset or corpus into Weaviate
-* Wondering how to use Apache Spark (or pyspark) with Weaviate, or 
-* Wondering what it took for us to get a dataset that big into Weaviate, 
+* Wondering how to use Apache Spark (or pyspark) with Weaviate, or
+* Wondering what it took for us to get a dataset that big into Weaviate,
 
 This article will answer at least some of those questions.
 
-We note that our goal was to import 1B objects into Weaviate to see how the system behaves. Currently for large datasets RAM is the most likely bottleneck, so we used node sizes that were larger than needed, to be on the safe side. 
+We note that our goal was to import 1B objects into Weaviate to see how the system behaves. Currently, for large datasets RAM is the most likely bottleneck, so we used node sizes that were larger than needed, to be on the safe side.
 
 Now let’s get to the details of the setup!
 
@@ -45,10 +45,10 @@ We deployed 6 instances of Weaviate (one on each GKE node with automatic shardin
 
 To import the dataset into Weaviate, we used the [Spark Connector](https://github.com/weaviate/weaviate-spark-connector) instead of one of our client libraries. The massive size of this dataset led to the use of the Spark dataframe, and the Spark connector can efficiently populate Weaviate from a Spark dataframe. Another time-saving feature is that the connector is able to automatically infer the correct datatype for your Weaviate class schema based on the Spark DataType. (We have a podcast speaking with the creator of the Spark connector coming up soon on our [YouTube channel](https://www.youtube.com/@Weaviate) so keep your eyes and ears peeled for that!)
 
-We used a single 64 GiB Google Cloud Platform(GCP) n2 instance to run Spark. The steps below can be followed to import data from the Sphere dataset. You can refer to this [tutorial](/developers/weaviate/tutorials/spark-connector) for details on the import code. 
+We used a single 64 GiB Google Cloud Platform(GCP) n2 instance to run Spark. The steps below can be followed to import data from the Sphere dataset. You can refer to this [tutorial](/developers/weaviate/tutorials/spark-connector) for details on the import code.
 
-> If you are following along, make sure to modify the code to import only as much of the Sphere dataset as you dare, as it might potentially become a very expensive exercise! 
-First, using the `pyspark` library, you can instantiate a connection, called a `SparkSession`: 
+> If you are following along, make sure to modify the code to import only as much of the Sphere dataset as you dare, as it might potentially become a very expensive exercise!
+First, using the `pyspark` library, you can instantiate a connection, called a `SparkSession`:
 
 ```python
 spark = (
@@ -107,15 +107,15 @@ With the setup above our main goal was to look at system performance while impor
 ## Import Performance Metrics
 ![Magnifying Glass](./img/magnifying-glass.png)
 
-In this section let’s take a look at a few stats related to the Sphere import run. This will give you an idea of the Weaviate cluster’s performance over the course of this massive import process. 
+In this section let’s take a look at a few stats related to the Sphere import run. This will give you an idea of the Weaviate cluster’s performance over the course of this massive import process.
 
-Let’s start off with a bird’s eye view of the whole run. As mentioned above, the entire process took approximately 48 hours and on a high level the system performed very well. The graph beneath the text show the number of vectors imported over time: 
+Let’s start off with a bird’s eye view of the whole run. As mentioned above, the entire process took approximately 48 hours and on a high level the system performed very well. The graph beneath the text show the number of vectors imported over time:
 
 ![Number of vectors imported](./img/number-of-vectors-imported.png)
 
 As can be seen the slope, indicating import speed, is almost linear. meaning that we see pretty much no slow down in the import times regardless of the quantity of objects already imported. Note here that the line is not completely straight due to the fact that time complexity of the HNSW index is roughly logarithmic and not linear.
 
-To remind ourselves of the scale of data that we’re dealing with, take a look at the bar chart below. It shows the size of the LSM stores. 
+To remind ourselves of the scale of data that we’re dealing with, take a look at the bar chart below. It shows the size of the LSM stores.
 
 ![LSM stores](./img/LSM-stores.png)
 
@@ -127,10 +127,10 @@ Now we’ll zoom in and look at performance over a window of 15 minutes of batch
 
 As seen in the time window above we get great consistent performance and generally the batch latency is low, keeping under a second for the most part. With last week’s v1.17 release, large dataset imports are made even faster by enabling the memtable to adjust size dynamically and additional fixes also remove the occasional latency spikes.
 
-And that’s all folks! Here we provided all the details of the hardware setup, the usage of the spark connector and system performance during the Sphere dataset import run. Hope you had as much fun reading this as I did putting it together! As I alluded to earlier if this work excites you then you’ll be glad to know that we’ve got a lot more updates along this line of work cooking in the Weaviate kitchen🧑‍🍳.
+And that’s all folks! Here we provided all the details of the hardware setup, the usage of the Spark connector and system performance during the Sphere dataset import run. Hope you had as much fun reading this as I did putting it together! As I alluded to earlier if this work excites you then you’ll be glad to know that we’ve got a lot more updates along this line of work cooking in the Weaviate kitchen🧑‍🍳.
 
 
 ## Stay Connected
-Thank you so much for reading! If you would like to talk to us more about this topic, please connect with us on [Slack](https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw) or [Twitter](https://twitter.com/weaviate_io). 
+Thank you so much for reading! If you would like to talk to us more about this topic, please connect with us on [Slack](https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw) or [Twitter](https://twitter.com/weaviate_io).
 
 Weaviate is open-source, you can follow the project on [GitHub](https://github.com/weaviate/weaviate). Don't forget to give us a ⭐️ while you are there.

--- a/developers/weaviate/api/rest/objects.md
+++ b/developers/weaviate/api/rest/objects.md
@@ -215,6 +215,7 @@ The request body for a new object has the following fields:
 | `properties` | array | yes | An object with the property values of the new data object |
 | `properties` > `{propertyName}` | dataType | yes | The property and its value according to the set dataType |
 | `id` | v4 UUID | no | Optional id for the object |
+| `vector` | `[float]` | no | Optional [custom vector](#create-a-data-object-with-a-custom-vector) |
 
 #### Example request
 

--- a/developers/weaviate/api/rest/objects.md
+++ b/developers/weaviate/api/rest/objects.md
@@ -374,6 +374,7 @@ The request body for replacing (some) properties of an object has the following 
 | `id` | string | ? | Required for `PUT` to be the same id as the one passed in the URL |
 | `properties` | array | yes | An object with the property values of the new data object |
 | `properties` > `{propertyName}` | dataType | yes | The property and its value according to the set dataType |
+| `vector` | `[float]` | no | Optional [custom vector](#create-a-data-object-with-a-custom-vector) |
 
 #### Example request
 

--- a/developers/weaviate/tutorials/import.md
+++ b/developers/weaviate/tutorials/import.md
@@ -11,7 +11,7 @@ import { DownloadButton } from '/src/theme/Buttons';
 
 ## Overview
 
-In this section, we will explore data import, including details of the batch import process. We will discuss points such as how are vectors imported, what a batch import is, how to manage errors, and some advice on optimization.
+In this section, we will explore data import, including details of the batch import process. We will discuss points such as how vectors are imported, what a batch import is, how to manage errors, and some advice on optimization.
 
 ## Prerequisites 
 
@@ -25,7 +25,7 @@ Before you start this tutorial, you should follow the steps in the tutorials to 
 - Set up a `Question` class in your schema. 
     - You can follow the Quickstart guide, or the [schema tutorial](./schema.md) to construct the Question class if you have not already.
 
-We will use the below dataset. We suggest that you download it to your working directory.
+We will use the dataset below. We suggest that you download it to your working directory.
 
 <p>
   <DownloadButton link="https://raw.githubusercontent.com/weaviate-tutorials/quickstart/main/data/jeopardy_tiny.json">Download jeopardy_tiny.json</DownloadButton>
@@ -39,7 +39,7 @@ So the data import must map properties of each record to those of the relevant c
 
 ### Data object structure
 
-Each Weaviate data object is structured as below:
+Each Weaviate data object is structured as follows:
 
 ```json
 {
@@ -93,15 +93,15 @@ Typically, a size between 20 and 100 is a reasonable starting point, although th
 
 You may have noticed that we do not provide a vector. As a `vectorizer` is specified in our schema, Weaviate will send a request to the appropriate module (`text2vec-openai` in this case) to vectorize the data, and the vector in the response will be indexed and saved as a part of the data object.
 
-### Bring your own vector
+### Bring your own vectors
 
-If you wish to upload your own vector, you can do so with Weaviate. Refer to the [`batch` data object API documentation](../api/rest/batch.md#batch-create-objects). The object parameters correspond to those of the [individual objects](../api/rest/objects.md#object-fields).
+If you wish to upload your own vectors, you can do so with Weaviate. Refer to the [`batch` data object API documentation](../api/rest/batch.md#batch-create-objects). The object fields correspond to those of the [individual objects](../api/rest/objects.md#parameters-1).
 
-You can even manually upload existing vectors and use a vectorizer module for vectorizing queries.
+You can also manually upload existing vectors and use a vectorizer module for vectorizing queries.
 
 ## Confirm data import
 
-You can quickly check the imported object by opening – `weaviate-endpoint/v1/objects` in a browser, like this (replace with your endpoint):
+You can quickly check the imported object by opening `<weaviate-endpoint>/v1/objects` in a browser, like this (replace with your endpoint):
 
 ```
 https://some-endpoint.semi.network/v1/objects
@@ -132,7 +132,7 @@ When importing large datasets, it may be worth planning out an optimized import 
 1. The most likely bottleneck is the import script. Accordingly, aim to max out all the CPUs available. 
   1. Use `htop` when importing to see if all CPUs are maxed out.
 1. Use [parallelization](https://www.computerhope.com/jargon/p/parallelization.htm#:~:text=Parallelization%20is%20the%20act%20of,the%20next%2C%20then%20the%20next.); if the CPUs are not maxed out, just add another import process.
-1. For Kubernetes, fewer large machines are faster than more small machines. Just because of network latency.
+1. For Kubernetes, fewer large machines are faster than more small machines (due to network latency).
 
 Our rules of thumb are:
 * You should always use batch import.

--- a/developers/weaviate/tutorials/spark-connector.md
+++ b/developers/weaviate/tutorials/spark-connector.md
@@ -23,7 +23,7 @@ We will install the python `weaviate-client` and also run Spark locally for whic
 pip3 install pyspark weaviate-client
 ```
 
-For demonstration purposes this tutorial runs Spark locally. Please see the Apache Spark docs or consult your cloud environment for installation and deploying a Spark cluster and choosing a language runtime other than python.
+For demonstration purposes this tutorial runs Spark locally. Please see the Apache Spark docs or consult your cloud environment for installation and deploying a Spark cluster and choosing a language runtime other than Python.
 
 We will also need the Weaviate Spark connector. You can download this by running the following command in your terminal:
 
@@ -33,17 +33,17 @@ curl https://github.com/weaviate/spark-connector/releases/download/v||site.spark
 
 For this tutorial, you will also need a Weaviate instance running at `http://localhost:8080`. This instance does not need to have any modules and can be setup by following the [Quickstart tutorial](../quickstart/index.md).
 
-You will also need Java 8+ and Scala 2.12 installed. You can get these seperately setup or a more convenient way to get both of these set up is to install [IntelliJ](https://www.jetbrains.com/idea/). 
+You will also need Java 8+ and Scala 2.12 installed. You can get these separately setup or a more convenient way to get both of these set up is to install [IntelliJ](https://www.jetbrains.com/idea/). 
 
-## What is the Spark Connector?
+## What is the Spark connector?
 
 The Spark Connector gives you the ability to easily write data from Spark data structures into Weaviate. This is quite useful when used in conjunction with Spark extract, transform, load (ETLs) processes to populate a Weaviate vector database.
 
-The Spark Connector is able to automatically infer the correct Spark DataType based on your schema for the class in Weaviate. You can choose to vectorize your data when writing to Weaviate or if you already have vector available you can supply them. By default the Weaviate client will create document IDs for you for new documents but if you already have IDs you can also supply those in the dataframe. All of this and more can be specified as options in the Spark Connector. 
+The Spark Connector is able to automatically infer the correct Spark DataType based on your schema for the class in Weaviate. You can choose to vectorize your data when writing to Weaviate, or if you already have vectors available, you can supply them. By default, the Weaviate client will create document IDs for you for new documents but if you already have IDs you can also supply those in the dataframe. All of this and more can be specified as options in the Spark Connector. 
 
-## Initializing a Spark Session
+## Initializing a Spark session
 
-The below code will create a Spark Session using the libraries mentioned above.
+The code below will create a Spark Session using the libraries mentioned above.
 
 ```python
 from pyspark.sql import SparkSession
@@ -70,7 +70,7 @@ You can also verify the local Spark Session is running by executing:
 spark
 ```
 
-## Reading Data into Spark
+## Reading data into Spark
 
 For this tutorial we will read in a subset of the Sphere dataset, containing 100k lines, into the Spark Session that was just started. 
 
@@ -91,10 +91,10 @@ df.limit(3).toPandas().head()
 ## Writing to Weaviate
 
 :::tip
-Prior to this step make sure your weaviate instance is running at `http://localhost:8080`. You can refer to the [Quickstart tutorial](../quickstart/index.md) for instructions on how to set that up.
+Prior to this step, make sure your Weaviate instance is running at `http://localhost:8080`. You can refer to the [Quickstart tutorial](../quickstart/index.md) for instructions on how to set that up.
 :::
 
-To quickly get a weaviate instance running you can run the line of code below to get a docker file:
+To quickly get a Weaviate instance running you can run the line of code below to get a docker file:
 
 ```bash
 curl -o docker-compose.yml "https://configuration.weaviate.io/v2/docker-compose/docker-compose.yml?modules=standalone&runtime=docker-compose&weaviate_version=v||site.weaviate_version||"
@@ -139,7 +139,7 @@ client.schema.create_class(
 )
 ```
 
-Next we will write the Spark dataframe to Weaviate. Note the limit(1500) can be removed to load the full dataset.
+Next we will write the Spark dataframe to Weaviate. The `.limit(1500)` could be removed to load the full dataset.
 
 ```python
 df.limit(1500).withColumnRenamed("id", "uuid").write.format("io.weaviate.spark.Weaviate") \
@@ -152,7 +152,7 @@ df.limit(1500).withColumnRenamed("id", "uuid").write.format("io.weaviate.spark.W
     .mode("append").save()
 ```
 
-## Spark Connector Options
+## Spark connector options
 
 Let's examine the code above to understand exactly what's happening and all the settings for the Spark Connector.
 
@@ -160,21 +160,21 @@ Let's examine the code above to understand exactly what's happening and all the 
 
 - Using `.option("className", "Sphere")` we ensure that the data is written to the class we just created.
 
-- Since we already have document IDs in our dataframe we can supply those for use in Weaviate by renaming the column that is storing them to `uuid` using `.withColumnRenamed("id", "uuid")` followed up with the `.option("id", "uuid")`.
+- Since we already have document IDs in our dataframe, we can supply those for use in Weaviate by renaming the column that is storing them to `uuid` using `.withColumnRenamed("id", "uuid")` followed by the `.option("id", "uuid")`.
 
 - Using `.option("vector", "vector")` we can specify for Weaviate to use the vectors stored in our dataframe under the column named `vector` instead of re-vectorizing the data from scratch.
 
-- Using `.option("batchSize", 200)` we specify how to batch the data when writing to Weaviate. Outside of batching operations, streaming is also allowed.
+- Using `.option("batchSize", 200)` we specify how to batch the data when writing to Weaviate. Aside from batching operations, streaming is also allowed.
 
 - Using `.mode("append")` we specify the write mode as `append`. Currently only the append write mode is supported.
 
-Now that we've written our data to Weaviate and we understand the capabilities of the Spark Connector and its settings. As a last step, we can query the data via the python client to confirm that the data has been loaded.
+By now we've written our data to Weaviate, and we understand the capabilities of the Spark connector and its settings. As a last step, we can query the data via the Python client to confirm that the data has been loaded.
 
 ```python
 client.query.get("Sphere", "title").do()
 ```
 
-## More Resources
+## More resources
 
 import DocsMoreResources from '/_includes/more-resources-docs.md';
 


### PR DESCRIPTION
* document `vector` field for [POST /v1/objects](https://weaviate.io/developers/weaviate/api/rest/objects#create-a-data-object)
* [Import tutorial -> BYOV](https://weaviate.io/developers/weaviate/tutorials/import#bring-your-own-vector): fix link to object parameters->fields (from that of the [GET /v1/objects response](https://weaviate.io/developers/weaviate/api/rest/objects#object-fields), to that of the [POST /v1/objects](https://weaviate.io/developers/weaviate/api/rest/objects#parameters-1))
* rm trailing comma in curl object+vector creation example (syntax error)
  + more "realistic" example vector
* rm trailing spaces in Spark connector tutorial