### PR TITLE
[docs:chore] update old H1s to H2s so that they show up on TOCs

### DIFF
--- a/developers/weaviate/api/graphql/filters.md
+++ b/developers/weaviate/api/graphql/filters.md
@@ -345,7 +345,7 @@ Using the `IsNull` operator allows you to do filter for objects where given prop
 Filtering by null-state requires the target class to be configured to index this. See [here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--indexnullstate) for details.
 :::
 
-# Sorting
+## Sorting
 
 :::info
 Support for sorting was added in `v1.13.0`.
@@ -353,7 +353,7 @@ Support for sorting was added in `v1.13.0`.
 
 You can sort results by any primitive property, typically a `text`, `string`, `number`, or `int` property. When a query has a natural order (e.g. because of a `near<Media>` vector search), adding a sort operator will override the order.
 
-## Cost of sorting / architecture
+### Cost of sorting / architecture
 
 Weaviate's sorting implementation is built in a way that it does not lead to massive memory spikes; it does not need to load all objects to be sorted into memory completely. Only the property value being sorted is kept in memory.
 
@@ -378,7 +378,7 @@ Examples:
 - `[2, 2] > [1, 2, 3, 4]`
 - `[1, 2, 3] < [1, 2, 3, 4]`
 
-## Sorting API
+### Sorting API
 
 import GraphQLGetSorting from '/_includes/code/graphql.get.sorting.mdx';
 

--- a/developers/weaviate/api/rest/backups.md
+++ b/developers/weaviate/api/rest/backups.md
@@ -147,6 +147,6 @@ import BackupStatusRestore from '/_includes/code/backup.status.restore.mdx';
 
 <BackupStatusRestore/>
 
-# Learn more about Backups
+## Learn more about Backups
 
 Discover more about [Backups Configuration](/developers/weaviate/configuration/backups.md#configuration), including Backups to [S3](/developers/weaviate/configuration/backups.md#s3-aws-or-s3-compatible), [GCS](/developers/weaviate/configuration/backups.md#gcs-google-cloud-storage), or [Azure](/developers/weaviate/configuration/backups.md#azure-storage), [Technical Considerations of Backups](/developers/weaviate/configuration/backups.md#technical-considerations), as well as [additional use cases](/developers/weaviate/configuration/backups.md#other-use-cases).

--- a/developers/weaviate/benchmarks/ann.md
+++ b/developers/weaviate/benchmarks/ann.md
@@ -102,7 +102,7 @@ recommend using the [Go](/developers/weaviate/client-libraries/go.md) or
 
 The complete import and test scripts are available [here](https://github.com/weaviate/weaviate-benchmarking).
 
-# Results
+## Results
 
 :::info A guide for picking the right dataset
    The following results section contains multiple datasets. To get the most of
@@ -136,9 +136,9 @@ trade-off. The highlight sections will give you a good overview of Weaviate's
 performance with the respective dataset. Below the highlighted configuration,
 you can find alternative configurations.
 
-## SIFT1M (1M 128d vectors, L2 distance)
+### SIFT1M (1M 128d vectors, L2 distance)
 
-### Highlighted Configuration
+#### Highlighted Configuration
 
 <!-- TODO: Add formatting to table if desired -->
 | **1.0M** | **128** | **l2** | **128** | **32** | **64** |
@@ -149,7 +149,7 @@ you can find alternative configurations.
 | --- | --- | --- | --- |
 | Recall@10 | QPS (Limit 10) | Mean Latency (Limit 10) | p99 Latency (Limit 10) |
 
-### All Results
+#### All Results
 
 #### QPS vs Recall
 
@@ -163,9 +163,9 @@ import AnnReadResultsTable from '/_includes/ann-read-results-table.mdx';
 
 <AnnReadResultsTable/>
 
-## Glove-25 (1.2M 25d vectors, cosine distance)
+### Glove-25 (1.2M 25d vectors, cosine distance)
 
-### Highlighted Configuration
+#### Highlighted Configuration
 
 | **1.28M** | **35** | **cosine** | **64** | **16** | **64** |
 | --- | --- | --- | --- | --- |
@@ -175,7 +175,7 @@ import AnnReadResultsTable from '/_includes/ann-read-results-table.mdx';
 | --- | --- | --- | --- |
 | Recall@10 | QPS (Limit 10) | Mean Latency (Limit 10) | p99 Latency (Limit 10) |
 
-### All Results
+#### All Results
 
 #### QPS vs Recall
 
@@ -187,9 +187,9 @@ import AnnGlove25 from '/_includes/ann-glove-25.mdx';
 
 <AnnReadResultsTable/>
 
-## Deep Image 96 (9.99M 96d vectors, cosine distance)
+### Deep Image 96 (9.99M 96d vectors, cosine distance)
 
-### Highlighted Configuration
+#### Highlighted Configuration
 
 | **9.99M** | **96** | **cosine** | **128** | **32** | **64** |
 | --- | --- | --- | --- | --- |
@@ -199,7 +199,7 @@ import AnnGlove25 from '/_includes/ann-glove-25.mdx';
 | --- | --- | --- | --- |
 | Recall@10 | QPS (Limit 10) | Mean Latency (Limit 10) | p99 Latency (Limit 10) |
 
-### All Results
+#### All Results
 
 #### QPS vs Recall
 
@@ -211,9 +211,9 @@ import AnnDeep96 from '/_includes/ann-deep-96.mdx';
 
 <AnnReadResultsTable/>
 
-## GIST 960 (1.0M 960d vectors, cosine distance)
+### GIST 960 (1.0M 960d vectors, cosine distance)
 
-### Highlighted Configuration
+#### Highlighted Configuration
 
 | **1.00M** | **960** | **cosine** | **512** | **32** | **128** |
 | --- | --- | --- | --- | --- |
@@ -223,7 +223,7 @@ import AnnDeep96 from '/_includes/ann-deep-96.mdx';
 | --- | --- | --- | --- |
 | Recall@10 | QPS (Limit 10) | Mean Latency (Limit 10) | p99 Latency (Limit 10) |
 
-### All Results
+#### All Results
 
 #### QPS vs Recall
 
@@ -235,9 +235,9 @@ import AnnGist960 from '/_includes/ann-gist-960.mdx';
 
 <AnnReadResultsTable/>
 
-# Learn more & FAQ
+## Learn more & FAQ
 
-## What is the difference between latency and throughput?
+### What is the difference between latency and throughput?
 
 The latency refers to the time it takes to complete a single request. This
 is typically measured by taking a mean or percentile distribution of all
@@ -269,7 +269,7 @@ extrapolate what the numbers would be like in a multi-threaded setting.
 All throughput numbers ("QPS") outlined in this benchmark are actual
 multi-threaded measurements on a 30-core machine, not estimations.
 
-## What is a p99 latency?
+### What is a p99 latency?
 
 The mean latency gives you an average value of all requests measured. This is a
 good indication of how long a user will have to wait on average for
@@ -297,7 +297,7 @@ The higher the percentile (e.g. p99 over p95) the "safer" the quoted
 latency becomes. We have thus decided to use p99-latencies instead of
 p95-latencies in our measurements.
 
-## What happens if I run with fewer or more CPU cores than on the example test machine?
+### What happens if I run with fewer or more CPU cores than on the example test machine?
 
 The benchmark outlines a QPS per core measurement. This can help you make a
 rough estimation of how the throughput would vary on smaller or larger
@@ -306,14 +306,14 @@ cores. If you need more throughput, you can run with more CPU cores.
 
 Please note that there is a point of diminishing returns with adding more CPUs because of synchronization mechanisms, disk, and memory bottlenecks. Beyond that point, you can scale horizontally instead of vertically. Horizontal scaling with replication will be [available in Weaviate soon](/developers/weaviate/roadmap/index.md).
 
-## What are ef, efConstruction, and maxConnections?
+### What are ef, efConstruction, and maxConnections?
 
 These parameters refer to the [HNSW build and query
 parameters](/developers/weaviate/configuration/indexes.md#how-to-configure-hnsw).
 They represent a trade-off between recall, latency & throughput, index size, and
 memory consumption. This trade-off is highlighted in the benchmark results.
 
-## I can't match the same latencies/throughput in my own setup, how can I debug this?
+### I can't match the same latencies/throughput in my own setup, how can I debug this?
 
 If you are encountering other numbers in your own dataset, here are a couple of
 hints to look at:
@@ -341,6 +341,6 @@ hints to look at:
   [vector cache large enough](/developers/weaviate/concepts/resources.md#vector-cache)
   for maximum performance.
 
-## Where can I find the scripts to run this benchmark myself?
+### Where can I find the scripts to run this benchmark myself?
 
 The [repository is located here](https://github.com/weaviate/weaviate-benchmarking).

--- a/developers/weaviate/configuration/authorization.md
+++ b/developers/weaviate/configuration/authorization.md
@@ -28,7 +28,7 @@ permissions.
 If a subject is present on both the admin and read-only list, Weaviate will
 throw an error on startup due to the invalid configuration.
 
-# Usage
+## Usage
 
 :::info Using Kubernetes?
 See [this page](../installation/kubernetes.md#authentication-and-authorization) for how to set up `values.yaml` for authentication & authorization.
@@ -54,7 +54,7 @@ The above would enable the plugin and make users `jane@doe.com` and
 As shown in the above example, any string can be used to identify the user. This depends on what you configured in the authentication settings. For example, OIDC users may be identified by their email address by setting `AUTHENTICATION_OIDC_USERNAME_CLAIM` as `email`, whereas API key-authenticated users may be identified as a plain string such as `ian-smith`.
 :::
 
-# RBAC
+## RBAC
 
 More fine-grained Role-Based Access Control (RBAC) coming soon. As of now the
 only possible distinction is between Admins (CRUD), Read-Only Users and

--- a/developers/weaviate/installation/kubernetes.md
+++ b/developers/weaviate/installation/kubernetes.md
@@ -22,11 +22,11 @@ This can be done through either explicitly setting it as part of the `values.yam
   file system capable of `ReadWriteOnce` access mode is sufficient.
 * Helm (only v3 is compatible from Helm version `"v||site.helm_version||"`)
 
-# Weaviate Helm chart
+## Weaviate Helm chart
 
 To obtain and install the Weaviate chart on your Kubernetes cluster, take the following steps:
 
-## Verify tool setup and cluster access
+### Verify tool setup and cluster access
 
 ```bash
 # Check if helm is installed
@@ -36,7 +36,7 @@ $ helm version
 $ kubectl get pods
 ```
 
-## Obtain the Helm Chart
+### Obtain the Helm Chart
 
 Add the Weaviate helm repo that contains the Weaviate helm chart
 
@@ -49,7 +49,7 @@ Get the default `values.yaml` configuration file from the Weaviate helm chart:
 helm show values weaviate/weaviate > values.yaml
 ```
 
-## Modify values.yaml (as necessary)
+### Modify values.yaml (as necessary)
 
 :::note You do not *need* to modify values.yaml
 You can skip this step and run with all default values.
@@ -75,7 +75,7 @@ See the resource requests and limits in the example `values.yaml`. You can
 adjust them based on your expected load and the resources available on the
 cluster.
 
-### Authentication and authorization
+#### Authentication and authorization
 
 An example configuration for authentication is shown below.
 
@@ -113,7 +113,7 @@ For further, general documentation on authentication and authorization configura
 - [Authentication](../configuration/authentication.md)
 - [Authorization](../configuration/authorization.md)
 
-## Deploy (install the Helm chart)
+### Deploy (install the Helm chart)
 
 You can deploy the helm charts as follows:
 
@@ -135,12 +135,12 @@ have only namespace-level permissions, you can skip creating a new
 namespace and adjust the namespace argument on `helm upgrade` according to the
 name of your pre-configured namespace.
 
-## Updating the installation after the initial deployment
+### Updating the installation after the initial deployment
 
 The above command (`helm upgrade...`) is idempotent, you can run it again, for
 example after adjusting your desired configuration.
 
-# Additional Configuration Help
+### Additional Configuration Help
 
 - [Cannot list resource "configmaps" in API group when deploying Weaviate k8s setup on GCP](https://stackoverflow.com/questions/58501558/cannot-list-resource-configmaps-in-api-group-when-deploying-weaviate-k8s-setup)
 - [Error: UPGRADE FAILED: configmaps is forbidden](https://stackoverflow.com/questions/58501558/cannot-list-resource-configmaps-in-api-group-when-deploying-weaviate-k8s-setup)

--- a/developers/weaviate/more-resources/migration-guide.md
+++ b/developers/weaviate/more-resources/migration-guide.md
@@ -8,7 +8,7 @@ import Badges from '/_includes/badges.mdx';
 
 <Badges/>
 
-# Changelog for version v1.9.0
+## Changelog for version v1.9.0
 
 * no breaking changes
 
@@ -70,9 +70,9 @@ import Badges from '/_includes/badges.mdx';
   * fix an issue where a class could not be deleted on some file system (e.g. AWS EFS) (#1757)
 
 
-# Migration to version v1.8.0
+## Migration to version v1.8.0
 
-## Migration Notice
+### Migration Notice
 
 Version `v1.8.0` introduces multi-shard indices and horizontal scaling. As a
 result the dataset needs to be migrated. This migration is performed automatically -
@@ -81,7 +81,7 @@ without user interaction - when first starting up with Weaviate version
 reading the following migration notes and making a case-by-case decision about the
 best upgrade path for your needs.
 
-### Why is a data migration necessary?
+#### Why is a data migration necessary?
 
 Prior to `v1.8.0` Weaviate did not support multi-shard indices. The feature was
 already planned, therefore data was already contained in a single shard with a
@@ -120,7 +120,7 @@ If you see the error message `"shard Knuw6a360eCY: resolve node name
 \"5b6030dbf9ea\" to host"`, you can make Weaviate usable again, by setting
 `5b6030dbf9ea` as the host name: `CLUSTER_HOSTNAME=5b6030dbf9ea`.
 
-### Should you upgrade or reimport?
+#### Should you upgrade or reimport?
 
 Please note that besides new features, `v1.8.0` also contains a large
 collection of bugfixes. Some of those bugs also affected how the HNSW index was
@@ -129,17 +129,17 @@ subpar quality compared to a freshly built index in version `v1.8.0`.
 As such, if you can import using a script, we generally recommend starting
 with a fresh `v1.8.0` setup and reimporting instead of migrating.
 
-### Is downgrading possible after upgrading?
+#### Is downgrading possible after upgrading?
 
 Note that the data migration which happens at the first startup of v1.8.0 is
 not automatically reversible. If you plan on downgrading to `v1.7.x` again
 after upgrading, you must explicitly create a backup of the state prior to
 upgrading.
 
-## Changelog
+### Changelog
 
 
-# Changelog for version v1.7.2
+## Changelog for version v1.7.2
 * No breaking changes
 * New features
   * ### Array Datatypes (#1691)
@@ -150,7 +150,7 @@ upgrading.
   * ### Aggregation on array data type (#1686)
 
 
-# Changelog for version v1.7.0
+## Changelog for version v1.7.0
 * No breaking changes
 * New features
   * ### Array Datatypes (#1611)
@@ -266,14 +266,14 @@ upgrading.
 * Bug fixes
   * Aggregation can get stuck when aggregating `number` datatypes (#1660)
 
-# Changelog for version 1.6.0
+## Changelog for version 1.6.0
 * No breaking changes
 * No new features
  * **Zero Shot Classification (#1603)** This release adds a new classification type `zeroshot` that works with any `vectorizer` or custom vectors. It picks the label objects that have the lowest distance to the source objects. The link is made using cross-references, similar to existing classifications in Weaviate. To start a `zeroshot` classification use `"type": "zeroshot"` in your `POST /v1/classficiations` request and specify the properties you want classified normally using `"classifyProperties": [...]`. As zero shot involves no training data, you cannot set `trainingSetWhere` filters, but can filter both source (`"sourceWhere"`) and label objects (`"targetWhere"`) directly.
 * Bug fixes
 
 
-# Changelog for version 1.5.2
+## Changelog for version 1.5.2
 
 * No breaking changes
 * No new features
@@ -281,7 +281,7 @@ upgrading.
 * ### Fix possible data races (`short write`) (#1643)
   This release fixes various possible data races that could in the worst case lead to an unrecoverable error `"short write"`. The possibility for those races was introduced in `v.1.5.0` and we highly recommend anyone running on the `v1.5.x` timeline to upgrade to `v1.5.2` immediately.
 
-# Changelog for version 1.5.1
+## Changelog for version 1.5.1
 
 * No breaking changes
 * No new features
@@ -295,12 +295,12 @@ upgrading.
 * ### Fix potential data race in Auto Schema features (#1636)
   This fix improves incorrect synchronization on the auto schema feature which in extreme cases could lead to a data race.
 
-# Migration to version 1.5.0
+## Migration to version 1.5.0
 
-## Migration Notice
+### Migration Notice
 *This release does not contain any API-level breaking changes, however, it changes the entire storage mechanism inside Weaviate. As a result, an in-place update is not possible. When upgrading from previous versions, a new setup needs to be created and all data reimported. Prior backups are not compatible with this version.*
 
-## Changelog
+### Changelog
 * No breaking changes
 * New Features:
   * *LSM-Tree based Storage*. Previous releases of Weaviate used a B+Tree based storage mechanism. This was not fast enough to keep up with the high write speed requirements of a large-scale import. This release completely rewrites the storage layer of Weaviate to use a custom LSM-tree approach. This leads to considerably faster import times, often more than 100% faster than the previous version.
@@ -312,7 +312,7 @@ upgrading.
 Check [this github page](https://github.com/weaviate/weaviate/releases/tag/v1.5.0) for all the changes.
 
 
-# Changelog for version 1.4.0
+## Changelog for version 1.4.0
 
 * No breaking changes
 * New Features:
@@ -332,7 +332,7 @@ Check [this github page](https://github.com/weaviate/weaviate/releases/tag/v1.5.
 Check [this github page](https://github.com/weaviate/weaviate/releases/tag/v1.4.0) for all the changes.
 
 
-# Changelog for version 1.3.0
+## Changelog for version 1.3.0
 
 * No breaking changes
 * New feature: [Question Answering (Q&A) Module](/developers/weaviate/modules/reader-generator-modules/qna-transformers.md)
@@ -340,14 +340,14 @@ Check [this github page](https://github.com/weaviate/weaviate/releases/tag/v1.4.
 
 Check [this github page](https://github.com/weaviate/weaviate/releases/tag/v1.3.0) for all the changes.
 
-# Changelog for version 1.2.0
+## Changelog for version 1.2.0
 
 * No breaking changes
 * New feature: Introduction of the [Transformer Module](/developers/weaviate/modules/reader-generator-modules/qna-transformers.md)
 
 Check [this github page](https://github.com/weaviate/weaviate/releases/tag/v1.2.0) for all the changes.
 
-# Changelog for version 1.1.0
+## Changelog for version 1.1.0
 
 * No breaking changes
 * New feature: GraphQL `nearObject` search to get most similar object.
@@ -355,7 +355,7 @@ Check [this github page](https://github.com/weaviate/weaviate/releases/tag/v1.2.
 
 Check [this github page](https://github.com/weaviate/weaviate/releases/tag/v1.1.0) for all the changes.
 
-# Migration to version 1.0.0
+## Migration to version 1.0.0
 
 Weaviate version 1.0.0 was released on 12 January 2021, and consists of the major update of modularization. From version 1.0.0, Weaviate is modular, meaning that the underlying structure relies on a *pluggable* vector index, *pluggable* vectorization modules with possibility to extend with *custom* modules.
 
@@ -365,10 +365,10 @@ For client library specific changes, take a look at the change logs of the speci
 
 Moreover, a new version of the Console is released. Visit the Console documentation for more information.
 
-## Summary
+### Summary
 This contains most overall changes, but not all details. Those are documented in ["Changes"](#changes).
 
-### All RESTful API changes
+#### All RESTful API changes
 * from `/v1/schema/things/{ClassName}` to `/v1/schema/{ClassName}`
 * from `/v1/schema/actions/{ClassName} `to `/v1/schema/{ClassName}`from `/v1/schema/actions/{ClassName} `to `/v1/schema/{ClassName}`
 * from `/v1/things` to `/v1/objects`
@@ -380,7 +380,7 @@ This contains most overall changes, but not all details. Those are documented in
 * The `/v1/modules/` endpoint is introduced.
 * the `/v1/meta/` endpoint now contains module specific information in `"modules"`
 
-### All GraphQL API changes
+#### All GraphQL API changes
 * Removal of Things and Actions layer in query hierarchy
 * Reference properties of data objects are lowercase (previously uppercased)
 * Underscore properties, uuid and certainty are now grouped in the object `_additional`
@@ -388,27 +388,27 @@ This contains most overall changes, but not all details. Those are documented in
 * `nearVector(vector:[])` filter is introduced in `Get{}` query
 * `Explore (concepts: ["foo"]){}` query is changed to `Explore (near<MediaType>: ... ) {}`.
 
-### All data schema changes
+#### All data schema changes
 * Removal of Things and Actions
 * Per class and per property configuration is changed to support modules and vector index type settings.
 
-### All data object changes
+#### All data object changes
 * From `schema` to `properties` in the data object.
 
-### Contextionary
+#### Contextionary
 * Contextionary is renamed to the module `text2vec-contextionary`
 * `/v1/c11y/concepts` to `/v1/modules/text2vec-contextionary/concepts`
 * `/v1/c11y/extensions` to `/v1/modules/text2vec-contextionary/extensions`
 * `/v1/c11y/corpus` is removed
 
-### Other
+#### Other
 * Removal of `/things` and `/actions` in short and long beacons
 * Classification body is changed to support modularization
 * `DEFAULT_VECTORIZER_MODULE` is a new environment variable
 
-## Changes
+### Changes
 
-### Removal of Things and Actions
+#### Removal of Things and Actions
 `Things` and `Actions` are removed from the Data Schema. This comes with the following changes in the schema definition and API endpoints:
 1. **Data schema:** The `semantic kind` (`Things` and `Actions`) is removed from the Schema Endpoint. This means the URLs will change:
   * from `/v1/schema/things/{ClassName}` to `/v1/schema/{ClassName}`
@@ -459,14 +459,14 @@ This contains most overall changes, but not all details. Those are documented in
 
      * `weaviate://localhost/ClassName/4fbacd6e-1153-47b1-8cb5-f787a7f01718/propName`
 
-### Renaming /batching/ to /batch/
+#### Renaming /batching/ to /batch/
 
 * `/v1/batching/things` to `/v1/batch/objects`
 * `/v1/batching/actions` to `/v1/batch/objects`
 * `/v1/batching/references` to `/v1/batch/references`
 
 
-### From "schema" to "properties" in data object
+#### From "schema" to "properties" in data object
 
 The name "schema" on the data object is not intuitive and is replaced by "properties". The change looks like:
 
@@ -490,11 +490,11 @@ to
 }
 ```
 
-### Consistent casing in GraphQL properties
+#### Consistent casing in GraphQL properties
 
 Previously, reference properties in the schema definitions are always lowercase, yet in graphQL they needed to be uppercased. E.g.: `Article { OfAuthor { … on Author { name } } } }`, even though the property is defined as ofAuthor. New is that the casing in GraphQL reflects exactly the casing in the schema definition, thus the above example would become: `Article { ofAuthor { … on Author { name } } } }`
 
-### Additional data properties in GraphQL and RESTful API
+#### Additional data properties in GraphQL and RESTful API
 Since modularization, a module can contribute to the additional properties of a data object (thus are not fixed), which should be retrievable by the GraphQL and/or RESTful API.
 1. **REST**: `additional` properties (formerly named `"underscore"` properties) can be included in RESTful query calls like `?include=...`, e.g. `?include=classification`. The underscores will thus be removed from the names (e.g. `?include=_classification` is deprecated). In the Open API specifications, all additional properties will be grouped in the object `additional`. For example:
     ```json
@@ -555,10 +555,10 @@ Since modularization, a module can contribute to the additional properties of a 
    }
    ```
 
-### Modules RESTful endpoint
+#### Modules RESTful endpoint
 With the modularization of Weaviate, the `v1/modules/` endpoint is introduced.
 
-### GraphQL semantic search
+#### GraphQL semantic search
 
 With the modularization, it becomes possible to vectorize non-text objects. Search is no longer restricted to use the Contextionary's vectorization of text and data objects, but could also be applied to non-text objects or raw vectors. The formerly 'explore' filter in Get queries and 'Explore' queries in GraphQL were tied to text, but the following changes are made to this filter with the new version of Weaviate:
 
@@ -614,7 +614,7 @@ With the modularization, it becomes possible to vectorize non-text objects. Sear
     }
    ```
 
-### Data schema configuration
+#### Data schema configuration
 1. **Per-class configuration**
 
     With modularization, it is possible to configure per class the vectorizer module, module-specific configuration for the overall class, vector index type, and vector index type specific configuration:
@@ -694,7 +694,7 @@ With the modularization, it becomes possible to vectorize non-text objects. Sear
   }
   ```
 
-### RESTful /meta endpoint
+#### RESTful /meta endpoint
 
 The `/v1/meta` object now contains module specific information at in the newly introduced namespaced `modules.<moduleName>` property:
 
@@ -724,7 +724,7 @@ to
 }
 ```
 
-### Modular classification
+#### Modular classification
 
 Some classification types are tied to modules (e.g. the former "contextual" classification is tied to the `text2vec-contextionary` module. We make a distinction between fields which are always present and those which are type dependent. Additionally the API is improved by grouping `settings` and `filters` in separate properties. kNN classification is the only type of classification that is present with Weaviate Core without dependency on modules. The former "contextual" classification is tied to the `text2vec-contextionary` module, see [here](#text2vec-contextionary). An example of how the change looks like in the classification API POST body:
 
@@ -805,12 +805,7 @@ To
 }
 ```
 
-
-
-
-
-
-### text2vec-contextionary
+#### text2vec-contextionary
 The Contextionary becomes the first vectorization module of Weaviate, renamed to `text2vec-contextionary` in formal use. This brings the following changes:
 1. **RESTful** endpoint `/v1/c11y` changes to `v1/modules/text2vec-contextionary`:
    * `/v1/c11y/concepts` to `/v1/modules/text2vec-contextionary/concepts`
@@ -891,11 +886,11 @@ To
 }
 ```
 
-### Default vectorizer module
+#### Default vectorizer module
 The default vectorizer module can be specified in a new environment variable so that this doesn't have to be specified on every data class in the schema. The environment variable is `DEFAULT_VECTORIZER_MODULE`, which can be set to for example `DEFAULT_VECTORIZER_MODULE="text2vec-contextionary"`.
 
 
-# Official release notes
+### Official release notes
 Official release notes can be found on [GitHub](https://github.com/weaviate/weaviate/releases/tag/0.23.0).
 
 


### PR DESCRIPTION
### What's being changed:

Update H1s to H2s in the docs

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
