### PR TITLE
Update typescript embedded docs

### DIFF
--- a/_includes/code/embedded.instantiate.mdx
+++ b/_includes/code/embedded.instantiate.mdx
@@ -24,17 +24,11 @@ import TabItem from '@theme/TabItem';
   <TabItem value="js" label="JavaScript / TypeScript">
 
   ```js
-  import weaviate from 'weaviate-ts-client';
+  import { weaviate, EmbeddedClient, EmbeddedOptions } from 'weaviate-ts-embedded';
 
-  const client = weaviate.client({
-    scheme: 'http',
-    host: 'localhost:6666',
-    embedded: new weaviate.EmbeddedOptions({
-      port: 6666,
-    }),
-  });
+  const client: EmbeddedClient = weaviate.client(new EmbeddedOptions());
 
-  await client.embedded?.start();
+  await client.embedded.start();
 
   const result = await client.data
     .creator()
@@ -45,7 +39,7 @@ import TabItem from '@theme/TabItem';
     })
     .do();
 
-  await client.embedded?.stop();
+  client.embedded.stop();
   ```
 
   </TabItem>

--- a/_includes/code/embedded.instantiate.simple.mdx
+++ b/_includes/code/embedded.instantiate.simple.mdx
@@ -17,21 +17,15 @@ import TabItem from '@theme/TabItem';
   <TabItem value="js" label="JavaScript / TypeScript">
 
   ```js
-  import weaviate from 'weaviate-ts-client';
+  import { weaviate, EmbeddedClient, EmbeddedOptions } from 'weaviate-ts-embedded';
 
-  const client = weaviate.client({
-    scheme: 'http',
-    host: 'localhost:6666',
-    embedded: new weaviate.EmbeddedOptions({
-      port: 6666,
-    }),
-  });
+  const client: EmbeddedClient = weaviate.client(new EmbeddedOptions());
 
-  await client.embedded?.start();
+  await client.embedded.start();
 
   // Work with Weaviate
 
-  await client.embedded?.stop();
+  client.embedded.stop();
   ```
 
   </TabItem>

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -129,7 +129,7 @@ The [Python client](../client-libraries/python.md) – `v3.15.4` or newer
 
 Due to use of server-side dependencies which are not available in the browser platform, the embedded TypeScript client has been split out into its own project. Therefore the original non-embedded TypeScript client can remain isomorphic.
 
-The TypeScript embedded client simply extends the original TypeScript client, so once instantiated it can be used exactly the same way to interact Weaviate. It can be installed with the following command:
+The TypeScript embedded client simply extends the original TypeScript client, so once instantiated it can be used exactly the same way to interact with Weaviate. It can be installed with the following command:
 
 ```
 npm install weaviate-ts-embedded

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -119,16 +119,23 @@ Embedded Weaviate is currently supported on Linux only.
 
 We are actively working to provide support for MacOS. We hope to share an update in the near future.
 
-### Language Clients
+## Language Clients
 
-Embedded Weaviate is supported in the following language clients:
+### Python
 
-* [Python client](../client-libraries/python.md) – `v3.15.4` or newer
+The [Python client](../client-libraries/python.md) – `v3.15.4` or newer
 
-Note that due to use of server-side dependencies which are not available in the browser platform, the embedded TypeScript client has been split out into its own project. Therefore the original non-embedded TypeScript client can remain isomorphic.
+### TypeScript
 
-The TypeScript embedded client simply extends the original TypeScript client, so once instantiated it can be used exactly the same way to interact Weaviate.
+Due to use of server-side dependencies which are not available in the browser platform, the embedded TypeScript client has been split out into its own project. Therefore the original non-embedded TypeScript client can remain isomorphic.
 
+The TypeScript embedded client simply extends the original TypeScript client, so once instantiated it can be used exactly the same way to interact Weaviate. It can be installed with the following command:
+
+```
+npm install weaviate-ts-embedded
+```
+
+GitHub repositories:
 * [TypeScript embedded client](https://github.com/weaviate/typescript-embedded)
 * [Original TypeScript client](https://github.com/weaviate/typescript-client)
 

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -62,6 +62,7 @@ The following modules are enabled by default:
 
 Additional modules can be enabled by setting additional environment variables as [laid out above](#embedded-options). For instance, to add a module called `backup-s3` to the set, you would pass it at instantiation as follows:
 
+Python:
 ```python
 import weaviate
 from weaviate.embedded import EmbeddedOptions
@@ -73,6 +74,19 @@ client = weaviate.Client(
         "backup-s3,text2vec-openai,text2vec-cohere,text2vec-huggingface,ref2vec-centroid,generative-openai,qna-openai"}
     )
 )
+```
+
+TypeScript:
+```ts
+import weaviate, { EmbeddedClient, EmbeddedOptions } from 'weaviate-ts-embedded';
+
+const client: EmbeddedClient = weaviate.client(
+  new EmbeddedOptions({
+    env: {
+      ENABLE_MODULES: "backup-s3,text2vec-openai,text2vec-cohere,text2vec-huggingface,ref2vec-centroid,generative-openai,qna-openai",
+    },
+  })
+);
 ```
 
 ## Starting Embedded Weaviate under the hood
@@ -110,7 +124,13 @@ We are actively working to provide support for MacOS. We hope to share an update
 Embedded Weaviate is supported in the following language clients:
 
 * [Python client](../client-libraries/python.md) – `v3.15.4` or newer
-* [TypeScript client](https://github.com/weaviate/typescript-client) – `v1.0.0` or newer
+
+Note that due to use of server-side dependencies which are not available in the browser platform, the embedded TypeScript client has been split out into its own project. Therefore the original non-embedded TypeScript client can remain isomorphic.
+
+The TypeScript embedded client simply extends the original TypeScript client, so once instantiated it can be used exactly the same way to interact Weaviate.
+
+* [TypeScript embedded client](https://github.com/weaviate/typescript-embedded)
+* [Original TypeScript client](https://github.com/weaviate/typescript-client)
 
 ## More Resources
 


### PR DESCRIPTION
### What's being changed:

The TypeScript embedded client has been split into it's own project, to retain isomorphism in the original client. This PR updates the docs related to that change


