### PR TITLE
[docs:fix] remove not operator from list

### DIFF
--- a/developers/weaviate/api/graphql/filters.md
+++ b/developers/weaviate/api/graphql/filters.md
@@ -29,7 +29,6 @@ The `where` filter is an [algebraic object](https://en.wikipedia.org/wiki/Algebr
 - `Operator` (which takes one of the following values)
   - `And`
   - `Or`
-  - `Not`
   - `Equal`
   - `NotEqual`
   - `GreaterThan`
@@ -495,7 +494,7 @@ import GraphQLFiltersAfter from '/_includes/code/graphql.filters.after.mdx';
 <GraphQLFiltersAfter/>
 
 :::note
-The `after` cursor is available on both single-shard and multi-shard set-ups.  
+The `after` cursor is available on both single-shard and multi-shard set-ups.
 :::
 
 ## More Resources


### PR DESCRIPTION
### What's being changed:

Remove `not` operator from the list of operators in `filters.md`, as it has been removed.

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)
