### PR TITLE
Do not use deprecated `text` type in schema

### DIFF
--- a/_includes/code/getting.started.schema.create.1.mdx
+++ b/_includes/code/getting.started.schema.create.1.mdx
@@ -46,7 +46,7 @@ class_obj = {
         },
         {
             "dataType": [
-                "text"
+                "string"
             ],
             "description": "A description of the author",
             "name": "description"
@@ -198,7 +198,7 @@ func main() {
                 Name:        "wonNobelPrize",
             },
             {
-                DataType:    []string{"text"},
+                DataType:    []string{"string"},
                 Description: "A description of the author",
                 Name:        "description",
             },
@@ -345,7 +345,7 @@ $ curl \
             },
             {
                 "dataType": [
-                    "text"
+                    "string"
                 ],
                 "description": "A description of the author",
                 "name": "description"

--- a/_includes/code/howto.customvectors.schemacreate.mdx
+++ b/_includes/code/howto.customvectors.schemacreate.mdx
@@ -14,7 +14,7 @@ class_obj = {
     "vectorizer": "none", # explicitly tell Weaviate not to vectorize anything, we are providing the vectors ourselves through our BERT model
     "properties": [{
         "name": "content",
-        "dataType": ["text"],
+        "dataType": ["string"],
     }]
 }
 
@@ -81,7 +81,7 @@ func main() {
     Class: "Post",
     Properties: []*models.Property{
       {
-        DataType: []string{"text"},
+        DataType: []string{"string"},
         Name:     "content",
       },
     },
@@ -153,7 +153,7 @@ $ curl \
         "vectorizer": "none",
         "properties": [{
             "name": "content",
-            "dataType": ["text"],
+            "dataType": ["string"],
         }]
     }' \
     http://localhost:8080/v1/schema

--- a/_includes/code/howto.schema.create.python.mdx
+++ b/_includes/code/howto.schema.create.python.mdx
@@ -43,7 +43,7 @@ schema = {
       },
       {
         "dataType": [
-          "text"
+          "string"
         ],
         "description": "The content of the article",
         "name": "content"

--- a/_includes/code/howto/search.aggregate.py
+++ b/_includes/code/howto/search.aggregate.py
@@ -146,7 +146,7 @@ expected_response = (
                 "value": "India"
               }
             ],
-            "type": "text"
+            "type": "string"
           }
         }
       ]

--- a/_includes/code/quickstart.schema.create.mdx
+++ b/_includes/code/quickstart.schema.create.mdx
@@ -16,17 +16,17 @@ class_obj = {
     "description": "Information from a Jeopardy! question",  # description of the class
     "properties": [
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "description": "The question",
             "name": "question",
         },
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "description": "The answer",
             "name": "answer",
         },
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "description": "The category",
             "name": "category",
         },
@@ -298,12 +298,12 @@ $ curl \
     "description": "Information from a Jeopardy! question",
     "properties": [
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "description": "The question",
             "name": "question"
         },
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "description": "The answer",
             "name": "answer"
         }

--- a/_includes/code/schema.class.add.property.mdx
+++ b/_includes/code/schema.class.add.property.mdx
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 
 ```python
 add_prop = {
-    "dataType": ["text"],
+    "dataType": ["string"],
     "name": "body"
 }
 

--- a/_includes/code/schema.class.create.property.mdx
+++ b/_includes/code/schema.class.create.property.mdx
@@ -10,11 +10,11 @@ class_obj = {
     # highlight-start
     "properties": [
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "name": "title",
         },
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "name": "body",
         },
     ],

--- a/_includes/code/schema.class.create.vectorizer.class.mdx
+++ b/_includes/code/schema.class.create.vectorizer.class.mdx
@@ -9,7 +9,7 @@ class_obj = {
     "class": "Article",
     "properties": [
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "name": "title",
         },
     ],

--- a/_includes/code/schema.class.create.vectorizer.mdx
+++ b/_includes/code/schema.class.create.vectorizer.mdx
@@ -9,7 +9,7 @@ class_obj = {
     "class": "Article",
     "properties": [
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "name": "title",
         },
     ],

--- a/_includes/code/schema.class.create.vectorizer.property.mdx
+++ b/_includes/code/schema.class.create.vectorizer.property.mdx
@@ -9,7 +9,7 @@ class_obj = {
     "class": "Article",
     "properties": [
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "name": "title",
             # highlight-start
             "moduleConfig": {

--- a/_includes/code/schema.things.create.elaborate.mdx
+++ b/_includes/code/schema.things.create.elaborate.mdx
@@ -27,7 +27,7 @@ class_obj = {
     "properties": [
         {
             "dataType": [
-                "text"
+                "string"
             ],
             "description": "Title of the article",
             "name": "title",
@@ -41,7 +41,7 @@ class_obj = {
         },
         {
             "dataType": [
-                "text"
+                "string"
             ],
             "description": "The content of the article",
             "name": "content",
@@ -204,12 +204,12 @@ func main() {
     },
     Properties: []*models.Property{
       {
-        DataType:    []string{"text"},
+        DataType:    []string{"string"},
         Description: "Title of the article",
         Name:        "title",
       },
       {
-        DataType:    []string{"text"},
+        DataType:    []string{"string"},
         Description: "The content of the article",
         Name:        "content",
       },
@@ -355,7 +355,7 @@ $ curl \
     "properties": [
         {
             "dataType": [
-                "text"
+                "string"
             ],
             "description": "Title of the article",
             "name": "title",
@@ -369,7 +369,7 @@ $ curl \
         },
         {
             "dataType": [
-                "text"
+                "string"
             ],
             "description": "The content of the article",
             "name": "content",

--- a/_includes/code/schema.things.create.mdx
+++ b/_includes/code/schema.things.create.mdx
@@ -14,12 +14,12 @@ class_obj = {
     "description": "A written text, for example a news article or blog post",
     "properties": [
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "description": "Title of the article",
             "name": "title",
         },
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "description": "The content of the article",
             "name": "content"
         }
@@ -106,7 +106,7 @@ func main() {
                 Name:        "title",
             },
             {
-                DataType:    []string{"text"},
+                DataType:    []string{"string"},
                 Description: "The content of the article",
                 Name:        "content",
             },
@@ -186,7 +186,7 @@ $ curl \
             },
             {
             "dataType": [
-                "text"
+                "string"
             ],
             "description": "The content of the article",
             "name": "content"

--- a/_includes/code/schema.things.put.mdx
+++ b/_includes/code/schema.things.put.mdx
@@ -22,7 +22,7 @@ class_obj = {
         },
         {
         "dataType": [
-            "text"
+            "string"
         ],
         "description": "The content of the article",
         "name": "content"
@@ -53,7 +53,7 @@ $ curl \
             },
             {
             "dataType": [
-                "text"
+                "string"
             ],
             "description": "The content of the article",
             "name": "content"

--- a/_includes/code/tutorials.wikipedia.schema.mdx
+++ b/_includes/code/tutorials.wikipedia.schema.mdx
@@ -17,7 +17,7 @@ article_class = {
         "text2vec-openai": {
             "model": "ada",
             "modelVersion": "002",
-            "type": "text",
+            "type": "string",
             "vectorizeClassName": False
         }
     },
@@ -25,14 +25,14 @@ article_class = {
         {
             "name": "title",
             "description": "The title of the article",
-            "dataType": ["text"],
+            "dataType": ["string"],
             # Don't vectorize the title
             "moduleConfig": {"text2vec-openai": {"skip": True}}
         },
         {
             "name": "content",
             "description": "The content of the article",
-            "dataType": ["text"],
+            "dataType": ["string"],
         }
     ]
 }

--- a/blog/2021-11-25-semantic-search-with-wikipedia-and-weaviate/index.mdx
+++ b/blog/2021-11-25-semantic-search-with-wikipedia-and-weaviate/index.mdx
@@ -67,7 +67,7 @@ Next, we want to make sure that the content of the paragraphs gets vectorized pr
 {
   name: "content",
   datatype: [
-    "text"
+    "string"
   ],
   description: "The content of the paragraph",
   invertedIndex: false,

--- a/blog/2023-01-31-weaviate-podcast-search/index.mdx
+++ b/blog/2023-01-31-weaviate-podcast-search/index.mdx
@@ -37,7 +37,7 @@ result = model.transcribe("20.mp3")
 print(f"Transcribed in {time.time() - start} seconds.")
 
 f = open("20-text-dump.txt", "w+")
-f.write(result["text"])
+f.write(result["string"])
 f.close()
 ```
 

--- a/blog/2023-02-07-generative-search/_index.md
+++ b/blog/2023-02-07-generative-search/_index.md
@@ -118,7 +118,7 @@ Here is a schema example using the text2vec-openai vectorizer:
         {
             "name": "content",
             "description": "content that will be vectorized",
-            "dataType": ["text"]
+            "dataType": ["string"]
         }
       ]
     }

--- a/blog/2023-04-27-how-to-chatgpt-plugin/index.mdx
+++ b/blog/2023-04-27-how-to-chatgpt-plugin/index.mdx
@@ -107,7 +107,7 @@ INDEX_NAME = "Document"
 SCHEMA = {
     "class": INDEX_NAME,
     "properties": [
-        {"name": "text", "dataType": ["text"]},
+        {"name": "string", "dataType": ["string"]},
         {"name": "document_id", "dataType": ["string"]},
     ],
 }
@@ -176,11 +176,11 @@ We developed these three endpoints through test driven development, as such we w
 @pytest.fixture
 def documents(weaviate_client):
     docs = [
-        {"text": "The lion is the king of the jungle", "document_id": "1"},
-        {"text": "The lion is a carnivore", "document_id": "2"},
-        {"text": "The lion is a large animal", "document_id": "3"},
-        {"text": "The capital of France is Paris", "document_id": "4"},
-        {"text": "The capital of Germany is Berlin", "document_id": "5"},
+        {"string": "The lion is the king of the jungle", "document_id": "1"},
+        {"string": "The lion is a carnivore", "document_id": "2"},
+        {"string": "The lion is a large animal", "document_id": "3"},
+        {"string": "The capital of France is Paris", "document_id": "4"},
+        {"string": "The capital of Germany is Berlin", "document_id": "5"},
     ]
 
     for doc in docs:
@@ -195,12 +195,12 @@ Here's the test that carries this out:
 
 ```python
 def test_upsert(weaviate_client):
-    response = client.post("/upsert", json={"text": "Hello World", "document_id": "1"})
+    response = client.post("/upsert", json={"string": "Hello World", "document_id": "1"})
     assert response.status_code == 200
 
     docs = weaviate_client.data_object.get(with_vector=True)["objects"]
     assert len(docs) == 1
-    assert docs[0]["properties"]["text"] == "Hello World"
+    assert docs[0]["properties"]["string"] == "Hello World"
     assert docs[0]["properties"]["document_id"] == "1"
     assert docs[0]["vector"] is not None
 ```
@@ -234,13 +234,13 @@ For this endpoint we mainly want to check that it returns the right number of ob
 ```python
 def test_query(documents):
     LIMIT = 3
-    response = client.post("/query", json={"text": "lion", "limit": LIMIT})
+    response = client.post("/query", json={"string": "lion", "limit": LIMIT})
 
     results = response.json()
 
     assert len(results) == LIMIT
     for result in results:
-        assert "lion" in result["document"]["text"]
+        assert "lion" in result["document"]["string"]
 ```
 
 The implementation below will take in a query and return a list of retrieved documents and metadata.
@@ -254,7 +254,7 @@ def query(query: Query, client=Depends(get_weaviate_client)) -> List[Document]:
     query_vector = get_embedding(query.text)
 
     results = (
-        client.query.get(INDEX_NAME, ["document_id", "text"])
+        client.query.get(INDEX_NAME, ["document_id", "string"])
         .with_near_vector({"vector": query_vector})
         .with_limit(query.limit)
         .with_additional("certainty")
@@ -265,7 +265,7 @@ def query(query: Query, client=Depends(get_weaviate_client)) -> List[Document]:
 
     return [
         QueryResult(
-            document={"text": doc["text"], "document_id": doc["document_id"]},
+            document={"string": doc["string"], "document_id": doc["document_id"]},
             score=doc["_additional"]["certainty"],
         )
         for doc in docs

--- a/blog/2023-05-05-generative-feedback-loops/index.mdx
+++ b/blog/2023-05-05-generative-feedback-loops/index.mdx
@@ -170,7 +170,7 @@ Now we will add more data to our prompt, a high-level ad target. We will write a
 ```python
 target_property = {
    "dataType": [
-       "text"
+       "string"
    ],
    "name": "target",
    "description": "High-level audience target for this ad."

--- a/developers/academy/_snippets/example_schema.mdx
+++ b/developers/academy/_snippets/example_schema.mdx
@@ -14,7 +14,7 @@
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "The title of the category",
           "name": "title",
@@ -30,7 +30,7 @@
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Question asked to the contestant",
           ...
@@ -39,7 +39,7 @@
         },
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Answer provided by the contestant",
           ...
@@ -56,7 +56,7 @@
         },
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Jeopardy round",
           ...

--- a/developers/academy/units/102_queries_1/_snippets/academy.queries.schema.short.mdx
+++ b/developers/academy/units/102_queries_1/_snippets/academy.queries.schema.short.mdx
@@ -5,20 +5,20 @@
       "class": "JeopardyQuestion",
       "properties": [
         {
-          "dataType": ["text"],
+          "dataType": ["string"],
           "name": "question",
           ...  // Truncated
-        },       
+        },
         {
-          "dataType": ["text"],
+          "dataType": ["string"],
           "name": "answer",
           ...  // Truncated
-        },  
+        },
         {
           "dataType": ["int"],
           "name": "points"
           ...  // Truncated
-        },        
+        },
         ...  // Truncated
       ],
       ...  // Truncated

--- a/developers/academy/units/103_schema_and_imports/10_data_structure.mdx
+++ b/developers/academy/units/103_schema_and_imports/10_data_structure.mdx
@@ -103,14 +103,14 @@ Here is an example schema structure:
         "text2vec-openai": {
           "model": "ada",
           "modelVersion": "002",
-          "type": "text",
+          "type": "string",
           "vectorizeClassName": true
         }
       },
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "moduleConfig": {
             "text2vec-openai": {
@@ -123,7 +123,7 @@ Here is an example schema structure:
         },
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "moduleConfig": {
             "text2vec-openai": {

--- a/developers/academy/units/103_schema_and_imports/_snippets/20_schema.py
+++ b/developers/academy/units/103_schema_and_imports/_snippets/20_schema.py
@@ -36,19 +36,19 @@ class_obj = {
         {
             "name": "title",
             # highlight-start
-            "dataType": ["text"],
+            "dataType": ["string"],
             # highlight-end
         },
         {
             "name": "body",
             # highlight-start
-            "dataType": ["text"],
+            "dataType": ["string"],
             # highlight-end
         },
         {
             "name": "url",
             # highlight-start
-            "dataType": ["text"],
+            "dataType": ["string"],
             # highlight-end
         },
     ],
@@ -64,7 +64,7 @@ datatypes = [c["dataType"] for c in client.schema.get("Article")["properties"]]
 assert "Article" in classes
 for p in ["title", "body", "url"]:
     assert p in property_names
-assert datatypes == [["text"], ["text"], ["text"]]
+assert datatypes == [["string"], ["string"], ["string"]]
 
 # ===== NOT SHOWN - Delete the class =====
 client.schema.delete_class("Article")
@@ -87,15 +87,15 @@ class_obj = {
     "properties": [
         {
             "name": "title",
-            "dataType": ["text"],
+            "dataType": ["string"],
         },
         {
             "name": "body",
-            "dataType": ["text"],
+            "dataType": ["string"],
         },
         {
             "name": "url",
-            "dataType": ["text"],
+            "dataType": ["string"],
         },
     ],
     # highlight-start
@@ -114,7 +114,7 @@ vectorizer = client.schema.get("Article")["vectorizer"]
 assert "Article" in classes
 for p in ["title", "body", "url"]:
     assert p in property_names
-assert datatypes == [["text"], ["text"], ["text"]]
+assert datatypes == [["string"], ["string"], ["string"]]
 assert vectorizer == "text2vec-openai"
 
 # ===== NOT SHOWN - Delete the class =====
@@ -134,22 +134,22 @@ class_obj = {
             "vectorizeClassName": False,
             "model": "ada",
             "modelVersion": "002",
-            "type": "text"
+            "type": "string"
         }
     },
     # highlight-end
     "properties": [
         {
             "name": "title",
-            "dataType": ["text"],
+            "dataType": ["string"],
         },
         {
             "name": "body",
-            "dataType": ["text"],
+            "dataType": ["string"],
         },
         {
             "name": "url",
-            "dataType": ["text"],
+            "dataType": ["string"],
         },
     ],
     "vectorizer": "text2vec-openai"
@@ -167,7 +167,7 @@ module_config = client.schema.get("Article")["moduleConfig"]
 assert "Article" in classes
 for p in ["title", "body", "url"]:
     assert p in property_names
-assert datatypes == [["text"], ["text"], ["text"]]
+assert datatypes == [["string"], ["string"], ["string"]]
 assert vectorizer == "text2vec-openai"
 assert module_config[vectorizer]["vectorizeClassName"] == False
 assert module_config[vectorizer]["model"] == "ada"
@@ -189,17 +189,17 @@ class_obj = {
             "vectorizeClassName": False,
             "model": "ada",
             "modelVersion": "002",
-            "type": "text"
+            "type": "string"
         }
     },
     "properties": [
         {
             "name": "title",
-            "dataType": ["text"],
+            "dataType": ["string"],
         },
         {
             "name": "body",
-            "dataType": ["text"],
+            "dataType": ["string"],
             # highlight-start
             "moduleConfig": {
                 "text2vec-openai": {
@@ -211,7 +211,7 @@ class_obj = {
         },
         {
             "name": "url",
-            "dataType": ["text"],
+            "dataType": ["string"],
             # highlight-start
             "moduleConfig": {
                 "text2vec-openai": {
@@ -236,7 +236,7 @@ module_config = client.schema.get("Article")["moduleConfig"]
 assert "Article" in classes
 for p in ["title", "body", "url"]:
     assert p in property_names
-assert datatypes == [["text"], ["text"], ["text"]]
+assert datatypes == [["string"], ["string"], ["string"]]
 assert vectorizer == "text2vec-openai"
 assert module_config[vectorizer]["vectorizeClassName"] == False
 assert module_config[vectorizer]["model"] == "ada"

--- a/developers/academy/units/103_schema_and_imports/_snippets/40_import_example_1.py
+++ b/developers/academy/units/103_schema_and_imports/_snippets/40_import_example_1.py
@@ -20,7 +20,7 @@ class_obj = {
     "properties": [
         {
             "name": "round",
-            "dataType": ["text"],
+            "dataType": ["string"],
             # Property-level module configuration for `round`
             "moduleConfig": {
                 "text2vec-openai": {
@@ -35,11 +35,11 @@ class_obj = {
         },
         {
             "name": "question",
-            "dataType": ["text"],
+            "dataType": ["string"],
         },
         {
             "name": "answer",
-            "dataType": ["text"],
+            "dataType": ["string"],
         },
     ],
 
@@ -52,7 +52,7 @@ class_obj = {
             "vectorizeClassName": False,
             "model": "ada",
             "modelVersion": "002",
-            "type": "text"
+            "type": "string"
         }
     },
 }
@@ -130,14 +130,14 @@ client.schema.get("JeopardyQuestion")
     "text2vec-openai": {
       "model": "ada",
       "modelVersion": "002",
-      "type": "text",
+      "type": "string",
       "vectorizeClassName": false
     }
   },
   "properties": [
     {
       "dataType": [
-        "text"
+        "string"
       ],
       "indexFilterable": true,
       "indexSearchable": true,
@@ -166,7 +166,7 @@ client.schema.get("JeopardyQuestion")
     },
     {
       "dataType": [
-        "text"
+        "string"
       ],
       "indexFilterable": true,
       "indexSearchable": true,
@@ -181,7 +181,7 @@ client.schema.get("JeopardyQuestion")
     },
     {
       "dataType": [
-        "text"
+        "string"
       ],
       "indexFilterable": true,
       "indexSearchable": true,

--- a/developers/academy/units/_109_tmp_leftovers/_leftovers.mdx
+++ b/developers/academy/units/_109_tmp_leftovers/_leftovers.mdx
@@ -434,7 +434,7 @@ Now, try it out yourself. This query should return something like the below:
                 "value": "Final Jeopardy!"
               }
             ],
-            "type": "text"
+            "type": "string"
           }
         }
       ]

--- a/developers/weaviate/_guides-further/_quick-start-with-the-text2vec-contextionary-module.md
+++ b/developers/weaviate/_guides-further/_quick-start-with-the-text2vec-contextionary-module.md
@@ -91,7 +91,7 @@ The output will look something like this:
             "properties": [
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "Name of the publication",
                     "moduleConfig": {
@@ -146,7 +146,7 @@ The output will look something like this:
             "properties": [
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "Name of the author",
                     "moduleConfig": {
@@ -195,7 +195,7 @@ The output will look something like this:
             "properties": [
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "title of the article",
                     "indexFilterable": true,
@@ -210,7 +210,7 @@ The output will look something like this:
                 },
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "url of the article",
                     "indexFilterable": false,
@@ -225,7 +225,7 @@ The output will look something like this:
                 },
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "summary of the article",
                     "indexInverted": true,
@@ -322,7 +322,7 @@ The output will look something like this:
             "properties": [
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "category name",
                     "indexInverted": true,

--- a/developers/weaviate/_guides-further/how-to-do-classification.md
+++ b/developers/weaviate/_guides-further/how-to-do-classification.md
@@ -161,7 +161,7 @@ Imagine you have a property for the popularity of the `Article` by the audience,
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "The popularity level",
           "name": "level"

--- a/developers/weaviate/_guides-further/how-to-use-weaviate-without-modules.md
+++ b/developers/weaviate/_guides-further/how-to-use-weaviate-without-modules.md
@@ -81,7 +81,7 @@ Weaviate allows the user to specify a Weaviate vectorizer to be used at class le
       "vectorizer": "none",  # explicitly tell Weaviate not to vectorize anything, we are providing the vectors ourselves
       "properties": [{
           "name": "content",
-          "dataType": ["text"],
+          "dataType": ["string"],
       }]
   }]
 }

--- a/developers/weaviate/api/rest/schema.md
+++ b/developers/weaviate/api/rest/schema.md
@@ -44,7 +44,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "category name",
           "indexFilterable": true,
@@ -71,7 +71,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Name of the publication",
           "name": "name"
@@ -112,7 +112,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Name of the author",
           "name": "name"
@@ -139,7 +139,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "title of the article",
           "indexFilterable": true,
@@ -153,7 +153,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
         },
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "url of the article",
           "indexFilterable": true,
@@ -167,7 +167,7 @@ import CodeSchemaDump from '/_includes/code/schema.dump.mdx';
         },
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "summary of the article",
           "indexFilterable": true,

--- a/developers/weaviate/client-libraries/python.md
+++ b/developers/weaviate/client-libraries/python.md
@@ -181,7 +181,7 @@ schema = {
     "properties": [
       {
         "dataType": [
-          "text"
+          "string"
         ],
         "description": "Name of the publication",
         "name": "name"
@@ -207,14 +207,14 @@ schema = {
     "properties": [
       {
         "dataType": [
-          "text"
+          "string"
         ],
         "description": "Title of the article",
         "name": "title"
       },
       {
         "dataType": [
-          "text"
+          "string"
         ],
         "description": "The content of the article",
         "name": "content"
@@ -226,7 +226,7 @@ schema = {
     "properties": [
       {
         "dataType": [
-            "text"
+            "string"
         ],
         "description": "Name of the author",
         "name": "name"
@@ -302,7 +302,7 @@ schema = {
       "properties": [
         {
           "name": "name",
-          "dataType": ["text"]
+          "dataType": ["string"]
         },
         {
           "name": "wroteBooks",
@@ -315,7 +315,7 @@ schema = {
       "properties": [
         {
           "name": "title",
-          "dataType": ["text"]
+          "dataType": ["string"]
         },
         {
           "name": "ofAuthor",
@@ -419,7 +419,7 @@ schema = {
       "properties": [
         {
           "name": "name",
-          "dataType": ["text"]
+          "dataType": ["string"]
         },
         {
           "name": "wroteBooks",
@@ -432,7 +432,7 @@ schema = {
       "properties": [
         {
           "name": "title",
-          "dataType": ["text"]
+          "dataType": ["string"]
         },
         {
           "name": "ofAuthor",
@@ -536,7 +536,7 @@ schema = {
       "properties": [
         {
           "name": "name",
-          "dataType": ["text"]
+          "dataType": ["string"]
         },
         {
           "name": "wroteBooks",
@@ -549,7 +549,7 @@ schema = {
       "properties": [
         {
           "name": "title",
-          "dataType": ["text"]
+          "dataType": ["string"]
         },
         {
           "name": "ofAuthor",

--- a/developers/weaviate/concepts/indexing.md
+++ b/developers/weaviate/concepts/indexing.md
@@ -121,7 +121,7 @@ When using vectorizers, you need to set vectorization at the class and property 
             }
         },
         "dataType": [
-            "text"
+            "string"
         ],
         "name": "name"
     }]

--- a/developers/weaviate/concepts/vector-index.md
+++ b/developers/weaviate/concepts/vector-index.md
@@ -54,7 +54,7 @@ Example of a class [vector index configuration in your data schema](/developers/
     {
       "name": "title",
       "description": "string",
-      "dataType": ["text"]
+      "dataType": ["string"]
     }
   ],
   "vectorIndexType": " ... ",

--- a/developers/weaviate/config-refs/schema.md
+++ b/developers/weaviate/config-refs/schema.md
@@ -48,7 +48,7 @@ The following are not allowed:
 
 A class describes a data object, such as in the form of a noun (e.g., *Person*, *Product*, *Timezone*) or a verb (e.g., *Move*, *Buy*, *Eat*).
 
-Classes are always written with a **capital letter** first. This helps in distinguishing classes from primitive data types when used in properties. For example, `dataType: ["text"]` means that a property is a text, whereas `dataType: ["Text"]` means that a property is a cross-reference type to a class named `Text`.
+Classes are always written with a **capital letter** first. This helps in distinguishing classes from primitive data types when used in properties. For example, `dataType: ["string"]` means that a property is a text, whereas `dataType: ["string"]` means that a property is a cross-reference type to a class named `Text`.
 
 After the first letter, classes may use any GraphQL-compatible characters. The current (as of `v1.10.0+`) class name validation regex is `/^[A-Z][_0-9A-Za-z]*$/`.
 
@@ -85,7 +85,7 @@ An example of a complete class object including properties:
       "name": "string",                     // The name of the property
       "description": "string",              // A description for your reference
       "dataType": [                         // The data type of the object as described above. When creating cross-references, a property can have multiple data types, hence the array syntax.
-        "text"
+        "string"
       ],
       "moduleConfig": {                     // Module-specific settings
         "text2vec-contextionary": {
@@ -327,7 +327,7 @@ If necessary, they can be configured in the schema per class, and can optionally
       "name": "title",
       "description": "title of the article",
       "dataType": [
-        "text"
+        "string"
       ],
       # Property-level settings override the class-level settings
       "invertedIndexConfig": {
@@ -354,7 +354,7 @@ An example of a complete property object:
     "name": "string",                     // The name of the property
     "description": "string",              // A description for your reference
     "dataType": [                         // The data type of the object as described above. When creating cross-references, a property can have multiple dataTypes.
-      "text"
+      "string"
     ],
     "tokenization": "word",               // Split field contents into word-tokens when indexing into the inverted index. See Property Tokenization below for more detail.
     "moduleConfig": {                     // Module-specific settings
@@ -379,7 +379,7 @@ You can customize how `text` data is tokenized and indexed in the inverted index
       "class": "Question",
       "properties": [
         {
-          "dataType": ["text"],
+          "dataType": ["string"],
           "name": "question",
           // highlight-start
           "tokenization": "word"

--- a/developers/weaviate/configuration/indexes.md
+++ b/developers/weaviate/configuration/indexes.md
@@ -59,7 +59,7 @@ Example of a class could be [configured in your data schema](/developers/weaviat
     {
       "name": "title",
       "description": "string",
-      "dataType": ["text"]
+      "dataType": ["string"]
     }
   ],
   "vectorIndexType": "hnsw",
@@ -122,7 +122,7 @@ You can set these keys in the schema like shown below, at a property level:
             "indexFilterable": false,  // <== turn off the filterable (Roaring Bitmap index) by setting `indexFilterable` to false
             "indexSearchable": false,  // <== turn off the searchable (for BM25/hybrid) by setting `indexSearchable` to false
             "dataType": [
-                "text"
+                "string"
             ],
             "name": "name"
         }
@@ -168,7 +168,7 @@ If we don't want to index the `Authors` we can simply skip all indices (vector _
             "indexFilterable": false,  // <== disable filterable index for this property
             "indexSearchable": false,  // <== disable searchable index for this property
             "dataType": [
-                "text"
+                "string"
             ],
             "description": "The name of the Author",
             "name": "name"
@@ -201,7 +201,7 @@ If we don't want to index the `Authors` we can simply skip all indices (vector _
             "indexFilterable": false,  // <== disable filterable index for this property
             "indexSearchable": false,  // <== disable searchable index for this property
             "dataType": [
-                "text"
+                "string"
             ],
             "description": "A description of the author",
             "name": "description"

--- a/developers/weaviate/configuration/replication.md
+++ b/developers/weaviate/configuration/replication.md
@@ -28,7 +28,7 @@ Replication is disabled by default and can be enabled per data class in the [sch
     {
       "name": "exampleProperty",
       "dataType": [
-        "text"
+        "string"
       ]
     }
   ],

--- a/developers/weaviate/configuration/schema-configuration.md
+++ b/developers/weaviate/configuration/schema-configuration.md
@@ -170,14 +170,14 @@ The response will be a JSON object, such as the example shown below.
         "text2vec-openai": {
           "model": "ada",
           "modelVersion": "002",
-          "type": "text",
+          "type": "string",
           "vectorizeClassName": true
         }
       },
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "moduleConfig": {
             "text2vec-openai": {
@@ -190,7 +190,7 @@ The response will be a JSON object, such as the example shown below.
         },
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "moduleConfig": {
             "text2vec-openai": {

--- a/developers/weaviate/modules/other-modules/custom-modules.md
+++ b/developers/weaviate/modules/other-modules/custom-modules.md
@@ -102,11 +102,11 @@ To use a new inference model (part 2) with an existing Weaviate interface (part 
 
 Request:
 ```bash
-curl localhost:8090/vectors/ -H "Content-Type: application/json" -d '{"text":"hello world"}'
+curl localhost:8090/vectors/ -H "Content-Type: application/json" -d '{"string":"hello world"}'
 ```
 Response:
 ```bash
-{"text":"hello world","vector":[-0.08469954133033752,0.4564870595932007, ..., 0.14153483510017395],"dim":384}
+{"string":"hello world","vector":[-0.08469954133033752,0.4564870595932007, ..., 0.14153483510017395],"dim":384}
 ```
 
 ### B. Build a completely new module

--- a/developers/weaviate/modules/reader-generator-modules/qna-openai.md
+++ b/developers/weaviate/modules/reader-generator-modules/qna-openai.md
@@ -139,7 +139,7 @@ The following schema configuration uses the `text-davinci-002` model.
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Content that will be vectorized",
           "name": "content"

--- a/developers/weaviate/modules/retriever-vectorizer-modules/img2vec-neural.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/img2vec-neural.md
@@ -164,7 +164,7 @@ A full example of a class using the `img2vec-neural` module is shown below. This
         },
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "label name (description) of the given image.",
           "name": "labelName"

--- a/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip.md
@@ -185,7 +185,7 @@ text fields using the `multi2vec-clip` module as a `vectorizer`:
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "name": "name"
         },

--- a/developers/weaviate/modules/retriever-vectorizer-modules/ref2vec-centroid.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/ref2vec-centroid.md
@@ -79,7 +79,7 @@ Although this example uses text2vec-contextionary to generate vectors for the `P
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Title of the article",
           "name": "title"
@@ -101,7 +101,7 @@ Although this example uses text2vec-contextionary to generate vectors for the `P
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Content that will be vectorized",
           "moduleConfig": {

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-cohere.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-cohere.md
@@ -83,7 +83,7 @@ The multilingual models use dot product, and the English model uses cosine. Make
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Content that will be vectorized",
           "moduleConfig": {

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md
@@ -111,7 +111,7 @@ For example
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Content that will be vectorized",
           "moduleConfig": {

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface.md
@@ -76,7 +76,7 @@ For example, the following schema configuration will set Weaviate to vectorize t
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Content that will be vectorized",
           "moduleConfig": {

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai.md
@@ -85,7 +85,7 @@ Set the vectorizer model using parameters `model`, `modelVersion` and `type` in 
         "text2vec-openai": {
           "model": "ada",
           "modelVersion": "002",
-          "type": "text"
+          "type": "string"
         }
       },
     }
@@ -130,12 +130,12 @@ Set property-level vectorizer behavior using the `moduleConfig` section under ea
         "text2vec-openai": {
           "model": "ada",
           "modelVersion": "002",
-          "type": "text"
+          "type": "string"
         }
       },
       "properties": [
         {
-          "dataType": ["text"],
+          "dataType": ["string"],
           "description": "Content that will be vectorized",
           "moduleConfig": {
             "text2vec-openai": {
@@ -191,7 +191,7 @@ The default model is `text-embedding-ada-002` but you can also specify it in you
         "text2vec-openai": {
           "model": "ada",
           "modelVersion": "002",
-          "type": "text"
+          "type": "string"
         }
       }
     }
@@ -225,7 +225,7 @@ Example (as part of a class definition):
         "text2vec-openai": {
           "model": "ada",
           "modelVersion": "002",
-          "type": "text"
+          "type": "string"
         }
       }
     }

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-palm.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-palm.md
@@ -171,7 +171,7 @@ Set property-level vectorizer behavior using the `moduleConfig` section under ea
       },
       "properties": [
         {
-          "dataType": ["text"],
+          "dataType": ["string"],
           "description": "Content that will be vectorized",
           "moduleConfig": {
             // highlight-start

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers.md
@@ -17,12 +17,12 @@ With the `text2vec-transformers` module, you can use one of any number of pretra
 The models are encapsulated in Docker containers. This allows for efficient scaling and resource planning. To choose your specific model, select the correct Docker container. There is a selection of pre-built Docker images available, but you can also build your own with a simple two-line Dockerfile. This separate-container microservice setup allows you to very easily host (and scale) the model independently on GPU-enabled hardware while keeping Weaviate on cheap CPU-only hardware, as  Weaviate is CPU-optimized.
 
 :::tip Significant GPU/CPU speed differences
-Transformer architecture models run *much* faster with GPUs, even for inference (10x+ speeds typically). 
+Transformer architecture models run *much* faster with GPUs, even for inference (10x+ speeds typically).
 
 Without a GPU, import or `nearText` queries may become bottlenecks in production if using `text2vec-transformers`.
 
 If this is the case, we recommend:
-- An API-based module such as [`text2vec-cohere`](./text2vec-cohere.md) or [`text2vec-openai`](./text2vec-openai.md), or 
+- An API-based module such as [`text2vec-cohere`](./text2vec-cohere.md) or [`text2vec-openai`](./text2vec-openai.md), or
 - The [`text2vec-contextionary`](./text2vec-contextionary.md) module if you prefer a local inference container.
 :::
 
@@ -203,7 +203,7 @@ to your `text2vec-transformers`.
 
 Then you can send REST requests to it directly, e.g.:
 ```shell
-curl localhost:9090/vectors -H 'Content-Type: application/json' -d '{"text": "foo bar"}
+curl localhost:9090/vectors -H 'Content-Type: application/json' -d '{"string": "foo bar"}
 ```
 and it will print the created vector directly.
 
@@ -228,7 +228,7 @@ For example:
       "properties": [
         {
           "dataType": [
-            "text"
+            "string"
           ],
           "description": "Content that will be vectorized",
           "moduleConfig": {

--- a/developers/weaviate/more-resources/migration-guide.md
+++ b/developers/weaviate/more-resources/migration-guide.md
@@ -47,7 +47,7 @@ Since filterable & searchable are separate indexes, filterable does not exist in
         "properties": [
           {
             "dataType": [
-              "text"
+              "string"
             ],
             "name": "name"
           },
@@ -673,7 +673,7 @@ With the modularization, it becomes possible to vectorize non-text objects. Sear
 
   ```json
   {
-    "dataType": [ "text" ],
+    "dataType": [ "string" ],
     "description": "string",
     "cardinality": "string",
     "vectorizePropertyName": true,
@@ -687,7 +687,7 @@ With the modularization, it becomes possible to vectorize non-text objects. Sear
 
   ```json
   {
-    "dataType": [ "text" ],
+    "dataType": [ "string" ],
     "description": "string",
     "moduleConfig": {
       "text2vec-contextionary": {
@@ -838,7 +838,7 @@ The Contextionary becomes the first vectorization module of Weaviate, renamed to
 
     ```json
     {
-      "dataType": [ "text" ],
+      "dataType": [ "string" ],
       "description": "string",
       "moduleConfig": {
         "text2vec-contextionary": {

--- a/developers/weaviate/tutorials/_how-to-create-a-schema.md
+++ b/developers/weaviate/tutorials/_how-to-create-a-schema.md
@@ -62,7 +62,7 @@ Classes always start with a capital letter. Properties always begin with a small
 
 Let's define the class `Publication` with the properties `name`, `hasArticles` and `headquartersGeoLocation` in JSON format. `name` will be the name of the `Publication`, in string format. `hasArticles` will be a reference to Article objects. We need to define the class `Articles` in the same schema to make sure the reference is possible. `headquartersGeoLocation` will be of the special dataType `geoCoordinates`.
 
-Note that the property `"title"` of the class `"Article"` has dataType `"string"`, while the property `"content"` is of dataType `"text"`. `string` values and `text` values are tokenized differently to each other.
+Note that the property `"title"` of the class `"Article"` has dataType `"string"`, while the property `"content"` is of dataType `"string"`. `string` values and `text` values are tokenized differently to each other.
 
 ```json
 {
@@ -71,7 +71,7 @@ Note that the property `"title"` of the class `"Article"` has dataType `"string"
   "properties": [
     {
       "dataType": [
-        "text"
+        "string"
       ],
       "description": "Name of the publication",
       "name": "name"
@@ -103,7 +103,7 @@ Add the classes `Article` and `Author` to the same schema, so you will end up wi
   "properties": [
     {
       "dataType": [
-        "text"
+        "string"
       ],
       "description": "Name of the publication",
       "name": "name"
@@ -129,14 +129,14 @@ Add the classes `Article` and `Author` to the same schema, so you will end up wi
   "properties": [
     {
       "dataType": [
-        "text"
+        "string"
       ],
       "description": "Title of the article",
       "name": "title"
     },
     {
       "dataType": [
-        "text"
+        "string"
       ],
       "description": "The content of the article",
       "name": "content"
@@ -148,7 +148,7 @@ Add the classes `Article` and `Author` to the same schema, so you will end up wi
   "properties": [
       {
         "dataType": [
-            "text"
+            "string"
         ],
         "description": "Name of the author",
         "name": "name"
@@ -181,7 +181,7 @@ Now, add this list of classes to the schema, which will look like this:
     "properties": [
       {
         "dataType": [
-          "text"
+          "string"
         ],
         "description": "Name of the publication",
         "name": "name"
@@ -207,14 +207,14 @@ Now, add this list of classes to the schema, which will look like this:
     "properties": [
       {
         "dataType": [
-          "text"
+          "string"
         ],
         "description": "Title of the article",
         "name": "title"
       },
       {
         "dataType": [
-          "text"
+          "string"
         ],
         "description": "The content of the article",
         "name": "content"
@@ -226,7 +226,7 @@ Now, add this list of classes to the schema, which will look like this:
     "properties": [
       {
         "dataType": [
-            "text"
+            "string"
         ],
         "description": "Name of the author",
         "name": "name"

--- a/developers/weaviate/tutorials/modules.md
+++ b/developers/weaviate/tutorials/modules.md
@@ -114,7 +114,7 @@ You will see that the class and property names are not indexed, but the article 
             "properties": [
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "title of the article",
                     "indexFilterable": true,
@@ -130,7 +130,7 @@ You will see that the class and property names are not indexed, but the article 
                 },
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "url of the article",
                     "indexFilterable": true,
@@ -146,7 +146,7 @@ You will see that the class and property names are not indexed, but the article 
                 },
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "summary of the article",
                     "indexFilterable": true,

--- a/developers/weaviate/tutorials/schema.md
+++ b/developers/weaviate/tutorials/schema.md
@@ -126,14 +126,14 @@ The result should look something like this:
                 "text2vec-openai": {
                     "model": "ada",
                     "modelVersion": "002",
-                    "type": "text",
+                    "type": "string",
                     "vectorizeClassName": true
                 }
             },
             "properties": [
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "The question",
                     "moduleConfig": {
@@ -147,7 +147,7 @@ The result should look something like this:
                 },
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "The answer",
                     "moduleConfig": {
@@ -161,7 +161,7 @@ The result should look something like this:
                 },
                 {
                     "dataType": [
-                        "text"
+                        "string"
                     ],
                     "description": "The category",
                     "moduleConfig": {
@@ -242,7 +242,7 @@ So for example, you might specify a schema like the one below:
     },
     "properties": [
         {
-            "dataType": ["text"],
+            "dataType": ["string"],
             "description": "The question",
             "moduleConfig": {
                 "text2vec-openai": {

--- a/developers/weaviate/tutorials/spark-connector.md
+++ b/developers/weaviate/tutorials/spark-connector.md
@@ -120,19 +120,19 @@ client.schema.create_class(
         "properties": [
             {
                 "name": "raw",
-                "dataType": ["text"]
+                "dataType": ["string"]
             },
             {
                 "name": "sha",
-                "dataType": ["text"]
+                "dataType": ["string"]
             },
             {
                 "name": "title",
-                "dataType": ["text"]
+                "dataType": ["string"]
             },
             {
                 "name": "url",
-                "dataType": ["text"]
+                "dataType": ["string"]
             },
         ],
     }

--- a/developers/weaviate/tutorials/wikipedia.md
+++ b/developers/weaviate/tutorials/wikipedia.md
@@ -86,7 +86,7 @@ As of Weaviate 1.18, the `text2vec-openai` vectorizer uses by default the same m
     "text2vec-openai": {
       "model": "ada",
       "modelVersion": "002",
-      "type": "text"
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
Change deprecated `text` type to `string` type.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
