### PR TITLE
[academy] replace videos w temp yt

### DIFF
--- a/developers/academy/units/101_hello_weaviate/examples_1.mdx
+++ b/developers/academy/units/101_hello_weaviate/examples_1.mdx
@@ -5,10 +5,10 @@ sidebar_position: 20
 
 ## <i class="fa-solid fa-square-chevron-right"></i>&nbsp;&nbsp;Vectors in action
 
-import imageUrl from '../../tmp_images/academy_placeholder.jpg';
+import ReactPlayer from 'react-player/lazy'
 
-<!-- <img src={imageUrl} alt="Image alt" width="75%"/> -->
-<iframe src="https://drive.google.com/file/d/1VJuvbOSd2yWzQGWTV97vjmHs4qyNXoIs/preview" width="854" height="480"></iframe>
+<ReactPlayer url='https://youtu.be/6Ignf_1Pyeo' controls='true'/>
+<br/>
 
 Let's take a look at a few more examples of what you can do with Weaviate.
 

--- a/developers/academy/units/101_hello_weaviate/examples_2.mdx
+++ b/developers/academy/units/101_hello_weaviate/examples_2.mdx
@@ -5,10 +5,10 @@ sidebar_position: 25
 
 ## <i class="fa-solid fa-square-chevron-right"></i>&nbsp;&nbsp;Beyond vector searches
 
-import imageUrl from '../../tmp_images/academy_placeholder.jpg';
+import ReactPlayer from 'react-player/lazy'
 
-<!-- <img src={imageUrl} alt="Image alt" width="75%"/> -->
-<iframe src="https://drive.google.com/file/d/1WmQYAJECciEFylY5RZnmRXca6IaHYKPT/preview" width="854" height="480"></iframe>
+<ReactPlayer url='https://youtu.be/sJGAIwH4H7Y' controls='true'/>
+<br/>
 
 You can do a lot more with Weaviate than to simply retrieve static information.
 

--- a/developers/academy/units/101_hello_weaviate/hands_on.mdx
+++ b/developers/academy/units/101_hello_weaviate/hands_on.mdx
@@ -11,10 +11,10 @@ This section includes queries using the OpenAI inference endpoint. So, we recomm
 
 ## <i class="fa-solid fa-square-chevron-right"></i>&nbsp;&nbsp;Overview
 
-import imageUrl from '../../tmp_images/academy_placeholder.jpg';
+import ReactPlayer from 'react-player/lazy'
 
-<!-- <img src={imageUrl} alt="Image alt" width="75%"/> -->
-<iframe src="https://drive.google.com/file/d/1DYCwJ8JqminmWjBLd16QJH1Oi5bGxiVL/preview" width="854" height="480"></iframe>
+<ReactPlayer url='https://youtu.be/nil86_auPXI' controls='true'/>
+<br/>
 
 Now that you've set up your own Weaviate instance and installed a client, let's get hands-on with Weaviate.
 

--- a/developers/academy/units/101_hello_weaviate/index.mdx
+++ b/developers/academy/units/101_hello_weaviate/index.mdx
@@ -5,11 +5,10 @@ sidebar_position: 101  # Like a subject number (e.g. CS101)
 
 ## <i class="fa-solid fa-chalkboard-user"></i>&nbsp;&nbsp;Unit overview
 
-import imageUrl from '../../tmp_images/academy_placeholder.jpg';
+import ReactPlayer from 'react-player/lazy'
 
-<!-- <img src={imageUrl} alt="Image alt" width="75%"/> -->
-
-<iframe src="https://drive.google.com/file/d/1Jkf3uYecS9iUzDXF-_CB8eeyQ-Y1rNWT/preview" width="854" height="480"></iframe>
+<ReactPlayer url='https://youtu.be/vLTNBf7S8Jc' controls='true'/>
+<br/>
 
 <!-- Provide context for this course, in addition to the concrete learning goals and outcomes. Why would someone want to do this unit? -->
 

--- a/developers/academy/units/101_hello_weaviate/intro_weaviate.mdx
+++ b/developers/academy/units/101_hello_weaviate/intro_weaviate.mdx
@@ -3,11 +3,12 @@ title: Introduction to Weaviate
 sidebar_position: 10
 ---
 
-import imageUrl from '../../tmp_images/academy_placeholder.jpg';
-
 ## <i class="fa-solid fa-square-chevron-right"></i>&nbsp;&nbsp;What is Weaviate?
 
-<iframe src="https://drive.google.com/file/d/1RcAUxmVxL22nfJX9TdchyhhfSwVtZiWn/preview" width="854" height="480"></iframe>
+import ReactPlayer from 'react-player/lazy'
+
+<ReactPlayer url='https://youtu.be/WmEKhFeA4Gg' controls='true'/>
+<br/>
 
 Weaviate is an open-source vector database. But what does that mean? Let's unpack it here.
 

--- a/developers/academy/units/101_hello_weaviate/overview_vectors.mdx
+++ b/developers/academy/units/101_hello_weaviate/overview_vectors.mdx
@@ -3,12 +3,12 @@ title: Vectors - An overview
 sidebar_position: 15
 ---
 
-import imageUrl from '../../tmp_images/academy_placeholder.jpg';
-
 ## <i class="fa-solid fa-square-chevron-right"></i>&nbsp;&nbsp;What is a vector?
 
-<!-- <img src={imageUrl} alt="Image alt" width="75%"/> -->
-<iframe src="https://drive.google.com/file/d/19XXLy4eeLwZrWtNZPOxuYgCoI4qnTF61/preview" width="854" height="480"></iframe>
+import ReactPlayer from 'react-player/lazy'
+
+<ReactPlayer url='https://youtu.be/E6K4QF7Cu0A' controls='true'/>
+<br/>
 
 We've covered that Weaviate is a vector database, and that a vector search is similarity-based. But what is a vector?
 

--- a/developers/academy/units/101_hello_weaviate/set_up.mdx
+++ b/developers/academy/units/101_hello_weaviate/set_up.mdx
@@ -3,7 +3,6 @@ title: Database & client setup
 sidebar_position: 40
 ---
 
-import imageUrl from '../../tmp_images/academy_placeholder.jpg';
 import registerImg from '../../../wcs/img/register.png';
 import WCSoptions from '../../../wcs/img/wcs-options.png';
 import WCScreateButton from '../../../wcs/img/wcs-create-button.png';
@@ -12,8 +11,10 @@ import WCScreationProgress from '../../../wcs/img/wcs-creation-progress.png';
 
 ## <i class="fa-solid fa-square-chevron-right"></i>&nbsp;&nbsp;Overview
 
-<!-- <img src={imageUrl} alt="Image alt" width="75%"/> -->
-<iframe src="https://drive.google.com/file/d/1GMEq9XeKOiVDukfSCAvsai9eOl7ZEecx/preview" width="854" height="480"></iframe>
+import ReactPlayer from 'react-player/lazy'
+
+<ReactPlayer url='https://youtu.be/rqNNGrvIpfI' controls='true'/>
+<br/>
 
 ## <i class="fa-solid fa-square-chevron-right"></i>&nbsp;&nbsp;Options for running Weaviate
 


### PR DESCRIPTION
### What's being changed:

Replace Google Drive videos with yt due to problems w/ some browsers

### Type of change:

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [x] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
