### PR TITLE
[docs] clarify max vector length

### DIFF
--- a/developers/weaviate/more-resources/faq.md
+++ b/developers/weaviate/more-resources/faq.md
@@ -214,9 +214,7 @@ For more information on the technical implementations, see [this video](https://
 
 #### What is the maximum number of vector dimensions for embeddings?
 
-There is (practically) no limit.
-
-We have tested embeddings with ~10k dimensions in the past. There may be a limit as the variable size increases, but for all practical purposes, it is unlimited.
+As the embedding is currently stored using `uint16`, the maximum possible length is currently 65535.
 
 ## Performance
 


### PR DESCRIPTION
### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
