### PR TITLE
[docs] update auth example; move link to k8 page from auth

### DIFF
--- a/developers/weaviate/configuration/authentication.md
+++ b/developers/weaviate/configuration/authentication.md
@@ -10,6 +10,10 @@ import Badges from '/_includes/badges.mdx';
 
 ## Overview
 
+:::info Using Kubernetes?
+See [this page](../installation/kubernetes.md#authentication-and-authorization) for how to set up `values.yaml` for authentication & authorization.
+:::
+
 Weaviate offers an optional authentication scheme using API keys and OpenID Connect (OIDC), which can enable various [authorizations](authorization.md) levels.
 
 When authentication is disabled, all anonymous requests will be granted access.
@@ -144,10 +148,6 @@ By default, Weaviate will validate that the token includes a specified client id
 :::
 
 ### Setting configuration options
-
-:::info Using Kubernetes?
-See [this page](../installation/kubernetes.md#authentication-and-authorization) for how to set up `values.yaml` for authentication & authorization.
-:::
 
 To use OpenID Connect (OIDC), the **respective environment variables** must be correctly configured in the configuration yaml for Weaviate.
 

--- a/developers/weaviate/installation/kubernetes.md
+++ b/developers/weaviate/installation/kubernetes.md
@@ -84,9 +84,11 @@ authentication:
   apikey:
     enabled: true
     allowed_keys:
-      - readonly-key,secr3tk3y
+      - readonly-key
+      - secr3tk3y
     users:
-      - readonly@example.com,admin@example.com
+      - readonly@example.com
+      - admin@example.com
   anonymous_access:
     enabled: false
   oidc:


### PR DESCRIPTION
### What's being changed:

- Update Kubernetes auth example code
- Move link to Kubernetes auth page from generic auth pages

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
