### PR TITLE
[site] add ing to domain ignore list

### DIFF
--- a/_build_scripts/verify-links-build-dev.sh
+++ b/_build_scripts/verify-links-build-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net|https://cohere.ai|www.meetup.com|wiki.pathmind.com|twitter.com|chat.openai.com|https://platform.openai.com*"
+URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net|https://cohere.ai|www.meetup.com|wiki.pathmind.com|twitter.com|chat.openai.com|platform.openai.com*|www.ing.com"
 GITHUB_IGNORES="github.com|github.com/weaviate/howto*"
 DEV_BUILD_LINKS_TO_IGNORE="assets/files|https://weaviate.io"
 

--- a/_build_scripts/verify-links.sh
+++ b/_build_scripts/verify-links.sh
@@ -2,7 +2,7 @@
 set -e
 set -o errexit # stop script immediately on error
 
-URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net|https://cohere.ai|www.meetup.com|wiki.pathmind.com|twitter.com|chat.openai.com|https://platform.openai.com*"
+URL_IGNORES="jsonlines.org/|arxiv.org/|huggingface.co/|linkedin.com/in/|crunchbase.com|www.nytimes.com|www.researchgate.net|https://cohere.ai|www.meetup.com|wiki.pathmind.com|twitter.com|chat.openai.com|platform.openai.com*|www.ing.com"
 DOCUSAURUS_IGNORES="github.com/.*github.com/|github.com/weaviate/weaviate-io|github.com/weaviate/howto-weaviate-retrieval-plugin*"
 # Note #1 github.com/.*github.com/ - is to ignore meta links that include blog co-authors
 # Note #2 github.com/weaviate/weaviate-io/tree/ - is for edit on github links


### PR DESCRIPTION
### What's being changed:

The ING ventures page is broken again (https://www.ing.com/About-us/ING-Ventures.htm). Adding ING domain to ignore list to prevent further build failures.

### Type of change:

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [x] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
