### PR TITLE
[site] remove wcs docs link under wcs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -163,12 +163,12 @@ const config = {
                                 label: 'Pricing',
                                 to: '/pricing',
                             },
-                            {
-                                label: 'Documentation',
-                                docId: 'wcs/index',
-                                sidebarid: 'wcsSidebar',
-                                type: 'doc',
-                            },
+                            // {
+                            //     label: 'Documentation',
+                            //     docId: 'wcs/index',
+                            //     sidebarid: 'wcsSidebar',
+                            //     type: 'doc',
+                            // },
                             {
                                 label: 'Weaviate Cloud console',
                                 href: 'https://console.weaviate.cloud',


### PR DESCRIPTION
### What's being changed:

Remove wcs docs link under wcs

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
