### PR TITLE
update node alloc doc; roadmap

### DIFF
--- a/developers/weaviate/concepts/cluster.md
+++ b/developers/weaviate/concepts/cluster.md
@@ -82,9 +82,18 @@ Weaviate - especially when running as a cluster - is optimized to run on Kuberne
 
 ## Node affinity of shards and/or replication shards
 
-As of `v1.8.0`, users cannot specify the node-affinity of a specific shard or replication shard. Shards are assigned to 'live' nodes in a round-robin fashion starting with a random node. There are not yet any mechanisms in place to make sure that a new class' shards are owned by the node that currently has the least work. Similarly, there is no way to assign specific classes to specific nodes if nodes aren't equally sized in the cluster.
+Weaviate tries to select the node with the most available resources.
 
-Such node-affinity labels and/or rules may be added in future releases.
+This only applies when creating a new class, rather than when adding more data to an existing single class. The current implementation only considers the disk space.
+
+<details>
+  <summary>Pre-`v1.18.1` behavior</summary>
+
+In versions `v1.8.0`-`v1.18.0`, users could not specify the node-affinity of a specific shard or replication shard.
+
+Shards were assigned to 'live' nodes in a round-robin fashion starting with a random node.
+
+</details>
 
 ## Consistency and current limitations
 

--- a/developers/weaviate/roadmap/index.md
+++ b/developers/weaviate/roadmap/index.md
@@ -18,10 +18,6 @@ If you find any of the issues of interest, follow the link and upvote <i classNa
 
 Please feel free to engage with us about the roadmap on [Weaviate's GitHub](https://github.com/weaviate/weaviate) or on [Slack](https://weaviate.io/slack).
 
-## Planned for Weaviate 1.19
-
-<Roadmap label="planned-1.19"/>
-
 ## Planned for Weaviate 1.20
 
 <Roadmap label="planned-1.20"/>


### PR DESCRIPTION
### What's being changed:

Updated node allocation doc to reflect 1.18.1 behavior
Remove 1.19 from roadmap

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
