### PR TITLE
Fix Python example for querying with BM25

### DIFF
--- a/_includes/code/graphql.filters.bm25.filter.example.mdx
+++ b/_includes/code/graphql.filters.bm25.filter.example.mdx
@@ -36,7 +36,7 @@ query_result = (
   client.query
   .get("Article", ["title", "summary"])
   .with_where(where_filter)
-  .with_bm25("query" = "how to fish")
+  .with_bm25(query="how to fish")
   .do()
 )
 ```

--- a/_includes/code/graphql.filters.bm25.mdx
+++ b/_includes/code/graphql.filters.bm25.mdx
@@ -38,7 +38,7 @@ bm25 = {
 result = (
   client.query
   .get("Article", ["title", "_additional {score} "])
-  .with_bm25(bm25)
+  .with_bm25(**bm25)
   .do()
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:
This PR fixes the examples of querying with BM25 using the Python client. According to this [PR comment](https://github.com/weaviate/weaviate-python-client/pull/290#issuecomment-1514176358), `with_bm25` expects separate parameters and not a single dict.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
