### PR TITLE
[site] Fix Netlify link in the slack message

### DIFF
--- a/_build_scripts/publish-draft-to-netlify.sh
+++ b/_build_scripts/publish-draft-to-netlify.sh
@@ -14,6 +14,6 @@ rm build/robots.txt
 mv build/robots.txt.live build/robots.txt
 
 # Extract Netlify URL
-NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
-NETLIFY_URL=$(echo ${NETLIFY_LOC:29})
-echo $NETLIFY_URL
+# NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
+# NETLIFY_URL=$(echo ${NETLIFY_LOC:29})
+# echo $NETLIFY_URL

--- a/_build_scripts/publish-draft-to-netlify.sh
+++ b/_build_scripts/publish-draft-to-netlify.sh
@@ -12,8 +12,3 @@ Disallow: /" >> build/robots.txt
 # Bring back the original robots.txt file
 rm build/robots.txt
 mv build/robots.txt.live build/robots.txt
-
-# Extract Netlify URL
-# NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
-# NETLIFY_URL=$(echo ${NETLIFY_LOC:29})
-# echo $NETLIFY_URL

--- a/_build_scripts/publish-draft-to-netlify.sh
+++ b/_build_scripts/publish-draft-to-netlify.sh
@@ -7,13 +7,13 @@ echo -e "User-agent: *
 Disallow: /" >> build/robots.txt
 
 # sudo netlify deploy --dir=build --site=tangerine-buttercream-20c32f >> netlify.out
-./node_modules/.bin/netlify deploy --dir=build --site=tangerine-buttercream-20c32f >> netlify.out
+./node_modules/.bin/netlify deploy --dir=build --site=tangerine-buttercream-20c32f > netlify.out
 
 # Bring back the original robots.txt file
-rm build/robots.txt 
+rm build/robots.txt
 mv build/robots.txt.live build/robots.txt
 
 # Extract Netlify URL
 NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
-NETLIFY_URL=$(echo ${NETLIFY_LOC:29})
-
+NETLIFY_URL=$(echo ${NETLIFY_LOC:36})
+echo $NETLIFY_URL

--- a/_build_scripts/publish-draft-to-netlify.sh
+++ b/_build_scripts/publish-draft-to-netlify.sh
@@ -15,5 +15,5 @@ mv build/robots.txt.live build/robots.txt
 
 # Extract Netlify URL
 NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
-NETLIFY_URL=$(echo ${NETLIFY_LOC:36})
+NETLIFY_URL=$(echo ${NETLIFY_LOC:29})
 echo $NETLIFY_URL

--- a/_build_scripts/slack-netlify-message.sh
+++ b/_build_scripts/slack-netlify-message.sh
@@ -10,6 +10,11 @@ commit_message=${commit_message//&/&amp;}
 commit_message=${commit_message//</&lt;}
 commit_message=${commit_message//>/&gt;}
 
+# Extract Netlify URL
+NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
+NETLIFY_URL=$(echo ${NETLIFY_LOC:29})
+echo $NETLIFY_URL
+
 # Prepare the message and send it to Slack
 branch_name=${GITHUB_REF##*/}
 MESSAGE="{ \"text\": \"Hey $AUTHOR_NAME - your :docusaurus: *weaviate website* build (\`$branch_name\`) is ready on Netlify: $NETLIFY_URL \n> $commit_message\" }"

--- a/_build_scripts/slack-netlify-message.sh
+++ b/_build_scripts/slack-netlify-message.sh
@@ -13,7 +13,6 @@ commit_message=${commit_message//>/&gt;}
 # Extract Netlify URL
 NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
 NETLIFY_URL=$(echo ${NETLIFY_LOC:19})
-echo $NETLIFY_URL
 
 # Prepare the message and send it to Slack
 branch_name=${GITHUB_REF##*/}

--- a/_build_scripts/slack-netlify-message.sh
+++ b/_build_scripts/slack-netlify-message.sh
@@ -12,12 +12,12 @@ commit_message=${commit_message//>/&gt;}
 
 # Extract Netlify URL
 NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
-NETLIFY_URL=$(echo ${NETLIFY_LOC:29})
+NETLIFY_URL=$(echo ${NETLIFY_LOC:20})
 echo $NETLIFY_URL
 
 # Prepare the message and send it to Slack
 branch_name=${GITHUB_REF##*/}
-MESSAGE="{ \"text\": \"Hey $AUTHOR_NAME - your :docusaurus: *weaviate website* build (\`$branch_name\`) is ready on Netlify: $NETLIFY_URL \n> $commit_message\" }"
+MESSAGE="{ \"text\": \"Hey $AUTHOR_NAME - your :docusaurus: *weaviate website* build (\`$branch_name\`) is ready on Netlify:\n $NETLIFY_URL \n> $commit_message\" }"
 
 echo $MESSAGE > payload_netlify.json
 

--- a/_build_scripts/slack-netlify-message.sh
+++ b/_build_scripts/slack-netlify-message.sh
@@ -12,7 +12,7 @@ commit_message=${commit_message//>/&gt;}
 
 # Extract Netlify URL
 NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
-NETLIFY_URL=$(echo ${NETLIFY_LOC:20})
+NETLIFY_URL=$(echo ${NETLIFY_LOC:19})
 echo $NETLIFY_URL
 
 # Prepare the message and send it to Slack
@@ -20,10 +20,6 @@ branch_name=${GITHUB_REF##*/}
 MESSAGE="{ \"text\": \"Hey $AUTHOR_NAME - your :docusaurus: *weaviate website* build (\`$branch_name\`) is ready on Netlify:\n $NETLIFY_URL \n> $commit_message\" }"
 
 echo $MESSAGE > payload_netlify.json
-
-echo "-----"
-echo $MESSAGE
-echo "-----"
 
 # Send the slack message
 curl -X POST -H 'Content-type: application/json' -d @payload_netlify.json https://hooks.slack.com/services/$SLACK_BOT

--- a/_build_scripts/slack-netlify-message.sh
+++ b/_build_scripts/slack-netlify-message.sh
@@ -16,5 +16,9 @@ MESSAGE="{ \"text\": \"Hey $AUTHOR_NAME - your :docusaurus: *weaviate website* b
 
 echo $MESSAGE > payload_netlify.json
 
+echo "-----"
+echo $MESSAGE
+echo "-----"
+
 # Send the slack message
 curl -X POST -H 'Content-type: application/json' -d @payload_netlify.json https://hooks.slack.com/services/$SLACK_BOT

--- a/_build_scripts/verify-links.sh
+++ b/_build_scripts/verify-links.sh
@@ -10,7 +10,6 @@ DOCUSAURUS_IGNORES="github.com/.*github.com/|github.com/weaviate/weaviate-io"
 # Extract Netlify URL
 NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
 NETLIFY_URL=$(echo ${NETLIFY_LOC:19})
-echo $NETLIFY_URL
 
 echo "**************************************
 Starting Link Verification

--- a/_build_scripts/verify-links.sh
+++ b/_build_scripts/verify-links.sh
@@ -7,6 +7,11 @@ DOCUSAURUS_IGNORES="github.com/.*github.com/|github.com/weaviate/weaviate-io"
 # Note #1 github.com/.*github.com/ - is to ignore meta links that include blog co-authors
 # Note #2 github.com/weaviate/weaviate-io/tree/ - is for edit on github links
 
+# Extract Netlify URL
+NETLIFY_LOC=$(grep -r 'Website Draft URL:' netlify.out)
+NETLIFY_URL=$(echo ${NETLIFY_LOC:19})
+echo $NETLIFY_URL
+
 echo "**************************************
 Starting Link Verification
 PATH: ${NETLIFY_URL}


### PR DESCRIPTION
### What's being changed:

Netlify links shares on the website-updates slack channel didn't show the correct links for branch builds.
This PR makes sure that we always share the correct Netlify link.

### Type of change:

- [x] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors

