### PR TITLE
[docs] remove incorrect "the" placement

### DIFF
--- a/developers/weaviate/configuration/index.md
+++ b/developers/weaviate/configuration/index.md
@@ -24,7 +24,7 @@ This section shows you how to configure Weaviate to suit your specific needs.
 For example, you can read about how to:
 
 - Extend Weaviate's functionality by adding [modules](./modules.md), including vectorizers
-- Configure how Weaviate stores and indexes data through its the [schema](./schema-configuration.md), [data type](../config-refs/datatypes.md) and [distance metric](../config-refs/distances.md)
+- Configure how Weaviate stores and indexes data through its [schema](./schema-configuration.md), [data type](../config-refs/datatypes.md) and [distance metric](../config-refs/distances.md)
 - Manage performance vs. cost tradeoffs by its [vector index properties](./indexes.md)
 - [Back up](./backups.md) your Weaviate instance
 - Control access through [authentication](./authentication.md) and [authorization](./authorization.md)


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:
I just removed "the" from "... through its ~~the~~ schema, ..."

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
