### PR TITLE
fix(WCS): copyedit

### DIFF
--- a/_includes/client.capabilities.mdx
+++ b/_includes/client.capabilities.mdx
@@ -1,3 +1,3 @@
 With these clients you can perform *all* RESTful and GraphQL requests. This means you can use any endpoint, and perform all GraphQL queries directly from your Python, TypeScript, Java or Go scripts.
 
-The Weaviate documentation, including the [RESTful API](/developers/weaviate/api/rest/) and [GraphQL](/developers/weaviate/api/graphql/) reference pages include code snippets using each client. The methods of the clients are designed to reflect the API functions 1-1, but are designed (structured and named) in the way native to the language.
+The Weaviate documentation, including the [RESTful API](/developers/weaviate/api/rest/) and [GraphQL](/developers/weaviate/api/graphql/) reference pages, include code snippets using each client. The methods of the clients are designed to reflect the API functions 1:1, but are designed (structured and named) in the way native to the language.

--- a/developers/wcs/quickstart.mdx
+++ b/developers/wcs/quickstart.mdx
@@ -19,7 +19,7 @@ Welcome to the **Quickstart guide** for Weaviate Cloud Services (WCS). Here, you
 
 ### Agenda
 
-By the end of this tutorial, you will be familiar with basics of WCS. You will have:
+By the end of this tutorial, you will be familiar with the basics of WCS. You will have:
 - Created a WCS account,
 - Created a new free WCS sandbox instance without authentication,
 - Installed a Weaviate client of your choice, and
@@ -72,7 +72,7 @@ In the meantime, let's start installing a client library.
 
 ## Install a client library
 
-You can communicate with Weaviate with the available [client libraries](../weaviate/client-libraries/index.md) (currently available for `Python`, `JavaScript`, `Java` and `Go`) or the [RESTful API](../weaviate/api/rest/index.md).
+You can communicate with Weaviate using the available [client libraries](../weaviate/client-libraries/index.md) (currently for `Python`, `JavaScript`, `Java` and `Go`), the [GraphQL API](../weaviate/api/graphql/index.md), or the [RESTful API](../weaviate/api/rest/index.md).
 
 import ClientCapabilitiesOverview from '/_includes/client.capabilities.mdx'
 
@@ -90,7 +90,7 @@ By now, you should have:
 * Set up a sandbox instance of Weaviate on WCS, and
 * Installed a Weaviate client library.
 
-Let's put the pieces together by connecting to the Weaviate instance and retrieve the existing schema, which should be empty.
+Let's put the pieces together by connecting to the Weaviate instance and retrieving the existing schema, which should be empty.
 
 This can be done by sending a request to the `schema` endpoint.
 


### PR DESCRIPTION
Grammar fixes before adding the comment widget to the bottom of WCS doc pages as well.

https://642b649dcaa5da3738e9caf4--tangerine-buttercream-20c32f.netlify.app/developers/wcs