### PR TITLE
[site] update slack redirect link

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,2 @@
 # Redirect from weaviate.io/slack to the slack invite link
-/slack https://join.slack.com/t/weaviate/shared_invite/zt-1rzclhiqq-DWedOB3P1UONumxTMGH_Bg
+/slack https://join.slack.com/t/weaviate/shared_invite/zt-1teerbwdj-D7te4dSr~hvmZudrZoRPPg


### PR DESCRIPTION
Update slack redirect link 

### What's being changed:

Update slack redirect link as the previous one appears to have expired

### Type of change:

- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
