### PR TITLE
[Docs] V1.19 release

### DIFF
--- a/_includes/code/graphql.get.consistency.mdx
+++ b/_includes/code/graphql.get.consistency.mdx
@@ -1,0 +1,109 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="languages">
+<TabItem value="graphql" label="GraphQL">
+
+```graphql
+{
+  Get {
+    Article (consistencyLevel: ALL) {
+      name
+      _additional {
+        isConsistent
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+<TabItem value="py" label="Python">
+
+```python
+import weaviate
+from weaviate.data.replication import ConsistencyLevel
+
+client = weaviate.Client("http://localhost:8080")
+
+resp = (
+    client.query.get("Article", ["name"])
+    .with_additional("isConsistent")
+    .with_consistency_level(ConsistencyLevel.ALL)
+    .do()
+)
+
+print(f"resp: {resp}")
+```
+
+</TabItem>
+<TabItem value="js" label="JavaScript">
+
+```js
+const weaviate = require('weaviate-ts-client');
+
+const client = weaviate.client({
+  scheme: 'http',
+  host: 'localhost:8080',
+});
+
+const resp = await client.graphql
+  .get()
+  .withClassName('Article')
+  .withFields('_additional { id isConsistent }')
+  .withConsistencyLevel('ONE')
+  .do();
+
+console.log(`resp: ${JSON.stringify(resp)}`);
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import weaviate, { WeaviateClient } from 'weaviate-ts-client';
+
+const client: WeaviateClient = weaviate.client({
+  scheme: 'http',
+  host: 'localhost:8080',
+});
+
+const resp = await client.graphql
+  .get()
+  .withClassName('Article')
+  .withFields('_additional { id isConsistent }')
+  .withConsistencyLevel('ONE')
+  .do();
+
+console.log(`resp: ${JSON.stringify(resp)}`);
+```
+
+</TabItem>
+<TabItem value="go" label="Go">
+
+```go
+resp, err := client.GraphQL().Get().
+    WithClassName("Article").
+    WithFields(fields...).
+    WithConsistencyLevel(replication.ConsistencyLevel.ALL).
+    Do(ctx)
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+Field name = Field.builder().name("name").build();
+Field _additional = Field.builder()
+      .name("_additional")
+      .fields(new Field[]{Field.builder().name("isConsistent").build()})
+      .build();
+
+Result<GraphQLResponse> result = client.graphQL().get()
+      .withClassName("Article").withConsistencyLevel(ConsistencyLevel.ALL)
+      .withFields(name, _additional)
+      .run();
+```
+
+</TabItem>
+</Tabs>

--- a/_includes/datatypes.mdx
+++ b/_includes/datatypes.mdx
@@ -1,7 +1,7 @@
 | Weaviate Type     | Exact Data Type       | Formatting                                                                         |
 |-------------------|-----------------------|------------------------------------------------------------------------------------|
-| string            | string                | `"string"`                                                                         |
-| string[]          | list of strings       | `["string", "second string"]`                                                      |
+| text              | string                  | `string`                                                                           |
+| text[]            | list of strings         | `["string one", "string two"]`                                                     |
 | int               | int64 (*)             | `0`                                                                                |
 | int[]             | list of int64 (*)     | `[0, 1]`                                                                           |
 | boolean           | boolean               | `true`/`false`                                                                     |
@@ -10,9 +10,17 @@
 | number[]          | list of float64       | `[0.0, 1.1]`                                                                       |
 | date              | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-date)            |
 | date[]            | list of string        | [more info](/developers/weaviate/config-refs/datatypes#datatype-date)            |
-| text              | text                  | `string`                                                                           |
-| text[]            | list of texts         | `["string one", "string two"]`                                                     |
+| uuid | string | `c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c` |
+| uuid[] | list of string |  |
 | geoCoordinates    | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-geocoordinates)  |
 | phoneNumber       | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-phonenumber)     |
 | blob              | base64 encoded string | [more info](/developers/weaviate/config-refs/datatypes#datatype-blob)            |
 | *cross reference* | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-cross-reference) |
+
+
+### Deprecated types
+
+| Weaviate Type     | Exact Data Type       | Formatting          | Deprecated from |
+|-------------------|-----------------------|---------------------|-----------------|
+| string            | string                | `"string"` | `v1.19` |
+| string[]          | list of strings       | `["string", "second string"]` | `v1.19` |

--- a/_includes/datatypes.mdx
+++ b/_includes/datatypes.mdx
@@ -10,8 +10,8 @@
 | number[]          | list of float64       | `[0.0, 1.1]`                                                                       |
 | date              | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-date)            |
 | date[]            | list of string        | [more info](/developers/weaviate/config-refs/datatypes#datatype-date)            |
-| uuid | string | `c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c` |
-| uuid[] | list of string |  |
+| uuid | string | `"c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c"` |
+| uuid[] | list of strings | `["c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c", "36ddd591-2dee-4e7e-a3cc-eb86d30a4303"]` |
 | geoCoordinates    | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-geocoordinates)  |
 | phoneNumber       | string                | [more info](/developers/weaviate/config-refs/datatypes#datatype-phonenumber)     |
 | blob              | base64 encoded string | [more info](/developers/weaviate/config-refs/datatypes#datatype-blob)            |

--- a/developers/academy/_snippets/example_schema.mdx
+++ b/developers/academy/_snippets/example_schema.mdx
@@ -14,7 +14,7 @@
       "properties": [
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "description": "The title of the category",
           "name": "title",
@@ -56,12 +56,12 @@
         },
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "description": "Jeopardy round",
           ...
           "name": "round"
-        },     
+        },
         {
           "dataType": [
             "Category"
@@ -69,7 +69,7 @@
           "description": "The category of the question",
           ...
           "name": "hasCategory"
-        }        
+        }
         ...
       ],
       ...

--- a/developers/weaviate/_guides-further/_quick-start-with-the-text2vec-contextionary-module.md
+++ b/developers/weaviate/_guides-further/_quick-start-with-the-text2vec-contextionary-module.md
@@ -198,7 +198,8 @@ The output will look something like this:
                         "string"
                     ],
                     "description": "title of the article",
-                    "indexInverted": true,
+                    "indexFilterable": true,
+                    "indexSearchable": true,
                     "moduleConfig": {
                         "text2vec-contextionary": {
                             "skip": false,
@@ -212,7 +213,8 @@ The output will look something like this:
                         "string"
                     ],
                     "description": "url of the article",
-                    "indexInverted": false,
+                    "indexFilterable": false,
+                    "indexSearchable": false,
                     "moduleConfig": {
                         "text2vec-contextionary": {
                             "skip": false,

--- a/developers/weaviate/_guides-further/how-to-do-classification.md
+++ b/developers/weaviate/_guides-further/how-to-do-classification.md
@@ -161,7 +161,7 @@ Imagine you have a property for the popularity of the `Article` by the audience,
       "properties": [
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "description": "The popularity level",
           "name": "level"

--- a/developers/weaviate/api/graphql/aggregate.md
+++ b/developers/weaviate/api/graphql/aggregate.md
@@ -118,10 +118,11 @@ As such, this `Aggregate` query will retrieve the total object count in a class.
 <HowToGetObjectCount/>
 :::
 
-### GroupBy Argument
+### groupBy argument
+
 You can use a groupBy argument to get meta information about groups of data objects.
 
-The `groupBy{}` argument is structured as follows for the `Get{}` function:
+The `groupBy{}` argument is structured as follows for the `Aggregate{}` function:
 
 ```graphql
 {

--- a/developers/weaviate/api/graphql/get.md
+++ b/developers/weaviate/api/graphql/get.md
@@ -40,6 +40,178 @@ The above query will result in something like the following:
 The order of object retrieval is not guaranteed in a `Get` query without any search parameters or filters. Accordingly, such a `Get` query is not suitable for any substantive object retrieval strategy.
 :::
 
+### groupBy argument
+
+You can use a groupBy argument to retrieve groups of objects from Weaviate. This functionality offers the advantage of maintaining granular search results by searching through detailed or segmented objects (e.g. chunks of documents), while also enabling you to step back and view the broader context of the objects (e.g. documents as a whole).
+
+The `groupBy{}` argument is structured as follows for the `Get{}` function:
+
+```graphql
+{
+  Get{
+    <Class>(
+      <vectorSearchParameter>  # e.g. nearVector, nearObject, nearText
+      groupBy:{
+        path: [<propertyName>]  # Properties to group by
+        groups: <number>  # Max. number of groups
+        objectPerGroup: <number>  # Max. number of objects per group
+      }
+    ) {
+      _additional {
+        id  # An identifier for the group in this search
+        group {
+          id  # UUID of the group (if one exists)
+          groupedBy  # Properties grouped by
+          count  # Count of objects in this group
+          maxDistance  # Maximum distance from the group to the query vector
+          minDistance  # Minimum distance from the group to the query vector
+          hits {  # Where the actual properties for each grouped objects will be
+            <properties>  # Properties of the individual object
+            _additional {
+              id  # UUID of the individual object
+              vector  # The vector of the individual object
+              distance  # The distance from the individual object to the query vector
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Take a collection of `Passage` objects for example, each object belonging to a `Document`. If searching through `Passage` objects, you can group the results according to any property of the `Passage`, including the cross-reference property that represents the `Document` each `Passage` is associated with.
+
+The `groups` and `objectsPerGroup` limits are customizable. So in this example, you could retrieve the top 1000 objects and group them to identify the 3 most relevant `Document` objects, based on the top 3 `Passage` objects from each `Document`.
+
+More concretely, an query such as below:
+
+<details>
+  <summary>Example Get query with groupBy</summary>
+
+```graphql
+{
+  Get{
+    Passage(
+      limit: 100
+      nearObject:{
+        id: "00000000-0000-0000-0000-000000000001"
+      }
+      groupBy:{
+        path:["content"]
+        groups:2
+        objectsPerGroup:2
+      }
+    ){
+      _additional{
+        id
+        group{
+          id
+          count
+          groupValue
+          maxDistance
+          minDistance
+          hits{
+            content
+            ofDocument {
+              ... on Document{
+                _additional{
+                  id
+                }
+              }
+            }
+            _additional{
+              id
+              distance
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+</details>
+
+Will result in the following response:
+
+<details>
+  <summary>Corresponding response</summary>
+
+```json
+{
+  "data": {
+    "Get": {
+      "Passage": [
+        {
+          "_additional": {
+            "group": {
+              "count": 1,
+              "groupValue": "Content of passage 1",
+              "hits": [
+                {
+                  "_additional": {
+                    "distance": 0,
+                    "id": "00000000-0000-0000-0000-000000000001"
+                  },
+                  "content": "Content of passage 1",
+                  "ofDocument": [
+                    {
+                      "_additional": {
+                        "id": "00000000-0000-0000-0000-000000000011"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "id": 0,
+              "maxDistance": 0,
+              "minDistance": 0
+            },
+            "id": "00000000-0000-0000-0000-000000000001"
+          }
+        },
+        {
+          "_additional": {
+            "group": {
+              "count": 1,
+              "groupValue": "Content of passage 2",
+              "hits": [
+                {
+                  "_additional": {
+                    "distance": 0.00078231096,
+                    "id": "00000000-0000-0000-0000-000000000002"
+                  },
+                  "content": "Content of passage 2",
+                  "ofDocument": [
+                    {
+                      "_additional": {
+                        "id": "00000000-0000-0000-0000-000000000011"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "id": 1,
+              "maxDistance": 0.00078231096,
+              "minDistance": 0.00078231096
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+</details>
+
+:::note Performance vs `path` complexity
+Keep in mind that specifying a `path` value that requires resolving a large number of objects may be computationally expensive. For instance, setting the `path` above to `["ofDocument", "Document", "title"]` would require resolving all documents and may take considerably longer.
+:::
+
 ## Query beacon references
 
 If you've set a beacon reference in the schema, you can query it as follows:

--- a/developers/weaviate/api/graphql/get.md
+++ b/developers/weaviate/api/graphql/get.md
@@ -212,6 +212,19 @@ Will result in the following response:
 Keep in mind that specifying a `path` value that requires resolving a large number of objects may be computationally expensive. For instance, setting the `path` above to `["ofDocument", "Document", "title"]` would require resolving all documents and may take considerably longer.
 :::
 
+### Consistency levels
+
+:::info Available from `v1.19` onwards
+:::
+
+The `Get{}` function can be configured to return results with different levels of consistency. This is useful when you want to retrieve the most up-to-date data, or when you want to retrieve data as fast as possible.
+
+Read more about consistency levels [here](../../concepts/replication-architecture/consistency.md).
+
+import GraphQLGetConsistency from '/_includes/code/graphql.get.consistency.mdx';
+
+<GraphQLGetConsistency/>
+
 ## Query beacon references
 
 If you've set a beacon reference in the schema, you can query it as follows:

--- a/developers/weaviate/api/graphql/vector-search-parameters.md
+++ b/developers/weaviate/api/graphql/vector-search-parameters.md
@@ -160,7 +160,7 @@ The settings for BM25 are the [free parameters `k1` and `b`](https://en.wikipedi
       "name": "string",
       "description": "string",
       "dataType": [
-        "string"
+        "text"
       ],
       # Property-level settings override the class-level settings
       "invertedIndexConfig": {

--- a/developers/weaviate/api/graphql/vector-search-parameters.md
+++ b/developers/weaviate/api/graphql/vector-search-parameters.md
@@ -169,7 +169,8 @@ The settings for BM25 are the [free parameters `k1` and `b`](https://en.wikipedi
           "k1": 1.2
         }
       },
-      "indexInverted": true
+      "indexFilterable": true,
+      "indexSearchable": true,
     }
   ]
 }

--- a/developers/weaviate/api/rest/schema.md
+++ b/developers/weaviate/api/rest/schema.md
@@ -47,7 +47,8 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
             "text"
           ],
           "description": "category name",
-          "indexInverted": true,
+          "indexFilterable": true,
+          "indexSearchable": true,
           "moduleConfig": {
             "text2vec-contextionary": {
               "vectorizePropertyName": false
@@ -141,7 +142,8 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
             "text"
           ],
           "description": "title of the article",
-          "indexInverted": true,
+          "indexFilterable": true,
+          "indexSearchable": true,
           "moduleConfig": {
             "text2vec-contextionary": {
               "vectorizePropertyName": false
@@ -154,7 +156,8 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
             "text"
           ],
           "description": "url of the article",
-          "indexInverted": false,
+          "indexFilterable": true,
+          "indexSearchable": false,
           "moduleConfig": {
             "text2vec-contextionary": {
               "vectorizePropertyName": false
@@ -167,7 +170,8 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
             "text"
           ],
           "description": "summary of the article",
-          "indexInverted": true,
+          "indexFilterable": true,
+          "indexSearchable": true,
           "moduleConfig": {
             "text2vec-contextionary": {
               "vectorizePropertyName": false
@@ -258,7 +262,9 @@ Learn more about the schema configuration [here](/developers/weaviate/configurat
 | `properties` > `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | If true, the whole property will NOT be included in vectorization. Default is false, meaning that the object will be NOT be skipped. |
 | `properties` > `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | Whether the name of the property is used in the calculation for the vector position of data objects. Default is true. Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 | `properties` > `name` | body | string | The name of the property. Multiple words should be concatenated in camelCase, e.g. `nameOfAuthor`. |
-| `properties` > `indexInverted` | body | boolean | Should the data stored in this property be indexed? Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `properties` > `indexFilterable` (available from `v1.19`) | body | boolean | Should the data stored in this property be indexed with the filterable, Roaring Bitmap index? Read more on how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `properties` > `indexSearchable` (available from `v1.19`) | body | boolean | Should the data stored in this property be indexed to allow BM25/hybrid-search index? Read more on how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `properties` > `indexInverted` (deprecated) | body | boolean | Should the data stored in this property be indexed? Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 | `properties` > `tokenization` | body | string | Only for `string`/`text` props. Introduced in `v1.12.0`. Control how a field is tokenized in the inverted index. Defaults to `"word"`, can be set to `"field"`. Learn more about [property tokenization](/developers/weaviate/configuration/schema-configuration.md#property-tokenization).|
 | `invertedIndexConfig` > `stopwords` | body | object | Configure which words should be treated as stopwords and therefore be ignored on querying (stopwords are still indexed).<br/> Since `v1.18`, stopwords can be configured at runtime.<br/>See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--stopwords-stopword-lists). |
 | `invertedIndexConfig` > `indexTimestamps` | body | boolean | Maintain an inverted index for each object by its internal timestamps, currently including `creationTimeUnix` and `lastUpdateTimeUnix`.<br/>See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--indextimestamps). |
@@ -353,7 +359,9 @@ Parameters in the PUT body:
 | `properties` > `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | If true, the whole property will NOT be included in vectorization. Default is false, meaning that the object will be NOT be skipped. |
 | `properties` > `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | Whether the name of the property is used in the calculation for the vector position of data objects. Default is true. Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 | `properties` > `name` | body | string | The name of the property. Multiple words should be concatenated in camelCase, e.g. `nameOfAuthor`. |
-| `properties` > `indexInverted` | body | boolean | Should the data stored in this property be indexed? Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `properties` > `indexFilterable` (available from `v1.19`) | body | boolean | Should the data stored in this property be indexed with the filterable, Roaring Bitmap index? Read more on how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `properties` > `indexSearchable` (available from `v1.19`) | body | boolean | Should the data stored in this property be indexed to allow BM25/hybrid-search index? Read more on how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `properties` > `indexInverted` (deprecated) | body | boolean | Should the data stored in this property be indexed? Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 | `properties` > `tokenization` | body | string | Only for `string`/`text` props. Introduced in `v1.12.0`. Control how a field is tokenized in the inverted index. Defaults to `"word"`. If `string` is used, can be set to `"field"`. Learn more about [property tokenization](/developers/weaviate/configuration/schema-configuration.md#property-tokenization). |
 | `invertedIndexConfig` > `stopwords` | body | object | Configure which words should be treated as stopwords and therefore be ignored when querying (stopwords are still indexed).<br/> Since`v1.18`, stopwords can be configured at runtime.<br/>See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--stopwords-stopword-lists). |
 | `invertedIndexConfig` > `indexTimestamps` | body | boolean | Maintain an inverted index for each object by its internal timestamps, currently including `creationTimeUnix` and `lastUpdateTimeUnix` See [more details here](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--indextimestamps). |
@@ -382,7 +390,9 @@ POST v1/schema/{class_name}/properties
 | `moduleConfig`  > `text2vec-contextionary` > `skip` | body | boolean | If true, the whole property will NOT be included in vectorization. Default is false, meaning that the object will be NOT be skipped. |
 | `moduleConfig`  > `text2vec-contextionary` > `vectorizePropertyName` | body | boolean | Whether the name of the property is used in the calculation for the vector position of data objects. Default is true. Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 | `name` | body | string | The name of the property. Multiple words should be concatenated in camelCase like `nameOfAuthor`. |
-| `indexInverted` | body | boolean | Should the data stored in this property be indexed? Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `indexFilterable` (available from `v1.19`) | body | boolean | Should the data stored in this property be indexed with the filterable, Roaring Bitmap index? Read more on how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `indexSearchable` (available from `v1.19`) | body | boolean | Should the data stored in this property be indexed to allow BM25/hybrid-search index? Read more on how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
+| `indexInverted` (deprecated) | body | boolean | Should the data stored in this property be indexed? Learn more about how to [configure indexing in Weaviate](/developers/weaviate/configuration/schema-configuration.md#configure-semantic-indexing). |
 
 ### Example request for adding a property
 

--- a/developers/weaviate/api/rest/schema.md
+++ b/developers/weaviate/api/rest/schema.md
@@ -44,7 +44,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
       "properties": [
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "description": "category name",
           "indexInverted": true,
@@ -70,7 +70,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
       "properties": [
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "description": "Name of the publication",
           "name": "name"
@@ -111,7 +111,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
       "properties": [
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "description": "Name of the author",
           "name": "name"
@@ -138,7 +138,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
       "properties": [
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "description": "title of the article",
           "indexInverted": true,
@@ -151,7 +151,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
         },
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "description": "url of the article",
           "indexInverted": false,

--- a/developers/weaviate/client-libraries/python.md
+++ b/developers/weaviate/client-libraries/python.md
@@ -181,7 +181,7 @@ schema = {
     "properties": [
       {
         "dataType": [
-          "string"
+          "text"
         ],
         "description": "Name of the publication",
         "name": "name"
@@ -207,7 +207,7 @@ schema = {
     "properties": [
       {
         "dataType": [
-          "string"
+          "text"
         ],
         "description": "Title of the article",
         "name": "title"
@@ -226,7 +226,7 @@ schema = {
     "properties": [
       {
         "dataType": [
-            "string"
+            "text"
         ],
         "description": "Name of the author",
         "name": "name"
@@ -302,7 +302,7 @@ schema = {
       "properties": [
         {
           "name": "name",
-          "dataType": ["string"]
+          "dataType": ["text"]
         },
         {
           "name": "wroteBooks",
@@ -419,7 +419,7 @@ schema = {
       "properties": [
         {
           "name": "name",
-          "dataType": ["string"]
+          "dataType": ["text"]
         },
         {
           "name": "wroteBooks",
@@ -536,7 +536,7 @@ schema = {
       "properties": [
         {
           "name": "name",
-          "dataType": ["string"]
+          "dataType": ["text"]
         },
         {
           "name": "wroteBooks",

--- a/developers/weaviate/concepts/indexing.md
+++ b/developers/weaviate/concepts/indexing.md
@@ -121,7 +121,7 @@ When using vectorizers, you need to set vectorization at the class and property 
             }
         },
         "dataType": [
-            "string"
+            "text"
         ],
         "name": "name"
     }]

--- a/developers/weaviate/concepts/interface.md
+++ b/developers/weaviate/concepts/interface.md
@@ -129,6 +129,12 @@ There are currently three main functions in a GraphQL request: "Get{}", "Explore
 2. **Explorative & fuzzy search: `Explore {}`**: to search in a fuzzy way, when you don't know the data schema and class names.
 3. **Data analysis (meta data): `Aggregate {}`**: to search for meta data, and do data analysis of data aggregations.
 
+## gRPC API support
+
+Starting with version `1.19`, Weaviate is introducing support for the gRPC (gRPC Remote Procedure Calls) API, with the aim of making Weaviate even faster over time.
+
+This will not result in any user-facing API changes. As of May 2023, gRPC has been added at a very small scale, with the goal of rolling it out further over time to the core library as well as the clients.
+
 ## Weaviate Console
 
 The [Weaviate Console](https://console.weaviate.cloud) is a dashboard to manage Weaviate clusters from WCS, and access Weaviate instances running elsewhere. You can use the Query Module to make GraphQL queries.

--- a/developers/weaviate/concepts/prefiltering.md
+++ b/developers/weaviate/concepts/prefiltering.md
@@ -38,13 +38,21 @@ In the section about Storage, [we have described in detail which parts make up a
 
 ### Pre-filtering with Roaring Bitmaps
 
+:::info Available for Weaviate versions `1.18` and up
+:::
+
 Weaviate versions `1.18.0` and up use Roaring Bitmaps through the `RoaringSet` data type. Roaring Bitmaps employ various strategies to add efficiencies, whereby it divides data into chunks and applies an appropriate storage strategy to each one. This enables high data compression and set operations speeds, resulting in faster filtering speeds for Weaviate.
 
 If you are dealing with a large dataset, this will likely improve your filtering performance significantly and we therefore encourage you to migrate and re-index.
 
 In addition, our team maintains our underlying Roaring Bitmap library to address any issues and make improvements as needed.
 
-We note that the current implementation is not yet applicable to filtering `text` and `string` datatypes, which is an area that we aim to tackle in the future.
+#### Roaring Bitmaps for `text` properties
+
+:::info Available for Weaviate versions `1.19` and up
+:::
+
+A roaring bitmap index for `text` properties is available from `1.19` and up, and it is implemented using two separate (`filterable` & `searchable`) indexes, which replaces the existing single index. You can configure the new `indexFilterable` and `indexSearchable` parameters to determine whether to create the roaring set index and the BM25-suitable Map index, respectively. (Both are enabled by default.)
 
 #### Migration to Roaring Bitmaps
 

--- a/developers/weaviate/concepts/replication-architecture/consistency.md
+++ b/developers/weaviate/concepts/replication-architecture/consistency.md
@@ -83,7 +83,10 @@ Read operations are GET requests to data objects in Weaviate. Like write, read c
 Prior to `v1.18`, read consistency was tunable only for requests that [obtained an object by id](../../api/rest/objects.md#get-a-data-object), and all other read requests had a consistency of `ALL`.
 :::
 
-Starting with `v1.18`, the following consistency levels are applicable to most read operations:
+The following consistency levels are applicable to most read operations:
+
+- Starting with `v1.18`, consistency levels are applicable to REST endpoint operations.
+- Starting with `v1.19`, consistency levels are applicable to GraphQL `Get` requests.
 
 * **ONE** - a read response must be returned by at least one replica. This is the fastest (most available), but least consistent option.
 * **QUORUM** - a response must be returned by `QUORUM` amount of replica nodes. `QUORUM` is calculated as _n / 2 + 1_, where _n_ is the number of replicas (replication factor). For example, using a replication factor of 6, the quorum is 4, which means the cluster can tolerate 2 replicas down.

--- a/developers/weaviate/concepts/vector-index.md
+++ b/developers/weaviate/concepts/vector-index.md
@@ -54,7 +54,7 @@ Example of a class [vector index configuration in your data schema](/developers/
     {
       "name": "title",
       "description": "string",
-      "dataType": ["string"]
+      "dataType": ["text"]
     }
   ],
   "vectorIndexType": " ... ",

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -24,13 +24,19 @@ import DataTypes from '/_includes/datatypes.mdx';
 
 (*) Although Weaviate supports `int64`, GraphQL currently only supports `int32`, and does not support `int64`. This means that currently _integer_ data fields in Weaviate with integer values larger than `int32`, will not be returned using GraphQL queries. We are working on solving this [issue](https://github.com/weaviate/weaviate/issues/1563). As current workaround is to use a `string` instead.
 
-## DataType: string vs. text
+## DataType: `text`
 
-There are two data types dedicated to saving textual information: `string` and `text`. They exhibit slightly different tokenization behavior, and `string` also optionally allows the property to be indexed without tokenization.
+### Tokenization configuration
 
-Refer to [this section](../configuration/schema-configuration.md#property-tokenization) on the difference between the two types.
+Refer to [this section](../configuration/schema-configuration.md#property-tokenization) on how to configure the tokenization behavior of a `text` property.
 
-## DataType: date
+### `string` (deprecated)
+
+Prior to `v1.19`, Weaviate supported an additional datatype `string`, which was differentiated by tokenization behavior to `text`. As of `v1.19`, this type is deprecated and will be removed in a future release.
+
+Please use `text` instead, which now supports all tokenizations options previously available through `string`.
+
+## DataType: `date`
 
 Weaviate requires an [RFC 3339](https://datatracker.ietf.org/doc/rfc3339/) formatted date that includes the time and the offset.
 
@@ -42,7 +48,7 @@ For example:
 
 In case you want to add a list of dates as one Weaviate data value, you can use above formatting in an array, for example like: `["1985-04-12T23:20:50.52Z", "1937-01-01T12:00:27.87+00:20"]`
 
-## DataType: geoCoordinates
+## DataType: `geoCoordinates`
 
 Weaviate allows you to store geo coordinates related to a thing or action. When querying Weaviate, you can use this type to find items in a radius around this area. A geo coordinate value is a float, and is processed as [decimal degree](https://en.wikipedia.org/wiki/Decimal_degrees) according to the [ISO standard](https://www.iso.org/standard/39242.html#:~:text=For%20computer%20data%20interchange%20of,minutes%2C%20seconds%20and%20decimal%20seconds).
 
@@ -59,7 +65,7 @@ An example of how geo coordinates are used in a data object:
 }
 ```
 
-## DataType: phoneNumber
+## DataType: `phoneNumber`
 
 There is a special, primitive data type `phoneNumber`. When a phone number is added to this field, the input will be normalized and validated, unlike the single fields as `number` and `string`. The data field is an object, as opposed to a flat type similar to `geoCoordinates`. The object has multiple fields:
 
@@ -83,7 +89,7 @@ There are two fields that accept input. `input` must always be set, while `defau
 
 As you can see in the code snippet above, all other fields are read-only. These fields are filled automatically, and will appear when reading back a field of type `phoneNumber`.
 
-## DataType: blob
+## DataType: `blob`
 
 The datatype blob accepts any binary data. The data should be `base64` encoded, and passed as a `string`. Characteristics:
 * Weaviate doesn't make assumptions about the type of data that is encoded. A module (e.g. `img2vec`) can investigate file headers as it wishes, but Weaviate itself does not do this.
@@ -129,7 +135,7 @@ $ curl \
     http://localhost:8080/v1/objects
 ```
 
-## DataType: cross-reference
+## DataType: `cross-reference`
 
 The [`cross-reference`](../more-resources/glossary.md) type is the graph element of Weaviate: you can create a link from one object to another. In the schema you can define multiple classes to which a property can point, in a list of strings. The strings in the `dataType` list of are names of classes that exist elsewhere in the schema. For example:
 

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -30,11 +30,29 @@ import DataTypes from '/_includes/datatypes.mdx';
 
 Refer to [this section](../configuration/schema-configuration.md#property-tokenization) on how to configure the tokenization behavior of a `text` property.
 
-### `string` (deprecated)
+:::tip `string` is deprecated
 
 Prior to `v1.19`, Weaviate supported an additional datatype `string`, which was differentiated by tokenization behavior to `text`. As of `v1.19`, this type is deprecated and will be removed in a future release.
 
 Please use `text` instead, which now supports all tokenizations options previously available through `string`.
+:::
+## DataType: `cross-reference`
+
+The [`cross-reference`](../more-resources/glossary.md) type is the graph element of Weaviate: you can create a link from one object to another. In the schema you can define multiple classes to which a property can point, in a list of strings. The strings in the `dataType` list of are names of classes that exist elsewhere in the schema. For example:
+
+```json
+{
+  "properties": [
+    {
+      "name": "hasWritten",
+      "dataType": [
+        "Article",
+        "Blog"
+      ]
+    }
+  ]
+}
+```
 
 ## DataType: `date`
 
@@ -47,47 +65,6 @@ For example:
 - `"1937-01-01T12:00:27.87+00:20"`.
 
 In case you want to add a list of dates as one Weaviate data value, you can use above formatting in an array, for example like: `["1985-04-12T23:20:50.52Z", "1937-01-01T12:00:27.87+00:20"]`
-
-## DataType: `geoCoordinates`
-
-Weaviate allows you to store geo coordinates related to a thing or action. When querying Weaviate, you can use this type to find items in a radius around this area. A geo coordinate value is a float, and is processed as [decimal degree](https://en.wikipedia.org/wiki/Decimal_degrees) according to the [ISO standard](https://www.iso.org/standard/39242.html#:~:text=For%20computer%20data%20interchange%20of,minutes%2C%20seconds%20and%20decimal%20seconds).
-
-An example of how geo coordinates are used in a data object:
-
-```json
-{
-  "City": {
-    "location": {
-      "latitude": 52.366667,
-      "longitude": 4.9
-    }
-  }
-}
-```
-
-## DataType: `phoneNumber`
-
-There is a special, primitive data type `phoneNumber`. When a phone number is added to this field, the input will be normalized and validated, unlike the single fields as `number` and `string`. The data field is an object, as opposed to a flat type similar to `geoCoordinates`. The object has multiple fields:
-
-```yaml
-{
-  "phoneNumber": {
-    "input": "020 1234567",                       // Required. Raw input in string format
-    "defaultCountry": "nl",                       // Required if only a national number is provided, ISO 3166-1 alpha-2 country code. Only set if explicitly set by the user.
-    "internationalFormatted": "+31 20 1234567",   // Read-only string
-    "countryCode": 31,                            // Read-only unsigned integer, numerical country code
-    "national": 201234567,                        // Read-only unsigned integer, numerical representation of the national number
-    "nationalFormatted": "020 1234567",           // Read-only string
-    "valid": true                                 // Read-only boolean. Whether the parser recognized the phone number as valid
-  }
-}
-```
-
-There are two fields that accept input. `input` must always be set, while `defaultCountry` must only be set in specific situations. There are two scenarios possible:
-- When you entered an international number (e.g. `"+31 20 1234567"`) to the `input` field, no `defaultCountry` needs to be entered. The underlying parser will automatically recognize the number's country.
-- When you entered a national number (e.g. `"020 1234567"`), you need to specify the country in `defaultCountry` (in this case, `"nl"`), so that the parse can correctly convert the number into all formats. The string in `defaultCountry` should be an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
-
-As you can see in the code snippet above, all other fields are read-only. These fields are filled automatically, and will appear when reading back a field of type `phoneNumber`.
 
 ## DataType: `blob`
 
@@ -134,24 +111,60 @@ $ curl \
   }' \
     http://localhost:8080/v1/objects
 ```
+## DataType: `uuid`
 
-## DataType: `cross-reference`
+:::info Available from `v1.19` onwards
+:::
 
-The [`cross-reference`](../more-resources/glossary.md) type is the graph element of Weaviate: you can create a link from one object to another. In the schema you can define multiple classes to which a property can point, in a list of strings. The strings in the `dataType` list of are names of classes that exist elsewhere in the schema. For example:
+The dedicated `uuid` and `uuid[]` data types are more space-efficient than storing the same data as text.
+
+-   Each `uuid` is a 128-bit (16-byte) number.
+-   The filterable index uses roaring bitmaps.
+
+:::note Aggregate/sort currently not possible
+It is currently not possible to aggregate or sort by `uuid` or `uuid[]` types.
+:::
+
+## DataType: `geoCoordinates`
+
+Weaviate allows you to store geo coordinates related to a thing or action. When querying Weaviate, you can use this type to find items in a radius around this area. A geo coordinate value is a float, and is processed as [decimal degree](https://en.wikipedia.org/wiki/Decimal_degrees) according to the [ISO standard](https://www.iso.org/standard/39242.html#:~:text=For%20computer%20data%20interchange%20of,minutes%2C%20seconds%20and%20decimal%20seconds).
+
+An example of how geo coordinates are used in a data object:
 
 ```json
 {
-  "properties": [
-    {
-      "name": "hasWritten",
-      "dataType": [
-        "Article",
-        "Blog"
-      ]
+  "City": {
+    "location": {
+      "latitude": 52.366667,
+      "longitude": 4.9
     }
-  ]
+  }
 }
 ```
+
+## DataType: `phoneNumber`
+
+There is a special, primitive data type `phoneNumber`. When a phone number is added to this field, the input will be normalized and validated, unlike the single fields as `number` and `string`. The data field is an object, as opposed to a flat type similar to `geoCoordinates`. The object has multiple fields:
+
+```yaml
+{
+  "phoneNumber": {
+    "input": "020 1234567",                       // Required. Raw input in string format
+    "defaultCountry": "nl",                       // Required if only a national number is provided, ISO 3166-1 alpha-2 country code. Only set if explicitly set by the user.
+    "internationalFormatted": "+31 20 1234567",   // Read-only string
+    "countryCode": 31,                            // Read-only unsigned integer, numerical country code
+    "national": 201234567,                        // Read-only unsigned integer, numerical representation of the national number
+    "nationalFormatted": "020 1234567",           // Read-only string
+    "valid": true                                 // Read-only boolean. Whether the parser recognized the phone number as valid
+  }
+}
+```
+
+There are two fields that accept input. `input` must always be set, while `defaultCountry` must only be set in specific situations. There are two scenarios possible:
+- When you entered an international number (e.g. `"+31 20 1234567"`) to the `input` field, no `defaultCountry` needs to be entered. The underlying parser will automatically recognize the number's country.
+- When you entered a national number (e.g. `"020 1234567"`), you need to specify the country in `defaultCountry` (in this case, `"nl"`), so that the parse can correctly convert the number into all formats. The string in `defaultCountry` should be an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
+
+As you can see in the code snippet above, all other fields are read-only. These fields are filled automatically, and will appear when reading back a field of type `phoneNumber`.
 
 ### Number of linked instances
 

--- a/developers/weaviate/configuration/indexes.md
+++ b/developers/weaviate/configuration/indexes.md
@@ -59,7 +59,7 @@ Example of a class could be [configured in your data schema](/developers/weaviat
     {
       "name": "title",
       "description": "string",
-      "dataType": ["string"]
+      "dataType": ["text"]
     }
   ],
   "vectorIndexType": "hnsw",
@@ -115,7 +115,7 @@ The inverted index is by default _on_. You can simply turn it of like this:
         {
             "indexInverted": false, // <== turn it off by setting `indexInverted` to false
             "dataType": [
-                "string"
+                "text"
             ],
             "name": "name"
         }
@@ -158,7 +158,7 @@ If we don't want to index the `Authors` we can simply skip all indices (vector _
         {
             "indexInverted": false, // <== disable inverted index for this property
             "dataType": [
-                "string"
+                "text"
             ],
             "description": "The name of the Author",
             "name": "name"

--- a/developers/weaviate/configuration/indexes.md
+++ b/developers/weaviate/configuration/indexes.md
@@ -102,18 +102,21 @@ Note that the vector index type only specifies how the vectors of data objects a
 
 ## Inverted index
 
-### Configure the inverted index
+### Configure the inverted index - for `text`
 
-In contrast to the ANN index, there are very few configurable parameters for an inverted index. It's on or it's off and indexes on a property level.
+There are two indexes for filtering or searching the data, where the first (filterable) is for building a fast, Roaring Bitmaps index, and the second (searchable) index is for a BM25 or hybrid search.
 
-The inverted index is by default _on_. You can simply turn it of like this:
+So there are `indexFilterable` and `indexSearchable` keys that can be on or off on a property level.
 
-```js
+Both are by default _on_. You can simply turn each off like this:
+
+```json
 {
     "class": "Author",
     "properties": [ // <== note that the inverted index is set per property
         {
-            "indexInverted": false, // <== turn it off by setting `indexInverted` to false
+            "indexFilterable": false,  // <== turn off the filterable (Roaring Bitmap index) by setting `indexFilterable` to false
+            "indexSearchable": false,  // <== turn off the searchable (for BM25/hybrid) by setting `indexSearchable` to false
             "dataType": [
                 "text"
             ],
@@ -125,8 +128,10 @@ The inverted index is by default _on_. You can simply turn it of like this:
 
 A rule of thumb to follow when determining if you turn it on or off is this: _if you don't need it to query, turn it off._
 
-:::note
-We support both `string` and `text` data types, they play a role in tokenization in the inverted index, more information can be found [here](/developers/weaviate/config-refs/datatypes.md#datatype-string-vs-text).
+:::tip Data types and indexes
+
+Both `indexFilterable` and `indexSearchable` are available for all types of data. However, `indexSearchable` is only relevant for `text`/`text[]`, and in other cases it will be simply ignored.
+
 :::
 
 You can also enable an inverted index to search [based on timestamps](/developers/weaviate/configuration/schema-configuration.md#invertedindexconfig--indextimestamps).
@@ -156,7 +161,8 @@ If we don't want to index the `Authors` we can simply skip all indices (vector _
     },
     "properties": [
         {
-            "indexInverted": false, // <== disable inverted index for this property
+            "indexFilterable": true,  // <== disable filterable index for this property
+            "indexSearchable": true,  // <== disable searchable index for this property
             "dataType": [
                 "text"
             ],
@@ -164,7 +170,7 @@ If we don't want to index the `Authors` we can simply skip all indices (vector _
             "name": "name"
         },
         {
-            "indexInverted": false, // <== disable inverted index for this property
+            "indexFilterable": true,  // <== disable filterable index for this property
             "dataType": [
                 "int"
             ],
@@ -172,7 +178,7 @@ If we don't want to index the `Authors` we can simply skip all indices (vector _
             "name": "age"
         },
         {
-            "indexInverted": false, // <== disable inverted index for this property
+            "indexFilterable": true,  // <== disable filterable index for this property
             "dataType": [
                 "date"
             ],
@@ -180,7 +186,7 @@ If we don't want to index the `Authors` we can simply skip all indices (vector _
             "name": "born"
         },
         {
-            "indexInverted": false, // <== disable inverted index for this property
+            "indexFilterable": true,  // <== disable filterable index for this property
             "dataType": [
                 "boolean"
             ],
@@ -188,7 +194,8 @@ If we don't want to index the `Authors` we can simply skip all indices (vector _
             "name": "wonNobelPrize"
         },
         {
-            "indexInverted": false, // <== disable inverted index for this property
+            "indexFilterable": true,  // <== disable filterable index for this property
+            "indexSearchable": true,  // <== disable searchable index for this property
             "dataType": [
                 "text"
             ],

--- a/developers/weaviate/configuration/replication.md
+++ b/developers/weaviate/configuration/replication.md
@@ -28,7 +28,7 @@ Replication is disabled by default and can be enabled per data class in the [sch
     {
       "name": "exampleProperty",
       "dataType": [
-        "string"
+        "text"
       ]
     }
   ],

--- a/developers/weaviate/configuration/schema-configuration.md
+++ b/developers/weaviate/configuration/schema-configuration.md
@@ -44,6 +44,20 @@ It has the following characteristics:
 * When a previously unseen class is imported, the class is created alongside all the properties.
 * Weaviate also automatically recognizes array datatypes, such as `string[]`, `int[]`, `text[]`, `number[]`, `boolean[]` and `date[]`.
 
+#### Datatypes
+
+Weaviate needs to guess the datatypes based on the objects it sees. For this you can set some preferences. e.g.
+
+* `AUTOSCHEMA_DEFAULT_STRING=text` would tell Weaviate that when it sees a prop of type `string`, it should treat it as `text` (as opposed to `string`)
+* `AUTOSCHEMA_DEFAULT_NUMBER=number` would tell Weaviate that when its sees a numerical value, it should treat it as number as opposed to `int`, etc.
+* `AUTOSCHEMA_DEFAULT_DATE=date` respectively
+
+The above configurable defaults will themselves default to something reasonable, if they are not set.
+
+In addition, we need to catch types we do not support at all:
+* Any map type is forbidden, unless it clearly matches one of the two supported types `phoneNumber` or `geoCoordinates`.
+* Any array type is forbidden, unless it is clearly a reference-type. In this case, Weaviate needs to resolve the beacon and see what the class of the resolved beacon is, since it needs the ClassName to be able to alter the schema.
+
 ### Class
 
 A class describes a data object in the form of a noun (e.g., *Person*,
@@ -54,9 +68,9 @@ recognize, it will not accept the schema.
 
 Classes are always written with a **capital letter** first. This helps in
 distinguishing classes from primitive data types when used in properties. For
-example, `dataType: ["string"]` means that a property is a string, whereas
-`dataType: ["String"]` means that a property is a cross-reference type to a
-class named `String`.
+example, `dataType: ["text"]` means that a property is a string, whereas
+`dataType: ["Text"]` means that a property is a cross-reference type to a
+class named `Text`.
 
 After the first letter, classes may use any GraphQL-compatible characters. The
 current (as of `v1.10.0+`) class name validation regex is
@@ -89,7 +103,7 @@ An example of a complete class object including properties:
       "name": "string",                     // The name of the property
       "description": "string",              // A description for your reference
       "dataType": [                         // The data type of the object as described above. When creating cross-references, a property can have multiple data types, hence the array syntax.
-        "string"
+        "text"
       ],
       "moduleConfig": {                     // Module-specific settings
         "text2vec-contextionary": {
@@ -312,7 +326,7 @@ An example of a complete property object:
     "name": "string",                     // The name of the property
     "description": "string",              // A description for your reference
     "dataType": [                         // The data type of the object as described above. When creating cross-references, a property can have multiple dataTypes.
-    "string"
+      "text"
     ],
     "tokenization": "word",               // Split field contents into word-tokens when indexing into the inverted index. See Property Tokenization below for more detail.
     "moduleConfig": {                     // Module-specific settings
@@ -325,7 +339,89 @@ An example of a complete property object:
 }
 ```
 
-### Concatenate classes and properties
+### Property tokenization
+
+You can customize how `text` data is tokenized and indexed in the inverted index.
+
+:::note
+This feature was introduced in `v1.12.0`. This applies to the BM25/hybrid searching and filtering.
+:::
+
+:::caution `string` is deprecated
+`string` has been deprecated from Weaviate `v1.19` onwards. Please use `text` instead.
+:::
+
+Tokenization of `text` properties can be customized using `tokenization` property in the schema for the relevant class.
+
+Each token will be indexed separately in the inverted index. This would cause filtering, for example, to behave differently. For example, if you have a `text` property with the value `Hello, (beautiful) world`, the following table shows how the tokens would be indexed for each tokenization method:
+
+| Tokenization Method | Explanation                                                 | Example Input           | Indexed Tokens                                    |
+|---------------------|-------------------------------------------------------------|-------------------------|---------------------------------------------------|
+| `word` (default)    | Keep alpha-numeric characters, lowercase them, and split by whitespace. | `Hello, (beautiful) world` | `hello`, `beautiful`, `world`                   |
+| `whitespace`        | Split the text on whitespace.                               | `Hello, (beautiful) world` | `Hello,`, `(beautiful)`, `world`                |
+| `lowercase`         | Lowercase the text and split on whitespace.                 | `Hello, (beautiful) world` | `hello,`, `(beautiful)`, `world`                |
+| `field`             | Index the whole field after trimming whitespace characters. | `Hello, (beautiful) world` | `Hello, (beautiful) world`                      |
+
+<details>
+  <summary>
+    Pre <code>v1.19</code> tokenization behavior
+  </summary>
+
+**Tokenization with `text`**
+
+`text` properties are always tokenized, and by all non-alphanumerical characters. Tokens are then lowercased before being indexed. For example, a `text` property value `Hello, (beautiful) world`, would be indexed by tokens `hello`, `beautiful`, and `world`.
+
+Each of these tokens will be indexed separately in the inverted index. This means that a search for any of the three tokens with the `Equal` operator under `valueText` would return this object regardless of the case.
+
+**Tokenization with `string`**
+
+`string` properties allow the user to set whether it should be tokenized, by setting the `tokenization` class property.
+
+If `tokenization` for a `string` property is set to `word`, the field will be tokenized. The tokenization behavior for `string` is different from `text`, however, as `string` values are only tokenized by white spaces, and casing is not altered.
+
+So, a `string` property value `Hello, (beautiful) world` with `tokenization` set as `word` would be split into the tokens `Hello,`, `(beautiful)`, and `world`. In this case, the `Equal` operator would need the exact match including non-alphanumerics and case (e.g. `Hello,`, not `hello`) to retrieve this object.
+
+`string` properties can also be indexed as the entire value, by setting `tokenization` as `field`. In such a case the `Equal` operator would require the value `Hello, (beautiful) world` before returning the object as a match.
+
+**Default behavior**
+
+`text` and `string` properties default to `word` level tokenization for backward-compatibility.
+
+</details>
+
+## Configure semantic indexing
+
+:::info
+Only for `text2vec-*` modules
+:::
+
+Weaviate creates one vector per object by concatenating together the class name, followed by the [`text` properties](#property-tokenization) of the object sorted by the property name, then lowercasing and vectorizing the resulting string. For the precise sequence and how to configure the vectorization details, see [Tweaking text2vec vectorization](/blog/pulling-back-the-curtains-on-text2vec/#tweaking-text2vec-vectorization-in-weaviate).
+
+For example, this data object,
+
+```js
+Article = {
+  summery: "Cows lose their jobs as milk prices drop",
+  text: "As his 100 diary cows lumbered over for their Monday..."
+}
+```
+
+will be vectorized as:
+
+```md
+article cows lose their jobs as milk prices drop summary as his diary cows lumbered over for their monday...
+```
+
+By default, the `class name` and all property `values` *will* be taken in the calculation, but the property `names` *will not* be indexed. There are four ways in which you can configure the indexing. <!-- TODO: clarify -->
+
+### Default distance metric
+
+Weaviate allows you to configure the `DEFAULT_VECTOR_DISTANCE_METRIC` which will be applied to every class unless overridden individually. You can choose from: `cosine` (default), `dot`, `l2-squared`, `manhattan`, `hamming`.
+
+### Class/property names (`text2vec-contextionary` only)
+
+:::info Applicable to `text2vec-contextionary` module only
+:::
 
 Sometimes you might want to use multiple words to set as a class or property
 definition. For example, the year a person is born in, you might want to define
@@ -355,78 +451,6 @@ Author
   wroteArticles
   writesFor
 ```
-
-### Property tokenization
-
-:::note
-This feature was introduced in `v1.12.0`.
-:::
-
-Properties with `text` and `string` exhibit different tokenization behavior when indexing and
-searching through the inverted index.
-
-#### Tokenization with `text`
-
-`text` properties are always tokenized, and by all non-alphanumerical characters. Tokens are then lowercased before being indexed. For example, a `text` property value `Hello, (beautiful) world`, would be indexed by tokens `hello`, `beautiful`, and `world`.
-
-Each of these tokens will be indexed separately in the inverted index. This means that a search for any of the three tokens with the `Equal` operator under `valueText` would return this object regardless of the case.
-
-#### Tokenization with `string`
-
-`string` properties allow the user to set whether it should be tokenized, by setting the `tokenization` class property.
-
-If `tokenization` for a `string` property is set to `word`, the field will be tokenized. The tokenization behavior for `string` is different from `text`, however, as `string` values are only tokenized by white spaces, and casing is not altered.
-
-So, a `string` property value `Hello, (beautiful) world` with `tokenization` set as `word` would be split into the tokens `Hello,`, `(beautiful)`, and `world`. In this case, the `Equal` operator would need the exact match including non-alphanumerics and case (e.g. `Hello,`, not `hello`) to retrieve this object.
-
-`string` properties can also be indexed as the entire value, by setting `tokenization` as `field`. In such a case the `Equal` operator would require the value `Hello, (beautiful) world` before returning the object as a match.
-
-#### Default behavior
-
-`text` and `string` properties default to `word` level tokenization for backward-compatibility.
-
-## Configure semantic indexing
-
-:::info
-Only for `text2vec-*` modules
-:::
-
-Weaviate creates one vector per object by concatenating together the class name, followed by the [`string` and `text` properties](#property-tokenization) of the object sorted by the property name, then lowercasing and vectorizing the resulting string. For the precise sequence and how to configure the vectorization details, see [Tweaking text2vec vectorization](/blog/pulling-back-the-curtains-on-text2vec/#tweaking-text2vec-vectorization-in-weaviate).
-
-For example, this data object,
-
-```js
-Article = {
-  summery: "Cows lose their jobs as milk prices drop",
-  text: "As his 100 diary cows lumbered over for their Monday..."
-}
-```
-
-will be vectorized as:
-
-```md
-article cows lose their jobs as milk prices drop summary as his diary cows lumbered over for their monday...
-```
-
-By default, the `class name` and all property `values` *will* be taken in the calculation, but the property `names` *will not* be indexed. There are four ways in which you can configure the indexing. <!-- TODO: clarify -->
-
-### Datatypes
-
-Weaviate needs to guess the datatypes based on the objects it sees. For this you can set some preferences. e.g.
-
-* `AUTOSCHEMA_DEFAULT_STRING=text` would tell Weaviate that when it sees a prop of type `string`, it should treat it as `text` (as opposed to `string`)
-* `AUTOSCHEMA_DEFAULT_NUMBER=number` would tell Weaviate that when its sees a numerical value, it should treat it as number as opposed to `int`, etc.
-* `AUTOSCHEMA_DEFAULT_DATE=date` respectively
-
-The above configurable defaults will themselves default to something reasonable, if they are not set.
-
-In addition, we need to catch types we do not support at all:
-* Any map type is forbidden, unless it clearly matches one of the two supported types `phoneNumber` or `geoCoordinates`.
-* Any array type is forbidden, unless it is clearly a reference-type. In this case, Weaviate needs to resolve the beacon and see what the class of the resolved beacon is, since it needs the ClassName to be able to alter the schema.
-
-### Default distance metric
-
-Weaviate allows you to configure the `DEFAULT_VECTOR_DISTANCE_METRIC` which will be applied to every class unless overridden individually. You can choose from: `cosine` (default), `dot`, `l2-squared`, `manhattan`, `hamming`.
 
 ## More Resources
 

--- a/developers/weaviate/configuration/schema-configuration.md
+++ b/developers/weaviate/configuration/schema-configuration.md
@@ -111,7 +111,8 @@ An example of a complete class object including properties:
           "vectorizePropertyName": true,    // Whether the name of the property is used in the calculation for the vector position of data objects. Default false.
         }
       },
-      "indexInverted": true                 // Optional, default is true. By default each property is fully indexed both for full-text, as well as vector search. You can ignore properties in searches by explicitly setting index to false.
+      "indexFilterable": true,                // Optional, default is true. By default each property is indexed with a roaring bitmap index where available for efficient filtering.
+      "indexSearchable": true,                // Optional, default is true. By default each property is indexed with a searchable index for BM25-suitable Map index for BM25 or hybrid searching.
     }
   ],
   "invertedIndexConfig": {                  // Optional, index configuration
@@ -335,7 +336,8 @@ An example of a complete property object:
           "vectorizePropertyName": true,    // Whether the name of the property is used in the calculation for the vector position of data objects. Default false.
       }
     },
-    "indexInverted": true                 // Optional, default is true. By default each property is fully indexed both for full-text, as well as vector search. You can ignore properties in searches by explicitly setting index to false.
+    "indexFilterable": true,                // Optional, default is true. By default each property is indexed with a roaring bitmap index where available for efficient filtering.
+    "indexSearchable": true,                // Optional, default is true. By default each property is indexed with a searchable index for BM25-suitable Map index for BM25 or hybrid searching.
 }
 ```
 

--- a/developers/weaviate/modules/retriever-vectorizer-modules/img2vec-neural.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/img2vec-neural.md
@@ -164,7 +164,7 @@ A full example of a class using the `img2vec-neural` module is shown below. This
         },
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "description": "label name (description) of the given image.",
           "name": "labelName"

--- a/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip.md
@@ -185,7 +185,7 @@ text fields using the `multi2vec-clip` module as a `vectorizer`:
       "properties": [
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "name": "name"
         },

--- a/developers/weaviate/modules/retriever-vectorizer-modules/ref2vec-centroid.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/ref2vec-centroid.md
@@ -79,7 +79,7 @@ Although this example uses text2vec-contextionary to generate vectors for the `P
       "properties": [
         {
           "dataType": [
-            "string"
+            "text"
           ],
           "description": "Title of the article",
           "name": "title"

--- a/developers/weaviate/more-resources/migration-guide.md
+++ b/developers/weaviate/more-resources/migration-guide.md
@@ -8,6 +8,12 @@ import Badges from '/_includes/badges.mdx';
 
 <Badges/>
 
+## Migration for version 1.19.0
+
+This version introduces `indexFilterable` and `indexSearchable` variables for the new text indexes, whose values will be set based on the value of `indexInverted`.
+
+Since filterable & searchable are separate indexes, filterable does not exist in Weaviate instances upgraded from pre-`v1.19` to `v1.19`. The missing `filterable` index can be created though on startup for all `text/text[]` properties if env variable `INDEX_MISSING_TEXT_FILTERABLE_AT_STARTUP` is set.
+
 ## Changelog for version v1.9.0
 
 * no breaking changes

--- a/developers/weaviate/more-resources/migration-guide.md
+++ b/developers/weaviate/more-resources/migration-guide.md
@@ -41,7 +41,7 @@ import Badges from '/_includes/badges.mdx';
         "properties": [
           {
             "dataType": [
-              "string"
+              "text"
             ],
             "name": "name"
           },
@@ -667,7 +667,7 @@ With the modularization, it becomes possible to vectorize non-text objects. Sear
 
   ```json
   {
-    "dataType": [ "string" ],
+    "dataType": [ "text" ],
     "description": "string",
     "cardinality": "string",
     "vectorizePropertyName": true,
@@ -681,7 +681,7 @@ With the modularization, it becomes possible to vectorize non-text objects. Sear
 
   ```json
   {
-    "dataType": [ "string" ],
+    "dataType": [ "text" ],
     "description": "string",
     "moduleConfig": {
       "text2vec-contextionary": {
@@ -832,7 +832,7 @@ The Contextionary becomes the first vectorization module of Weaviate, renamed to
 
     ```json
     {
-      "dataType": [ "string" ],
+      "dataType": [ "text" ],
       "description": "string",
       "moduleConfig": {
         "text2vec-contextionary": {

--- a/developers/weaviate/tutorials/_how-to-create-a-schema.md
+++ b/developers/weaviate/tutorials/_how-to-create-a-schema.md
@@ -71,7 +71,7 @@ Note that the property `"title"` of the class `"Article"` has dataType `"string"
   "properties": [
     {
       "dataType": [
-        "string"
+        "text"
       ],
       "description": "Name of the publication",
       "name": "name"
@@ -103,7 +103,7 @@ Add the classes `Article` and `Author` to the same schema, so you will end up wi
   "properties": [
     {
       "dataType": [
-        "string"
+        "text"
       ],
       "description": "Name of the publication",
       "name": "name"
@@ -129,7 +129,7 @@ Add the classes `Article` and `Author` to the same schema, so you will end up wi
   "properties": [
     {
       "dataType": [
-        "string"
+        "text"
       ],
       "description": "Title of the article",
       "name": "title"
@@ -148,7 +148,7 @@ Add the classes `Article` and `Author` to the same schema, so you will end up wi
   "properties": [
       {
         "dataType": [
-            "string"
+            "text"
         ],
         "description": "Name of the author",
         "name": "name"
@@ -181,7 +181,7 @@ Now, add this list of classes to the schema, which will look like this:
     "properties": [
       {
         "dataType": [
-          "string"
+          "text"
         ],
         "description": "Name of the publication",
         "name": "name"
@@ -207,7 +207,7 @@ Now, add this list of classes to the schema, which will look like this:
     "properties": [
       {
         "dataType": [
-          "string"
+          "text"
         ],
         "description": "Title of the article",
         "name": "title"
@@ -226,7 +226,7 @@ Now, add this list of classes to the schema, which will look like this:
     "properties": [
       {
         "dataType": [
-            "string"
+            "text"
         ],
         "description": "Name of the author",
         "name": "name"

--- a/developers/weaviate/tutorials/modules.md
+++ b/developers/weaviate/tutorials/modules.md
@@ -114,7 +114,7 @@ You will see that the class and property names are not indexed, but the article 
             "properties": [
                 {
                     "dataType": [
-                        "string"
+                        "text"
                     ],
                     "description": "title of the article",
                     "indexInverted": true,
@@ -129,7 +129,7 @@ You will see that the class and property names are not indexed, but the article 
                 },
                 {
                     "dataType": [
-                        "string"
+                        "text"
                     ],
                     "description": "url of the article",
                     "indexInverted": false,

--- a/developers/weaviate/tutorials/modules.md
+++ b/developers/weaviate/tutorials/modules.md
@@ -117,7 +117,8 @@ You will see that the class and property names are not indexed, but the article 
                         "text"
                     ],
                     "description": "title of the article",
-                    "indexInverted": true,
+                    "indexFilterable": true,
+                    "indexSearchable": true,
                     "moduleConfig": {
                         "text2vec-transformers": {
                             "skip": false,
@@ -132,7 +133,8 @@ You will see that the class and property names are not indexed, but the article 
                         "text"
                     ],
                     "description": "url of the article",
-                    "indexInverted": false,
+                    "indexFilterable": true,
+                    "indexSearchable": true,
                     "moduleConfig": {
                         "text2vec-transformers": {
                             "skip": false,
@@ -147,7 +149,8 @@ You will see that the class and property names are not indexed, but the article 
                         "text"
                     ],
                     "description": "summary of the article",
-                    "indexInverted": true,
+                    "indexFilterable": true,
+                    "indexSearchable": true,
                     "moduleConfig": {
                         "text2vec-transformers": {
                             "skip": false,

--- a/developers/weaviate/tutorials/spark-connector.md
+++ b/developers/weaviate/tutorials/spark-connector.md
@@ -120,19 +120,19 @@ client.schema.create_class(
         "properties": [
             {
                 "name": "raw",
-                "dataType": ["string"]
+                "dataType": ["text"]
             },
             {
                 "name": "sha",
-                "dataType": ["string"]
+                "dataType": ["text"]
             },
             {
                 "name": "title",
-                "dataType": ["string"]
+                "dataType": ["text"]
             },
             {
                 "name": "url",
-                "dataType": ["string"]
+                "dataType": ["text"]
             },
         ],
     }


### PR DESCRIPTION
### What's being changed:

Doc updates to correspond to the `1.19` release, including:
- New datatypes
    - Update datatypes page (config-refs/datatypes) to add uuid & update `text` / `string`
    - Update tokenization docs (configuration/schema-configuration#property-tokenization) re: `text` / `string`
    - Update all example schemas to remove `string` datatypes
- Changes to the inverted index (now has two indexes!)
    - Update all example schemas to modify refs to `indexInverted` to `indexFilterable` and `indexSearchable`
    - Update docs on configuring indexes (configuration/indexes)
- New groupBy feature
    - Update GraphQL API docs on Get (api/graphql/get) to add groupby syntax and example
- Consistency level on GraphQL Get requests
    - Update GraphQL API docs on Get (api/graphql/get) to add consistency syntax
- New gRPC API
    - Update Concepts: Interfaces to let users know it's there in very small scale (concepts/interface)

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
