### PR TITLE
Fix broken links with datatypes

### DIFF
--- a/_includes/datatypes.mdx
+++ b/_includes/datatypes.mdx
@@ -8,11 +8,11 @@
 | boolean[]         | list of booleans      | `[true, false]`                                                                    |
 | number            | float64               | `0.0`                                                                              |
 | number[]          | list of float64       | `[0.0, 1.1]`                                                                       |
-| date              | string                | [more info](/developers/weaviate/configuration/datatypes#datatype-date)            |
-| date[]            | list of string        | [more info](/developers/weaviate/configuration/datatypes#datatype-date)            |
+| date              | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-date)            |
+| date[]            | list of string        | [more info](/developers/weaviate/config-refs/datatypes#datatype-date)            |
 | text              | text                  | `string`                                                                           |
 | text[]            | list of texts         | `["string one", "string two"]`                                                     |
-| geoCoordinates    | string                | [more info](/developers/weaviate/configuration/datatypes#datatype-geocoordinates)  |
-| phoneNumber       | string                | [more info](/developers/weaviate/configuration/datatypes#datatype-phonenumber)     |
-| blob              | base64 encoded string | [more info](/developers/weaviate/configuration/datatypes#datatype-blob)            |
-| *cross reference* | string                | [more info](/developers/weaviate/configuration/datatypes#datatype-cross-reference) |
+| geoCoordinates    | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-geocoordinates)  |
+| phoneNumber       | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-phonenumber)     |
+| blob              | base64 encoded string | [more info](/developers/weaviate/config-refs/datatypes#datatype-blob)            |
+| *cross reference* | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-cross-reference) |


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

The links in the data types page in the doc table were broken (they returned a 404). It's fixed now, and tested as shown below.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
