### PR TITLE
[docs:fix] ignore meetup.com links as they intermittently fail

### DIFF
--- a/_build_scripts/verify-links-build-dev.sh
+++ b/_build_scripts/verify-links-build-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net|https://cohere.ai"
+URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net|https://cohere.ai|https://www.meetup.com"
 GITHUB_IGNORES="github.com"
 DEV_BUILD_LINKS_TO_IGNORE="assets/files|https://weaviate.io"
 

--- a/_build_scripts/verify-links.sh
+++ b/_build_scripts/verify-links.sh
@@ -2,7 +2,7 @@
 set -e
 set -o errexit # stop script immediately on error
 
-URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net|https://cohere.ai"
+URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net|https://cohere.ai|https://www.meetup.com"
 DOCUSAURUS_IGNORES="github.com/.*github.com/|github.com/weaviate/weaviate-io"
 # Note #1 github.com/.*github.com/ - is to ignore meta links that include blog co-authors
 # Note #2 github.com/weaviate/weaviate-io/tree/ - is for edit on github links


### PR DESCRIPTION
### What's being changed:

Add https://www.meetup.com to ignored URLs as they keep intermittently failing

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Travis** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`