### PR TITLE
[docs] add optional flag includestartMarker in FilteredTextBlock

### DIFF
--- a/src/components/Documentation/FilteredTextBlock.js
+++ b/src/components/Documentation/FilteredTextBlock.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
 
-const FilteredTextBlock = ({ text, startMarker, endMarker, language }) => {
+const FilteredTextBlock = ({ text, startMarker, endMarker, language, includestartMarker='false' }) => {
   // Filter out lines that are before the start marker, and lines with or after the end marker
+  includestartMarker = includestartMarker == 'true';
   const lines = text.split('\n');
   let withinMarkers = false;
   const filteredLines = lines
     .filter((line) => {
       if (line.includes(startMarker)) {
         withinMarkers = true;
-        return false;
+        return includestartMarker;
       }
 
       if (line.includes(endMarker)) {

--- a/src/components/Documentation/FilteredTextBlock.js
+++ b/src/components/Documentation/FilteredTextBlock.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
 
-const FilteredTextBlock = ({ text, startMarker, endMarker, language, includestartMarker='false' }) => {
+const FilteredTextBlock = ({ text, startMarker, endMarker, language, includeStartMarker='false' }) => {
   // Filter out lines that are before the start marker, and lines with or after the end marker
-  includestartMarker = includestartMarker == 'true';
+  includeStartMarker = includeStartMarker == 'true';
   const lines = text.split('\n');
   let withinMarkers = false;
   const filteredLines = lines
     .filter((line) => {
       if (line.includes(startMarker)) {
         withinMarkers = true;
-        return includestartMarker;
+        return includeStartMarker;
       }
 
       if (line.includes(endMarker)) {


### PR DESCRIPTION
### What's being changed:

Add optional flag `includestartMarker` in FilteredTextBlock.

Previously, the code block here was configured to include lines after that containing the start marker, and before the end marker.

```
<FilteredTextBlock
  text={EndToEndPyCode}
  startMarker="# ===== add schema ====="
  endMarker="# ===== import data ====="
  language="py"
/>
```

Now, it has been modified so that setting `includeStartMarker` to `"true"` will cause the line containing the marker to be a part of the code snippet.

```
<FilteredTextBlock
  text={EndToEndPyCode}
  startMarker="# ===== add schema ====="
  endMarker="# ===== import data ====="
  language="py"
  includeStartMarker="true"
/>
```

### Type of change:

- [x] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
