### PR TITLE
[docs] update Quickstart to api key auth; overview other auth options

### DIFF
--- a/_includes/code/quickstart.autoschema.connect.withkey.mdx
+++ b/_includes/code/quickstart.autoschema.connect.withkey.mdx
@@ -9,8 +9,9 @@ import weaviate
 
 client = weaviate.Client(
     url = "https://some-endpoint.weaviate.network/",  # Replace with your endpoint
+    auth_client_secret=weaviate.auth.AuthApiKey(api_key="<YOUR-WEAVIATE-API-KEY>"),  # Replace w/ your API Key for the Weaviate instance
     additional_headers = {
-        "X-OpenAI-Api-Key": "<THE-KEY>"  # Replace with your API key
+        "X-OpenAI-Api-Key": "<THE-KEY>"  # Replace with your inference API key
     }
 )
 ```
@@ -24,7 +25,8 @@ const weaviate = require('weaviate-ts-client');
 const client = weaviate.client({
     scheme: 'https',
     host: 'some-endpoint.weaviate.network',  // Replace with your endpoint
-    headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your API key
+    apiKey: new weaviate.ApiKey('YOUR-WEAVIATE-API-KEY'),  // Replace w/ your API Key for the Weaviate instance
+    headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your inference API key
   });
 ```
 
@@ -37,7 +39,8 @@ import weaviate, { WeaviateClient } from 'weaviate-ts-client';
 const client: WeaviateClient = weaviate.client({
     scheme: 'https',
     host: 'some-endpoint.weaviate.network',  // Replace with your endpoint
-    headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your API key
+    apiKey: new ApiKey('YOUR-WEAVIATE-API-KEY'),  // Replace w/ your API Key for the Weaviate instance
+    headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your inference API key
   });
 ```
 
@@ -48,8 +51,9 @@ const client: WeaviateClient = weaviate.client({
 cfg := weaviate.Config{
   Host:   "some-endpoint.weaviate.network/",  // Replace with your endpoint
   Scheme: "https",
+  authConfig: auth.ApiKey{Value: "YOUR-WEAVIATE-API-KEY"}, // Replace w/ your API Key for the Weaviate instance
   Headers: map[string]string{
-    "X-OpenAI-Api-Key": "<THE-KEY>",
+    "X-OpenAI-Api-Key": "<THE-KEY>",  // Replace with your inference API key
   },
 }
 
@@ -116,7 +120,8 @@ echo '{
   "query": "<QUERY>"
 }' | curl \
     -X POST \
-    -H 'Content-Type: application/json' \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer {YOUR-WEAVIATE-API-KEY}" \
     -H "X-OpenAI-Api-Key: <API-KEY>" \
     -d @- \
     https://some-endpoint.weaviate.network/v1/graphql

--- a/_includes/code/quickstart.autoschema.endtoend.mdx
+++ b/_includes/code/quickstart.autoschema.endtoend.mdx
@@ -10,8 +10,9 @@ import json
 
 client = weaviate.Client(
     url = "https://some-endpoint.weaviate.network/",  # Replace with your endpoint
+    auth_client_secret=weaviate.auth.AuthApiKey(api_key="<YOUR-WEAVIATE-API-KEY>"),  # Replace w/ your API Key for the Weaviate instance
     additional_headers = {
-        "X-OpenAI-Api-Key": "<THE-KEY>"  # Replace with your API key
+        "X-OpenAI-Api-Key": "<THE-KEY>"  # Replace with your inference API key
     }
 )
 
@@ -55,7 +56,8 @@ const weaviate = require('weaviate-ts-client');
 const client = weaviate.client({
   scheme: 'https',
   host: 'some-endpoint.weaviate.network',  // Replace with your endpoint
-  headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your API key
+  apiKey: new weaviate.ApiKey('YOUR-WEAVIATE-API-KEY'),  // Replace w/ your API Key for the Weaviate instance
+  headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your inference API key
 });
 
 let classObj = {
@@ -146,7 +148,8 @@ import fetch, { Response } from 'node-fetch';  // Note that Node implements its 
 const client: WeaviateClient = weaviate.client({
   scheme: 'https',
   host: 'some-endpoint.weaviate.network',  // Replace with your endpoint
-  headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your API key
+  apiKey: new ApiKey('YOUR-WEAVIATE-API-KEY'),  // Replace w/ your API Key for the Weaviate instance
+  headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your inference API key
 });
 
 async function getJsonData(): Promise<any> {
@@ -234,8 +237,9 @@ func main() {
 	cfg := weaviate.Config{
 		Host:   "some-endpoint.weaviate.network/", // Replace with your endpoint
 		Scheme: "https",
+    authConfig: auth.ApiKey{Value: "YOUR-WEAVIATE-API-KEY"}, // Replace w/ your API Key for the Weaviate instance
 		Headers: map[string]string{
-			"X-OpenAI-Api-Key": "<THE-KEY>",
+			"X-OpenAI-Api-Key": "<THE-KEY>",  // Replace with your inference API key
 		},
 	}
 	client, err := weaviate.NewClient(cfg)
@@ -248,7 +252,7 @@ func main() {
 		Class:      "Question",
 		Vectorizer: "text2vec-openai",
 	}
-  
+
 	if client.Schema().ClassCreator().WithClass(classObj).Do(context.Background()) != nil {
 		panic(err)
 	}
@@ -398,6 +402,7 @@ if [ $lines_processed -ne 0 ]; then
 
   curl -X POST "$BATCH_API_URL" \
        -H "Content-Type: application/json" \
+       -H "Authorization: Bearer {YOUR-WEAVIATE-API-KEY}" \
        -H "X-OpenAI-Api-Key: $OPENAI_API_TOKEN" \
        -d "$batch_data"
   echo "" # Print a newline for better output formatting

--- a/_includes/code/quickstart.autoschema.neartext.mdx
+++ b/_includes/code/quickstart.autoschema.neartext.mdx
@@ -28,8 +28,9 @@ import json
 
 client = weaviate.Client(
     url="https://some-endpoint.weaviate.network/",  # Replace with your endpoint
+    auth_client_secret=weaviate.auth.AuthApiKey(api_key="<YOUR-WEAVIATE-API-KEY>"),  # Replace w/ your API Key for the Weaviate instance
     additional_headers={
-        "X-OpenAI-Api-Key": "<THE-KEY>"  # Replace with your API key
+        "X-OpenAI-Api-Key": "<THE-KEY>"  # Replace with your inference API key
     }
 )
 
@@ -55,7 +56,8 @@ const weaviate = require('weaviate-ts-client');
 const client = weaviate.client({
   scheme: 'https',
   host: 'some-endpoint.weaviate.network',  // Replace with your endpoint
-  headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your API key
+  apiKey: new weaviate.ApiKey('YOUR-WEAVIATE-API-KEY'),  // Replace w/ your API Key for the Weaviate instance
+  headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your inference API key
 });
 
 client.graphql
@@ -82,7 +84,8 @@ import weaviate, { WeaviateClient } from 'weaviate-ts-client';
 const client: WeaviateClient = weaviate.client({
   scheme: 'https',
   host: 'some-endpoint.weaviate.network',  // Replace with your endpoint
-  headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your API key
+  apiKey: new ApiKey('YOUR-WEAVIATE-API-KEY'),  // Replace w/ your API Key for the Weaviate instance
+  headers: {'X-OpenAI-Api-Key': '<THE-KEY>'},  // Replace with your inference API key
 });
 
 client.graphql
@@ -118,7 +121,8 @@ func main() {
   cfg := weaviate.Config{
     Host:    "some-endpoint.weaviate.network/",  // Replace with your endpoint
     Scheme:  "https",
-    Headers: map[string]string{"X-OpenAI-Api-Key": "<THE-KEY>"},
+    authConfig: auth.ApiKey{Value: "YOUR-WEAVIATE-API-KEY"}, // Replace w/ your API Key for the Weaviate instance
+    Headers: map[string]string{"X-OpenAI-Api-Key": "<THE-KEY>"},  // Replace with your inference API key
   }
   client, err := weaviate.NewClient(cfg)
   if err != nil {

--- a/_includes/code/wcs.authentication.api.key.mdx
+++ b/_includes/code/wcs.authentication.api.key.mdx
@@ -8,12 +8,10 @@ import TabItem from '@theme/TabItem';
 ```python
 import weaviate
 
-auth_config = weaviate.auth.AuthApiKey(api_key="<YOUR-WEAVIATE-API-KEY>")  # Replace w/ your API Key for the Weaviate instance
-
 # Instantiate the client with the auth config
 client = weaviate.Client(
     url="https://some-endpoint.weaviate.network",  # Replace w/ your endpoint
-    auth_client_secret=auth_config
+    auth_client_secret=weaviate.auth.AuthApiKey(api_key="<YOUR-WEAVIATE-API-KEY>")  # Replace w/ your API Key for the Weaviate instance
 )
 ```
 
@@ -61,7 +59,7 @@ import (
 cfg := weaviate.Config(
   Host:"some-endpoint.weaviate.network",
   Scheme: "http",
-  authConfig: auth.ApiKey{Value: "YOUR-WEAVIATE-API-KEY"}
+  authConfig: auth.ApiKey{Value: "YOUR-WEAVIATE-API-KEY"}, // Replace w/ your API Key for the Weaviate instance
   headers: nil,
 )
 

--- a/_includes/code/wcs.authentication.user.pass.mdx
+++ b/_includes/code/wcs.authentication.user.pass.mdx
@@ -8,15 +8,13 @@ import TabItem from '@theme/TabItem';
 ```python
 import weaviate
 
-auth_config = weaviate.AuthClientPassword(
-    username = "WCS_USERNAME",  # Replace w/ your WCS username
-    password = "WCS_PASSWORD",  # Replace w/ your WCS password
-)
-
 # Instantiate the client with the auth config
 client = weaviate.Client(
     url="https://some-endpoint.weaviate.network",  # Replace w/ your endpoint
-    auth_client_secret=auth_config
+    auth_client_secret=weaviate.AuthClientPassword(
+        username = "WCS_USERNAME",  # Replace w/ your WCS username
+        password = "WCS_PASSWORD",  # Replace w/ your WCS password
+    )
 )
 ```
 

--- a/developers/weaviate/quickstart/end-to-end.md
+++ b/developers/weaviate/quickstart/end-to-end.md
@@ -37,11 +37,41 @@ At this point, you should:
 We will be working with [this dataset](https://raw.githubusercontent.com/weaviate-tutorials/quickstart/main/data/jeopardy_tiny.json), which will be loaded directly from the remote URL.
 
 import WCSClientInstantiation from '/_includes/code/wcs.client.instantiation.mdx';
+import WCSAuthenticationApiKey from '/_includes/code/wcs.authentication.api.key.mdx';
+import WCSAuthenticationUserPass from '/_includes/code/wcs.authentication.user.pass.mdx';
 
 :::tip Connecting to Weaviate
-Before going further, please make sure that you can connect to your Weaviate instance, e.g. with the Weaviate client. If you do *not* have authentication enabled you should be able to run the below to retrieve your schema.
+Before going further, please make sure that you can connect to your Weaviate instance, e.g. with the Weaviate client.
+
+<br/>
+<details>
+  <summary><b>Without authentication enabled</b></summary>
 
 <WCSClientInstantiation/>
+
+</details>
+
+If you do have authentication enabled, you can log in with an API key (recommended), or with OIDC.
+
+<br/>
+<details>
+  <summary>With <b>API key authentication</b> (Recommended)</summary>
+
+<WCSAuthenticationApiKey/>
+
+</details>
+
+<details>
+  <summary>With <b>OIDC authentication</b> (WCS username & password)</summary>
+
+<WCSAuthenticationUserPass/>
+
+</details>
+
+Going forward, the examples will assume that
+
+- Authentication is enabled, and
+- The API key authentication method is used.
 :::
 
 ## Import data
@@ -122,9 +152,9 @@ import CautionSchemaDeleteClass from '/_includes/schema-delete-class.mdx'
 
 <hr />
 
-### Provide the API key
+### Provide the inference API key
 
-The API key can be provided to Weaviate as an environment variable, or in the HTTP header with every request. Here, we will add them to the Weaviate client at instantiation as shown below. It will then send the key as a part of the header with every request.
+The inference API key can be provided to Weaviate as an environment variable, or in the HTTP header with every request. Here, we will add them to the Weaviate client at instantiation as shown below. It will then send the key as a part of the header with every request.
 
 import ConnectToWeaviateWithKey from '/_includes/code/quickstart.autoschema.connect.withkey.mdx'
 


### PR DESCRIPTION
### What's being changed:

- Update Quickstart tutorial to primarily be based on API key auth
- Also add overview of the other auth options
- Minor change to shorten WCS Python auth code

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
