### PR TITLE
[docs] fix typo

### DIFF
--- a/developers/weaviate/api/graphql/get.md
+++ b/developers/weaviate/api/graphql/get.md
@@ -54,7 +54,7 @@ As of `1.19`, the `groupBy` `path` is limited to one property or cross-reference
       groupBy:{
         path: [<propertyName>]  # Property to group by (only one property or cross-reference)
         groups: <number>  # Max. number of groups
-        objectPerGroup: <number>  # Max. number of objects per group
+        objectsPerGroup: <number>  # Max. number of objects per group
       }
     ) {
       _additional {


### PR DESCRIPTION
### What's being changed:

Fix typo in `get` example

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
