### PR TITLE
Exclude http://localhost:8080 from link verification

### DIFF
--- a/_build_scripts/verify-links-build-dev.sh
+++ b/_build_scripts/verify-links-build-dev.sh
@@ -3,12 +3,12 @@ set -e
 
 URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net"
 GITHUB_IGNORES="github.com"
-DEV_BUILD_LINKS_TO_IGNORE="assets/files|https://weaviate.io"
+DEV_BUILD_LINKS_TO_IGNORE="assets/files|https://weaviate.io|http://localhost:8080"
 
 echo "**************************************
 Starting Link Verification
 PATH: ./build
-URL_IGNORES: ${URL_IGNORES}|${GITHUB_IGNORES}|${ASSET_FILES}
+URL_IGNORES: ${URL_IGNORES}|${GITHUB_IGNORES}|${DEV_BUILD_LINKS_TO_IGNORE}
 **************************************"
 
 ./node_modules/.bin/linkinator ./build.dev \

--- a/_build_scripts/verify-links-build-dev.sh
+++ b/_build_scripts/verify-links-build-dev.sh
@@ -3,7 +3,7 @@ set -e
 
 URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net"
 GITHUB_IGNORES="github.com"
-DEV_BUILD_LINKS_TO_IGNORE="assets/files|https://weaviate.io|http://localhost:8080"
+DEV_BUILD_LINKS_TO_IGNORE="assets/files|https://weaviate.io|http://localhost"
 
 echo "**************************************
 Starting Link Verification

--- a/_build_scripts/verify-links.sh
+++ b/_build_scripts/verify-links.sh
@@ -25,7 +25,7 @@ URL_IGNORES: ${URL_IGNORES}|${DOCUSAURUS_IGNORES}
 --retry-errors-count 4 \
 --retry-errors-jitter 4
 
-# USE search/replace to test validity of links on Nelify, as they might not yet exist on weaviate.io
+# Use search/replace to test validity of links on Netlify, as they might not yet exist on weaviate.io
 
 echo "**************************************
 Link Verification Complete


### PR DESCRIPTION
Running `yarn verify-links` locally will succeed for http://localhost:8080 links if a local instance of Weaviate is running, but the build will [fail on Netlify](https://app.travis-ci.com/github/weaviate/weaviate-io/builds/261505059). This PR ignores those links.

I couldn't find a definition for `ASSET_FILES` and `DEV_BUILD_LINKS_TO_IGNORE` wasn't echoed, so I replaced the former with the latter.