### PR TITLE
feat: embedded DB (spawning server from client)

### DIFF
--- a/_includes/code/embedded.instantiate.mdx
+++ b/_includes/code/embedded.instantiate.mdx
@@ -1,0 +1,50 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python">
+
+  ```python
+  import weaviate
+  from weaviate.embedded import EmbeddedOptions
+
+  client = weaviate.Client(
+    embedded_options=EmbeddedOptions(),
+  )
+
+  data_obj = {
+    "name": "Chardonnay",
+    "description": "Goes with fish"
+  }
+
+  client.data_object.create(data_obj, "Wine")
+  ```
+
+  </TabItem>
+  <TabItem value="js" label="JavaScript">
+
+  ```js
+  const client = weaviate.client({
+    scheme: 'http',
+    host: 'localhost:6666',
+    embedded: new weaviate.EmbeddedOptions({
+      port: 6666,
+    }),
+  });
+
+  await client.embedded?.start();
+
+  const result = await client.data
+    .creator()
+    .withClassName('Wine')
+    .withProperties({
+      name: 'Chardonnay',
+      description: 'Goes with fish',
+    })
+    .do();
+
+  await client.embedded?.stop();
+  ```
+
+  </TabItem>
+</Tabs>

--- a/_includes/code/embedded.instantiate.mdx
+++ b/_includes/code/embedded.instantiate.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
   from weaviate.embedded import EmbeddedOptions
 
   client = weaviate.Client(
-    embedded_options=EmbeddedOptions(),
+    embedded_options=EmbeddedOptions()
   )
 
   data_obj = {

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -37,6 +37,10 @@ The Weaviate server spwaned from the client can be configured via parameters pas
 | hostname | string | Hostname/IP to bind to. | 127.0.0.1 | |
 | additional_env_vars | key: value | Useful to pass additional environment variables to the server, such as API keys. | |
 
+:::danger
+It is not recommended to change `XDG_DATA_HOME` and `XDG_CACHE_HOME` environment variables, as that might affect many other (non-Weaviate related) applications and services running on the same server.
+:::
+
 :::tip Providing Weaviate version
 
 To provide the full path for `version`:

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -16,7 +16,7 @@ Here's what happens behind the scenes when the client uses the embedded options 
 1. The client downloads a Weaviate release from GitHub and caches it
 2. It then spawns a Weaviate process with a data directory configured to a specific location, and listening to the specified port (by default 6666)
 3. The server's STDOUT and STDERR are piped to the client
-4. The client connect to this server process (e.g. to http://127.0.0.1:6666) and runs the client code
+4. The client connect to this server process (e.g. to `http://127.0.0.1:6666`) and runs the client code
 5. After running the code, the client shuts down the Weaviate process
 6. The data directory is preserved, so subsequent invocations have access to the data from all previous invocations, across all clients using the embedded option.
 

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -1,24 +1,27 @@
----  
-title: Embedding Weaviate  
+---
+title: Embedding Weaviate (experimental)
 sidebar_position: 4
 # image: TODO
 # tags: ['installation', 'embedded', 'client']
----  
 ## Overview
 
-Starting with `v1.18`, Weaviate is also [distributed](https://github.com/weaviate/weaviate/releases) as a single-executable Linux binary (MacOS to follow). This allows launching the Weaviate database server from the client instantiation call, which makes the "installation" step transparent in the background:
+Embedded Weaviate is a new deployment model, which allows you to start a Weaviate instance, straight in your application code using a Weaviate Client library.
+
+:::warning Experimental phase
+Embedded Weaviate is still in the **Experimental** phase.
+
+Some of the APIs and parameters might change over time, as we work towards a perfect implementation.
+:::
+
+### How is this possible?
+
+With every Weaviate [release](https://github.com/weaviate/weaviate/releases) we also publish a single-executalbe Linux binary ([see assets](https://github.com/weaviate/weaviate/releases)).
+
+This allows launching the Weaviate database server from the client instantiation call, which makes the "installation" step transparent in the background:
 
 import EmbeddedInstantiation from '/_includes/code/embedded.instantiate.mdx';
 
-<EmbeddedInstantiation />  
-
-Here's what happens behind the scenes when the client uses the embedded options in the instantiation call:
-1. The client downloads a Weaviate release from GitHub and caches it
-2. It then spawns a Weaviate process with a data directory configured to a specific location, and listening to the specified port (by default 6666)
-3. The server's STDOUT and STDERR are piped to the client
-4. The client connect to this server process (e.g. to `http://127.0.0.1:6666`) and runs the client code
-5. After running the code, the client shuts down the Weaviate process
-6. The data directory is preserved, so subsequent invocations have access to the data from all previous invocations, across all clients using the embedded option.
+<EmbeddedInstantiation />
 
 ## Embedded options
 
@@ -31,8 +34,33 @@ The Weaviate server spwaned from the client can be configured via parameters pas
 | version | string | Full URL pointing to the Linux AMD64 binary | [Varies](https://github.com/weaviate/weaviate/releases) | |
 | port | integer | Which port the Weaviate server will listen to. Useful when running multiple instances in parallel. | 6666 | |
 | hostname | string | Hostname/IP to bind to. | 127.0.0.1 | |
-| cluster_hostname | string | | "embedded" | CLUSTER_HOSTNAME |
+| cluster_hostname | string | The label for the cluster hostname | "embedded" | CLUSTER_HOSTNAME |
 | additional_env_vars | key = value | Useful to pass additional environment variables to the server, such as API keys. | |
+
+## Starting Embedded Weaviate under the hood
+
+Here's what happens behind the scenes when the client uses the embedded options in the instantiation call:
+1. The client downloads a Weaviate release from GitHub and caches it
+2. It then spawns a Weaviate process with a data directory configured to a specific location, and listening to the specified port (by default 6666)
+3. The server's STDOUT and STDERR are piped to the client
+4. The client connect to this server process (e.g. to `http://127.0.0.1:6666`) and runs the client code
+5. After running the code (when the application reaches the end), the client shuts down the Weaviate process
+6. The data directory is preserved, so subsequent invocations have access to the data from all previous invocations, across all clients using the embedded option.
+
+## Supported Environments
+
+### Operating Systems
+
+Embedded Weaviate is currently supported on Linux only.
+
+We are actively working to provide support for MacOS. We hope to share an update in the near future.
+
+### Language Clients
+
+Embedded Weaviate is supported in the following language clients:
+
+* [Python client](../client-libraries/python.md) – version `3.15.4` or newer
+<!-- * [JavaScript client](../client-libraries/javascript.md) – version `v` or newer -->
 
 ## More Resources
 

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -1,0 +1,41 @@
+---  
+title: Embedding Weaviate  
+sidebar_position: 4
+# image: TODO
+# tags: ['installation', 'embedded', 'client']
+---  
+## Overview
+
+Starting with `v1.18`, Weaviate is also [distributed](https://github.com/weaviate/weaviate/releases) as a single-executable Linux binary (MacOS to follow). This allows launching the Weaviate database server from the client instantiation call, which makes the "installation" step transparent in the background:
+
+import EmbeddedInstantiation from '/_includes/code/embedded.instantiate.mdx';
+
+<EmbeddedInstantiation />  
+
+Here's what happens behind the scenes when the client uses the embedded options in the instantiation call:
+1. The client downloads a Weaviate release from GitHub and caches it
+2. It then spawns a Weaviate process with a data directory configured to a specific location, and listening to the specified port (by default 6666)
+3. The server's STDOUT and STDERR are piped to the client
+4. The client connect to this server process (e.g. to http://127.0.0.1:6666) and runs the client code
+5. After running the code, the client shuts down the Weaviate process
+6. The data directory is preserved, so subsequent invocations have access to the data from all previous invocations, across all clients using the embedded option.
+
+## Embedded options
+
+The Weaviate server spwaned from the client can be configured via parameters passed to the at instantiation time, and via environment variables. All parameters are optional.
+
+| Parameter | Type | Description | Default value | Environment variable |
+| --------- | ---- | ----------- | ------------- | ------------------- |
+| persistence_data_path | string | Directory where the files making up the database are stored | `/.local/share/weaviate` | `XDG_DATA_HOME` |
+| binary_path | string | Where the binary is downloaded. If deleted, the client will download the binary again. | `~/.cache/weaviate-embedded` | `XDG_CACHE_HOME` |
+| version | string | Full URL pointing to the Linux AMD64 binary | [Varies](https://github.com/weaviate/weaviate/releases) | |
+| port | integer | Which port the Weaviate server will listen to. Useful when running multiple instances in parallel. | 6666 | |
+| hostname | string | Hostname/IP to bind to. | 127.0.0.1 | |
+| cluster_hostname | string | | "embedded" | CLUSTER_HOSTNAME |
+| additional_env_vars | key = value | Useful to pass additional environment variables to the server, such as API keys. | |
+
+## More Resources
+
+import DocsMoreResources from '/_includes/more-resources-docs.md';
+
+<DocsMoreResources />

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -30,13 +30,24 @@ The Weaviate server spwaned from the client can be configured via parameters pas
 
 | Parameter | Type | Description | Default value | Environment variable |
 | --------- | ---- | ----------- | ------------- | ------------------- |
-| persistence_data_path | string | Directory where the files making up the database are stored | `/.local/share/weaviate` | `XDG_DATA_HOME` |
-| binary_path | string | Where the binary is downloaded. If deleted, the client will download the binary again. | `~/.cache/weaviate-embedded` | `XDG_CACHE_HOME` |
-| version | string | Full URL pointing to a Linux AMD64 or ARM64 binary | [Varies](https://github.com/weaviate/weaviate/releases) | |
+| persistence_data_path | string | Directory where the files making up the database are stored | `~/.local/share/weaviate` | `XDG_DATA_HOME` |
+| binary_path | string | Where the binary is downloaded to. If deleted, the client will download the binary again. | `~/.cache/weaviate-embedded` | `XDG_CACHE_HOME` |
+| version | string | Full URL pointing to a Linux AMD64 or ARM64 binary | The default value is set to a recent AMD64 Weaviate binary | |
 | port | integer | Which port the Weaviate server will listen to. Useful when running multiple instances in parallel. | 6666 | |
 | hostname | string | Hostname/IP to bind to. | 127.0.0.1 | |
 | cluster_hostname | string | The label for the cluster hostname | "embedded" | CLUSTER_HOSTNAME |
 | additional_env_vars | key: value | Useful to pass additional environment variables to the server, such as API keys. | |
+
+:::tip Providing Weaviate version
+
+To provide the full path for `version`:
+* head to [Weaviate releases](https://github.com/weaviate/weaviate/releases),
+* find the **Assets** section for the required Weaviate version
+* and copy the link to required `(name).tar.gz` file.<br/>
+
+For example, here is a path to Weaviate `1.18.2` `AMD64` binary: `https://github.com/weaviate/weaviate/releases/download/v1.18.2/weaviate-v1.18.2-linux-amd64.tar.gz`
+
+:::
 
 ## Starting Embedded Weaviate under the hood
 
@@ -44,9 +55,21 @@ Here's what happens behind the scenes when the client uses the embedded options 
 1. The client downloads a Weaviate release from GitHub and caches it
 2. It then spawns a Weaviate process with a data directory configured to a specific location, and listening to the specified port (by default 6666)
 3. The server's STDOUT and STDERR are piped to the client
-4. The client connect to this server process (e.g. to `http://127.0.0.1:6666`) and runs the client code
+4. The client connects to this server process (e.g. to `http://127.0.0.1:6666`) and runs the client code
 5. After running the code (when the application reaches the end), the client shuts down the Weaviate process
 6. The data directory is preserved, so subsequent invocations have access to the data from all previous invocations, across all clients using the embedded option.
+
+### Lifecycle
+
+The embedded instance will stay alive for as long as the parent application is running.
+
+When the application reaches the end (i.e. the end of the script), Weaviate will shut down the embedded instance, but the data will persist.
+
+:::note Embedded with Jupyter Notebooks
+An Embedded instance will stay alive for as long as the Jupyter notebook is active.
+
+This is really useful, as it will let you experiment and work with your Weaviate projects and examples.
+:::
 
 ## Supported Environments
 

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -16,7 +16,7 @@ Some of the APIs and parameters might change over time, as we work towards a per
 
 ### How is this possible?
 
-With every Weaviate [release](https://github.com/weaviate/weaviate/releases) we also publish a single-executalbe Linux binary ([see assets](https://github.com/weaviate/weaviate/releases)).
+With every Weaviate [release](https://github.com/weaviate/weaviate/releases) we also publish executable Linux binaries ([see assets](https://github.com/weaviate/weaviate/releases)).
 
 This allows launching the Weaviate database server from the client instantiation call, which makes the "installation" step transparent in the background:
 
@@ -32,11 +32,11 @@ The Weaviate server spwaned from the client can be configured via parameters pas
 | --------- | ---- | ----------- | ------------- | ------------------- |
 | persistence_data_path | string | Directory where the files making up the database are stored | `/.local/share/weaviate` | `XDG_DATA_HOME` |
 | binary_path | string | Where the binary is downloaded. If deleted, the client will download the binary again. | `~/.cache/weaviate-embedded` | `XDG_CACHE_HOME` |
-| version | string | Full URL pointing to the Linux AMD64 binary | [Varies](https://github.com/weaviate/weaviate/releases) | |
+| version | string | Full URL pointing to a Linux AMD64 or ARM64 binary | [Varies](https://github.com/weaviate/weaviate/releases) | |
 | port | integer | Which port the Weaviate server will listen to. Useful when running multiple instances in parallel. | 6666 | |
 | hostname | string | Hostname/IP to bind to. | 127.0.0.1 | |
 | cluster_hostname | string | The label for the cluster hostname | "embedded" | CLUSTER_HOSTNAME |
-| additional_env_vars | key = value | Useful to pass additional environment variables to the server, such as API keys. | |
+| additional_env_vars | key: value | Useful to pass additional environment variables to the server, such as API keys. | |
 
 ## Starting Embedded Weaviate under the hood
 

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -60,8 +60,9 @@ We are actively working to provide support for MacOS. We hope to share an update
 
 Embedded Weaviate is supported in the following language clients:
 
-* [Python client](../client-libraries/python.md) – version `3.15.4` or newer
-<!-- * [JavaScript client](../client-libraries/javascript.md) – version `v` or newer -->
+* [Python client](../client-libraries/python.md) – `v3.15.4` or newer
+* [TypeScript client](https://github.com/weaviate/typescript-client) – `v1` or newer
+    * Note: the TypeScript client is still in Beta.
 
 ## More Resources
 

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -1,5 +1,5 @@
 ---
-title: Embedding Weaviate (experimental)
+title: Embedded Weaviate (experimental)
 sidebar_position: 4
 # image: TODO
 # tags: ['installation', 'embedded', 'client']

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -1,7 +1,7 @@
 ---
 title: Embedded Weaviate (experimental)
 sidebar_position: 4
-# image: TODO
+image: og/docs/installation.jpg
 # tags: ['installation', 'embedded', 'client']
 ---
 ## Overview

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -35,7 +35,6 @@ The Weaviate server spwaned from the client can be configured via parameters pas
 | version | string | Full URL pointing to a Linux AMD64 or ARM64 binary | The default value is set to a recent AMD64 Weaviate binary | |
 | port | integer | Which port the Weaviate server will listen to. Useful when running multiple instances in parallel. | 6666 | |
 | hostname | string | Hostname/IP to bind to. | 127.0.0.1 | |
-| cluster_hostname | string | The label for the cluster hostname | "embedded" | CLUSTER_HOSTNAME |
 | additional_env_vars | key: value | Useful to pass additional environment variables to the server, such as API keys. | |
 
 :::tip Providing Weaviate version

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -8,7 +8,7 @@ image: og/docs/installation.jpg
 
 Embedded Weaviate is a new deployment model, which allows you to start a Weaviate instance, straight in your application code using a Weaviate Client library.
 
-:::warning Experimental phase
+:::warning Experimental
 Embedded Weaviate is still in the **Experimental** phase.
 
 Some of the APIs and parameters might change over time, as we work towards a perfect implementation.
@@ -37,19 +37,17 @@ The Weaviate server spwaned from the client can be configured via parameters pas
 | hostname | string | Hostname/IP to bind to. | 127.0.0.1 | |
 | additional_env_vars | key: value | Useful to pass additional environment variables to the server, such as API keys. | |
 
-:::danger
-It is not recommended to change `XDG_DATA_HOME` and `XDG_CACHE_HOME` environment variables, as that might affect many other (non-Weaviate related) applications and services running on the same server.
+:::danger XDG environment variables
+It is **not recommended** to change `XDG_DATA_HOME` and `XDG_CACHE_HOME` environment variables, as that might affect many other (non-Weaviate related) applications and services running on the same server.
 :::
 
 :::tip Providing Weaviate version
-
-To provide the full path for `version`:
+To find the **full path** for `version`:
 * head to [Weaviate releases](https://github.com/weaviate/weaviate/releases),
 * find the **Assets** section for the required Weaviate version
-* and copy the link to required `(name).tar.gz` file.<br/>
+* and copy the link to required `(name).tar.gz` file.
 
 For example, here is a path to Weaviate `1.18.2` `AMD64` binary: `https://github.com/weaviate/weaviate/releases/download/v1.18.2/weaviate-v1.18.2-linux-amd64.tar.gz`
-
 :::
 
 ## Starting Embedded Weaviate under the hood

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -3,6 +3,7 @@ title: Embedding Weaviate (experimental)
 sidebar_position: 4
 # image: TODO
 # tags: ['installation', 'embedded', 'client']
+---
 ## Overview
 
 Embedded Weaviate is a new deployment model, which allows you to start a Weaviate instance, straight in your application code using a Weaviate Client library.


### PR DESCRIPTION
Documenting the "embedded DB" option for Python and JavaScript on Linux.

**[Staging page](https://6423dd5319cb665c246ec2f2--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/installation/embedded)**