### PR TITLE
[docs] fix additional instances of auth.AuthApiKey

### DIFF
--- a/developers/academy/units/102_queries_1/_snippets/10_get.py
+++ b/developers/academy/units/102_queries_1/_snippets/10_get.py
@@ -3,7 +3,7 @@ import weaviate
 
 client = weaviate.Client(
     url="https://edu-demo.weaviate.network",
-    auth_client_secret=weaviate.auth.AuthApiKey(api_key="learn-weaviate"),  # A read-only API Key for the Weaviate instance
+    auth_client_secret=weaviate.AuthApiKey(api_key="learn-weaviate"),  # A read-only API Key for the Weaviate instance
     additional_headers={
         "X-OpenAI-Api-Key": "YOUR-OPENAI-API-KEY",  # Replace this with YOUR OpenAI API key
     }

--- a/developers/academy/units/103_schema_and_imports/_snippets/05_create_instance.py
+++ b/developers/academy/units/103_schema_and_imports/_snippets/05_create_instance.py
@@ -3,7 +3,7 @@ import weaviate
 
 client = weaviate.Client(
     url="https://some-endpoint.weaviate.network",  # Replace w/ your endpoint
-    auth_client_secret=weaviate.auth.AuthApiKey(api_key="YOUR-WEAVIATE-API-KEY"),  # Replace w/ your API Key for the Weaviate instance. Delete if authentication is disabled.
+    auth_client_secret=weaviate.AuthApiKey(api_key="YOUR-WEAVIATE-API-KEY"),  # Replace w/ your API Key for the Weaviate instance. Delete if authentication is disabled.
     additional_headers={
         "X-OpenAI-Api-Key": "YOUR-OPENAI-API-KEY",
     },

--- a/developers/academy/units/103_schema_and_imports/_snippets/20_schema.py
+++ b/developers/academy/units/103_schema_and_imports/_snippets/20_schema.py
@@ -3,7 +3,7 @@ import weaviate
 
 client = weaviate.Client(
     url="https://some-endpoint.weaviate.network",  # Replace w/ your endpoint
-    auth_client_secret=weaviate.auth.AuthApiKey(api_key="YOUR-WEAVIATE-API-KEY"),  # Replace w/ your API Key for the Weaviate instance. Delete if authentication is disabled.
+    auth_client_secret=weaviate.AuthApiKey(api_key="YOUR-WEAVIATE-API-KEY"),  # Replace w/ your API Key for the Weaviate instance. Delete if authentication is disabled.
     additional_headers={
         "X-OpenAI-Api-Key": "YOUR-OPENAI-API-KEY",
     },

--- a/developers/academy/units/103_schema_and_imports/_snippets/30_import.py
+++ b/developers/academy/units/103_schema_and_imports/_snippets/30_import.py
@@ -3,7 +3,7 @@ import weaviate
 
 client = weaviate.Client(
     url="https://some-endpoint.weaviate.network",  # Replace w/ your endpoint
-    auth_client_secret=weaviate.auth.AuthApiKey(api_key="YOUR-WEAVIATE-API-KEY"),  # Replace w/ your API Key for the Weaviate instance. Delete if authentication is disabled.
+    auth_client_secret=weaviate.AuthApiKey(api_key="YOUR-WEAVIATE-API-KEY"),  # Replace w/ your API Key for the Weaviate instance. Delete if authentication is disabled.
     additional_headers={
         "X-OpenAI-Api-Key": "YOUR-OPENAI-API-KEY",
     },

--- a/developers/academy/units/103_schema_and_imports/_snippets/40_import_example_1.py
+++ b/developers/academy/units/103_schema_and_imports/_snippets/40_import_example_1.py
@@ -7,7 +7,7 @@ import json
 
 client = weaviate.Client(
     url="https://some-endpoint.weaviate.network",  # Replace w/ your endpoint
-    auth_client_secret=weaviate.auth.AuthApiKey(api_key="YOUR-WEAVIATE-API-KEY"),  # Replace w/ your API Key for the Weaviate instance. Delete if authentication is disabled.
+    auth_client_secret=weaviate.AuthApiKey(api_key="YOUR-WEAVIATE-API-KEY"),  # Replace w/ your API Key for the Weaviate instance. Delete if authentication is disabled.
     additional_headers={
         "X-OpenAI-Api-Key": "YOUR-OPENAI-API-KEY",
     },

--- a/developers/academy/units/_snippets/setup.py
+++ b/developers/academy/units/_snippets/setup.py
@@ -3,7 +3,7 @@ import weaviate
 
 client = weaviate.Client(
     url="https://edu-demo.weaviate.network",
-    auth_client_secret=weaviate.auth.AuthApiKey(api_key="learn-weaviate"),  # A read-only API Key for the Weaviate instance
+    auth_client_secret=weaviate.AuthApiKey(api_key="learn-weaviate"),  # A read-only API Key for the Weaviate instance
 )
 
 client.is_ready()  # This should return `True`
@@ -15,7 +15,7 @@ import weaviate
 
 client = weaviate.Client(
     url="https://edu-demo.weaviate.network",
-    auth_client_secret=weaviate.auth.AuthApiKey(api_key="learn-weaviate"),  # A read-only API Key for the Weaviate instance
+    auth_client_secret=weaviate.AuthApiKey(api_key="learn-weaviate"),  # A read-only API Key for the Weaviate instance
     additional_headers={
         "X-OpenAI-Api-Key": "YOUR-OPENAI-API-KEY",  # Replace this with YOUR OpenAI API key
     }
@@ -43,7 +43,7 @@ import json
 
 client = weaviate.Client(
     url="https://edu-demo.weaviate.network",
-    auth_client_secret=weaviate.auth.AuthApiKey(api_key="learn-weaviate"),  # A read-only API Key for the Weaviate instance
+    auth_client_secret=weaviate.AuthApiKey(api_key="learn-weaviate"),  # A read-only API Key for the Weaviate instance
     additional_headers={
         "X-OpenAI-Api-Key": "YOUR-OPENAI-API-KEY",  # Replace this with YOUR OpenAI API key
     }


### PR DESCRIPTION
### What's being changed:

More `weaviate.auth.AuthApiKey` to `weaviate.AuthApiKey` changes

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
