### PR TITLE
[docs:fix] update more instances of string datatypes to text

### DIFF
--- a/_includes/code/quickstart.schema.create.mdx
+++ b/_includes/code/quickstart.schema.create.mdx
@@ -72,7 +72,7 @@ let classObj = {
           'name': 'answer',
       },
       {
-          'dataType': ['string'],
+          'dataType': ['text'],
           'description': 'The category',
           'name': 'category',
       },
@@ -134,7 +134,7 @@ let classObj = {
           'name': 'answer',
       },
       {
-          'dataType': ['string'],
+          'dataType': ['text'],
           'description': 'The category',
           'name': 'category',
       },
@@ -298,12 +298,12 @@ $ curl \
     "description": "Information from a Jeopardy! question",
     "properties": [
         {
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "The question",
             "name": "question"
         },
         {
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "The answer",
             "name": "answer"
         }

--- a/_includes/code/schema.things.create.mdx
+++ b/_includes/code/schema.things.create.mdx
@@ -14,7 +14,7 @@ class_obj = {
     "description": "A written text, for example a news article or blog post",
     "properties": [
         {
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "Title of the article",
             "name": "title",
         },

--- a/_includes/code/tutorials.wikipedia.schema.mdx
+++ b/_includes/code/tutorials.wikipedia.schema.mdx
@@ -25,7 +25,7 @@ article_class = {
         {
             "name": "title",
             "description": "The title of the article",
-            "dataType": ["string"],
+            "dataType": ["text"],
             # Don't vectorize the title
             "moduleConfig": {"text2vec-openai": {"skip": True}}
         },

--- a/developers/academy/units/_109_tmp_leftovers/_leftovers.mdx
+++ b/developers/academy/units/_109_tmp_leftovers/_leftovers.mdx
@@ -434,7 +434,7 @@ Now, try it out yourself. This query should return something like the below:
                 "value": "Final Jeopardy!"
               }
             ],
-            "type": "string"
+            "type": "text"
           }
         }
       ]

--- a/developers/weaviate/_guides-further/_quick-start-with-the-text2vec-contextionary-module.md
+++ b/developers/weaviate/_guides-further/_quick-start-with-the-text2vec-contextionary-module.md
@@ -91,7 +91,7 @@ The output will look something like this:
             "properties": [
                 {
                     "dataType": [
-                        "string"
+                        "text"
                     ],
                     "description": "Name of the publication",
                     "moduleConfig": {
@@ -146,7 +146,7 @@ The output will look something like this:
             "properties": [
                 {
                     "dataType": [
-                        "string"
+                        "text"
                     ],
                     "description": "Name of the author",
                     "moduleConfig": {
@@ -195,7 +195,7 @@ The output will look something like this:
             "properties": [
                 {
                     "dataType": [
-                        "string"
+                        "text"
                     ],
                     "description": "title of the article",
                     "indexFilterable": true,
@@ -210,7 +210,7 @@ The output will look something like this:
                 },
                 {
                     "dataType": [
-                        "string"
+                        "text"
                     ],
                     "description": "url of the article",
                     "indexFilterable": false,
@@ -322,7 +322,7 @@ The output will look something like this:
             "properties": [
                 {
                     "dataType": [
-                        "string"
+                        "text"
                     ],
                     "description": "category name",
                     "indexInverted": true,

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     - '8099'  # Specify different port to avoid confusion
     - --scheme
     - http
-    image: semitechnologies/weaviate:1.19.0
+    image: semitechnologies/weaviate:1.19.2
     ports:
     - 8099:8099
     restart: on-failure:0


### PR DESCRIPTION
### What's being changed:

Update more instances of string datatypes to text

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
