### PR TITLE
[docs] split filter into two pages

### DIFF
--- a/developers/weaviate/api/graphql/additional-operators.md
+++ b/developers/weaviate/api/graphql/additional-operators.md
@@ -1,0 +1,194 @@
+---
+title: GraphQL - Additional operators
+sidebar_position: 5
+image: og/docs/api.jpg
+# tags: ['graphql', 'additional operators']
+---
+
+import Badges from '/_includes/badges.mdx';
+
+<Badges/>
+
+## Syntax
+
+Additional operators such as `limit`, `after` and `sort` are available to modify queries at the class level.
+<!--
+For example:
+
+import GraphQLFiltersExample from '/_includes/code/graphql.filters.example.mdx';
+
+<GraphQLFiltersExample/> -->
+
+
+## Limit argument
+
+Supported by the `Get{}`, `Explore{}` and `Aggregate{}` function.
+
+A `limit` argument limits the number of results.
+
+An example of a stand-alone `limit` filter:
+
+import GraphQLFiltersLimit from '/_includes/code/graphql.filters.limit.mdx';
+
+<GraphQLFiltersLimit/>
+
+<MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28limit%3A5%29+%7B%0D%0A++++++title%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
+
+#### Example response
+
+```json
+{
+  "data": {
+    "Get": {
+      "Article": [
+        {
+          "title": "The War Vet, the Dating Site, and the Phone Call From Hell"
+        },
+        {
+          "title": "Opinion | John Lennon Told Them ‘Girls Don't Play Guitar.' He Was So Wrong."
+        },
+        {
+          "title": "The press pressed - Brazilian prosecutors go after Glenn Greenwald, an American journalist"
+        },
+        {
+          "title": "Not to Ruin the Super Bowl, but the Sea Is Consuming Miami"
+        },
+        {
+          "title": "Coca-Cola Resurrects Post of Chief Marketing Officer"
+        }
+      ]
+    }
+  },
+  "errors": null
+}
+```
+
+## Pagination with `offset`
+
+Supported by the `Get{}`, `Explore{}` and `Aggregate{}` function.
+
+The offset parameter works in conjunction with the existing limit parameter. For example, to list the first ten results, set `limit: 10`. Then, to "display the second page of 10", set `offset: 10`, `limit:10` and so on. E.g. to show the 9th page of 10 results, set `offset:80, limit:10` to effectively display results 81-90.
+
+An example of a stand-alone `limit` filter:
+
+import GraphQLFiltersOffset from '/_includes/code/graphql.filters.offset.mdx';
+
+<GraphQLFiltersOffset/>
+
+<MoleculeGQLDemo query='%7B%0A%20%20Get%20%7B%0A%20%20%20%20Article(%0A%20%20%20%20%20%20limit%3A%205%2C%0A%20%20%20%20%20%20offset%3A%202%0A%20%20%20%20)%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D'/>
+
+#### Example response
+
+```json
+{
+  "data": {
+    "Get": {
+      "Article": [
+        {
+          "title": "Hong Kong tries its best to spoil China's big anniversary"
+        },
+        {
+          "title": "‘People don't want any of them': Peru election sees unpredictable contest"
+        },
+        {
+          "title": "Brazil: homes of Bolsonaro associates raided in sweeping anti-corruption operation"
+        },
+        {
+          "title": "If Convicting Trump Is Out of Reach, Managers Seek a Verdict From the Public and History"
+        },
+        {
+          "title": "Watch The Juliana Plaintiffs Vic Barrett, Kelsey Juliana, and Levi Draheim in Conversation with Sandra Upson | Wired Video | CNE | Wired.com"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Performance and resource considerations & limitations
+
+The pagination implementation is an offset-based implementation, not a cursor-based implementation. This has the following implications:
+
+- The cost of retrieving one further page is higher than that of the last. Effectively when searching for search results 91-100, Weaviate will internally retrieve 100 search results and discard results 0-90 before serving them to the user. This effect is amplified if running in a multi-shard setup, where each shard would retrieve 100 results, then the results aggregated and ultimately cut off. So in a 10-shard setup asking for results 91-100 Weaviate will effectively have to retrieve 1000 results (100 per shard) and discard 990 of them before serving. This means, high page numbers lead to longer response times and more load on the machine/cluster.
+- Due to the increasing cost of each page outlined above, there is a limit to how many objects can be retrieved using pagination. By default setting the sum of `offset` and `limit` to higher than 10,000 objects, will lead to an error. If you must retrieve more than 10,000 objects, you can increase this limit by setting the environment variable `QUERY_MAXIMUM_RESULTS=<desired-value>`. Warning: Setting this to arbitrarily high values can make the memory consumption of a single query explode and single queries can slow down the entire cluster. We recommend setting this value to the lowest possible value that does not interfere with your users' expectations.
+- The pagination setup is not stateful. If the database state has changed between retrieving two pages there is no guarantee that your pages cover all results. If no writes happened, then pagination can be used to retrieve all possible within the maximum limit. This means asking for a single page of 10,000 objects will lead to the same results overall as asking for 100 pages of 100 results.
+
+## Cursor with `after`
+
+Starting with version `1.18`, the `after` parameter can be used to sequentially retrieve class objects from Weaviate. This may be useful for retrieving an entire set of objects from Weaviate, for example.
+
+The `after` parameter relies on the order of ids. It can therefore only be applied to list queries without any search operators. In other words, `after` is not compatible with `where`, `near<Media>`, `bm25`, `hybrid`, etc.
+
+For those cases, use pagination with `offset`.
+
+An example of the `after` parameter usage:
+
+import GraphQLFiltersAfter from '/_includes/code/graphql.filters.after.mdx';
+
+<GraphQLFiltersAfter/>
+
+:::note
+The `after` cursor is available on both single-shard and multi-shard set-ups.
+:::
+
+## Sorting
+
+:::info
+Support for sorting was added in `v1.13.0`.
+:::
+
+You can sort results by any primitive property, typically a `text`, `string`, `number`, or `int` property. When a query has a natural order (e.g. because of a `near<Media>` vector search), adding a sort operator will override the order.
+
+### Cost of sorting / architecture
+
+Weaviate's sorting implementation is built in a way that it does not lead to massive memory spikes; it does not need to load all objects to be sorted into memory completely. Only the property value being sorted is kept in memory.
+
+As of now, Weaviate does not have any data structures on disk specific to sorting, such as a column-oriented storage mechanism. As a result when an object should be sorted, the whole object is identified on disk and the relevant property extracted. This works reasonably well for small scales (100s of thousand or millions), but comes with a high cost at large lists of objects to be sorted (100s of millions, billions).  A column-oriented storage mechanism may be introduced in the future to  overcome this performance limitation.
+
+### Sorting decisions
+
+#### booleans order
+`false` is considered smaller than `true`. `false` comes before `true` in ascending order and after `true` in descending order.
+
+#### nulls order
+`null` values are considered smaller than any non-`null` values. `null` values come first in ascending order and last in descending order.
+
+#### arrays order
+Arrays are compared by each element separately. Elements at the same position are compared to each other, starting from the beginning of an array. First element smaller than its counterpart makes whole array smaller.
+
+Arrays are equal if they have the same size and all elements are equal. If array is subset of other array it is considered smaller.
+
+Examples:
+- `[1, 2, 3] = [1, 2, 3]`
+- `[1, 2, 4] < [1, 3, 4]`
+- `[2, 2] > [1, 2, 3, 4]`
+- `[1, 2, 3] < [1, 2, 3, 4]`
+
+### Sorting API
+
+import GraphQLGetSorting from '/_includes/code/graphql.get.sorting.mdx';
+
+### Additional properties
+
+Sometimes sorting by an additional property is required, such as `id`, `creationTimeUnix`, or `lastUpdateTimeUnix`.  This can be achieved by prefixing the property name with an underscore.
+
+For example:
+```graphql
+{
+  Get {
+    Article(sort: [{path: ["_creationTimeUnix"], order: asc}]) {
+      title
+    }
+  }
+}
+```
+
+<GraphQLGetSorting/>
+
+<MoleculeGQLDemo query='%7B%0A++Get+%7B%0A++++Article%28sort%3A+%5B%7B%0A++++++path%3A+%5B%22title%22%5D%0A++++++order%3A+asc%0A++++%7D%5D%29+%7B%0A++++++title%0A++++++url%0A++++++wordCount%0A++++%7D%0A++%7D%0A%7D'/>
+
+## More Resources
+
+import DocsMoreResources from '/_includes/more-resources-docs.md';
+
+<DocsMoreResources />

--- a/developers/weaviate/api/graphql/additional-properties.md
+++ b/developers/weaviate/api/graphql/additional-properties.md
@@ -1,6 +1,6 @@
 ---
 title: GraphQL - Additional properties
-sidebar_position: 6
+sidebar_position: 9
 image: og/docs/api.jpg
 # tags: ['graphql', 'additional properties', 'additional', 'underscore']
 ---

--- a/developers/weaviate/api/graphql/filters.md
+++ b/developers/weaviate/api/graphql/filters.md
@@ -1,26 +1,41 @@
 ---
-title: GraphQL - Filters
+title: GraphQL - Conditional filters
 sidebar_position: 4
 image: og/docs/api.jpg
 # tags: ['graphql', 'filters']
 ---
+
 import Badges from '/_includes/badges.mdx';
 
 <Badges/>
 
-## Setting filters
+## Overview
 
-Filters are added to GraphQL queries on the class level.
-
-For example:
-
+Conditional filters can be added to queries on the class level. The operator used for filtering is also called a `where` filter.
+<!--
 import GraphQLFiltersExample from '/_includes/code/graphql.filters.example.mdx';
 
-<GraphQLFiltersExample/>
+<GraphQLFiltersExample/> -->
 
-## Where filter
+## Single operand (condition)
 
-### Filter structure
+Each set of algebraic conditions is called an "operand". For each operand, the required properties are:
+- The GraphQL property path,
+- The operator type, and
+- The valueType with the value.
+
+For example, this filter will only allow objects from the class `Article` with a `wordCount` that is `GreaterThan` than `1000`.
+
+import GraphQLFiltersWhereSimple from '/_includes/code/graphql.filters.where.simple.mdx';
+
+<GraphQLFiltersWhereSimple/>
+
+import MoleculeGQLDemo from '/_includes/molecule-gql-demo.mdx';
+
+<MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28where%3A+%7B%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%2C++++%23+Path+to+the+property+that+should+be+used%0D%0A++++++++operator%3A+GreaterThan%2C++%23+operator%0D%0A++++++++valueInt%3A+1000++++++++++%23+value+%28which+is+always+%3D+to+the+type+of+the+path+property%29%0D%0A++++++%7D%29+%7B%0D%0A++++++title%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
+<br/>
+
+## Filter structure
 
 Supported by the [`Get{}`](./get.md) and [`Aggregate{}`](./aggregate.md) functions.
 
@@ -50,13 +65,11 @@ The `where` filter is an [algebraic object](https://en.wikipedia.org/wiki/Algebr
    }
  }
  ```
-the path selector for `name` will be `["inPublication", "Publication", "name"]`.
-- `valueInt`: The integer value that the last property in the `Path` selector should be compared to.
-- `valueBoolean`: The boolean value that the last property in `Path` should be compared to.
-- `valueString`: The string value that the last property in `Path` should be compared to.
-- `valueText`: The text value that the last property in `Path` should be compared to.
-- `valueNumber`: The number (float) value that the last property in `Path` should be compared to.
-- `valueDate`: The date (ISO 8601 timestamp, formatted as [RFC3339](https://datatracker.ietf.org/doc/rfc3339/)) value that the last property  in `Path` should be compared to.
+  Here, the path selector for `name` will be `["inPublication", "Publication", "name"]`.
+
+- `valueType`
+
+### Example filter structure
 
 ```graphql
 {
@@ -84,31 +97,26 @@ the path selector for `name` will be `["inPublication", "Publication", "name"]`.
 }
 ```
 
-#### Filter behavior of multi-word queries in `Equal` operator
+### Available `valueType` values
 
-The behavior for the `Equal` operator on multi-word textual properties in `where` filters depends on the property type (`string` or `text`), and the `tokenization` property.
+- `valueInt`: The integer value that the last property in the `Path` selector should be compared to.
+- `valueBoolean`: The boolean value that the last property in `Path` should be compared to.
+- `valueString`: The string value that the last property in `Path` should be compared to.
+- `valueText`: The text value that the last property in `Path` should be compared to.
+- `valueNumber`: The number (float) value that the last property in `Path` should be compared to.
+- `valueDate`: The date (ISO 8601 timestamp, formatted as [RFC3339](https://datatracker.ietf.org/doc/rfc3339/)) value that the last property  in `Path` should be compared to.
+
+### Filter behavior of multi-word queries in `Equal` operator
+
+The behavior for the `Equal` operator on multi-word textual properties in `where` filters depends on the `tokenization` of the property.
 
 Refer to [this section](../../config-refs/schema.md#property-tokenization) on the difference between the two types.
 
-#### Stopwords in `text`/`string` filter values
+### Stopwords in `text`/`string` filter values
 
 Starting with `v1.12.0` you can configure your own [stopword lists for the inverted index](/developers/weaviate/config-refs/schema.md#invertedindexconfig--stopwords-stopword-lists).
 
-### Single operand
-
-You can create operator filters by setting the `where` key. You always need to include the GraphQL property path, the operator type, and the valueType plus a value.
-
-For example, this filter selects articles from the class Article with a wordcount higher than 1000.
-
-import GraphQLFiltersWhereSimple from '/_includes/code/graphql.filters.where.simple.mdx';
-
-<GraphQLFiltersWhereSimple/>
-
-import MoleculeGQLDemo from '/_includes/molecule-gql-demo.mdx';
-
-<MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28where%3A+%7B%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%2C++++%23+Path+to+the+property+that+should+be+used%0D%0A++++++++operator%3A+GreaterThan%2C++%23+operator%0D%0A++++++++valueInt%3A+1000++++++++++%23+value+%28which+is+always+%3D+to+the+type+of+the+path+property%29%0D%0A++++++%7D%29+%7B%0D%0A++++++title%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
-
-#### Example response
+### Example response
 
 ```json
 {
@@ -125,7 +133,7 @@ import MoleculeGQLDemo from '/_includes/molecule-gql-demo.mdx';
 }
 ```
 
-### Filter by id
+## Filter by id
 
 You can filter object by their unique id or uuid, where you give the `id` as `valueString`.
 
@@ -134,8 +142,9 @@ import GraphQLFiltersWhereId from '/_includes/code/graphql.filters.where.id.mdx'
 <GraphQLFiltersWhereId/>
 
 <MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28where%3A+%7B%0D%0A++++++++path%3A+%5B%22id%22%5D%2C%0D%0A++++++++operator%3A+Equal%2C%0D%0A++++++++valueString%3A+%22e5dc4a4c-ef0f-3aed-89a3-a73435c6bbcf%22%0D%0A++++++%7D%29+%7B%0D%0A++++++title%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
+<br/>
 
-#### Example response
+### Example response
 
 ```json
 {
@@ -152,7 +161,7 @@ import GraphQLFiltersWhereId from '/_includes/code/graphql.filters.where.id.mdx'
 }
 ```
 
-### Filter by timestamps
+## Filter by timestamps
 
 Filtering can be performed with internal timestamps as well, such as `creationTimeUnix` and `lastUpdateTimeUnix`. These values can be represented either as Unix epoch milliseconds, or as [RFC3339](https://datatracker.ietf.org/doc/rfc3339/) formatted datetimes. Note that epoch milliseconds should be passed in as a `valueString`, and an RFC3339 datetime should be a `valueDate`.
 
@@ -165,8 +174,9 @@ import GraphQLFiltersWhereTimestamps from '/_includes/code/graphql.filters.where
 <GraphQLFiltersWhereTimestamps/>
 
 <MoleculeGQLDemo query='%7B%0A++Get+%7B%0A++++Article(where%3A+%7B%0A++++++++path%3A+%5B%22_creationTimeUnix%22%5D%2C%0A++++++++operator%3A+Equal%2C%0A++++++++valueString%3A+%221647653194586%22%0A++++++%7D)+%7B%0A++++++title%0A++++%7D%0A++%7D%0A%7D'/>
+<br/>
 
-#### Example Response
+### Example Response
 
 ```json
 {
@@ -183,7 +193,7 @@ import GraphQLFiltersWhereTimestamps from '/_includes/code/graphql.filters.where
 }
 ```
 
-### Filter by property length
+## Filter by property length
 
 Filtering can be performed with the length of properties.
 
@@ -209,7 +219,7 @@ Filtering by property length requires the target class to be configured to index
 :::
 
 
-### Multiple operands
+## Multiple operands
 
 You can set multiple operands by providing an array.
 
@@ -224,8 +234,9 @@ import GraphQLFiltersWhereOperands from '/_includes/code/graphql.filters.where.o
 <GraphQLFiltersWhereOperands/>
 
 <MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28where%3A+%7B%0D%0A++++++operator%3A+And%2C%0D%0A++++++operands%3A+%5B%7B%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%2C%0D%0A++++++++++operator%3A+GreaterThan%2C%0D%0A++++++++++valueInt%3A+1000%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%2C%0D%0A++++++++++operator%3A+LessThan%2C%0D%0A++++++++++valueInt%3A+1500%0D%0A++++++++%7D%5D%0D%0A++++++%7D%29+%7B%0D%0A++++++title%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
+<br/>
 
-### Like operator
+## Like operator
 
 Using the `Like` operator allows you to do string searches based on partial match. The capabilities of this operator are:
 
@@ -240,11 +251,12 @@ import GraphQLFiltersWhereLike from '/_includes/code/graphql.filters.where.like.
 <GraphQLFiltersWhereLike/>
 
 <MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28where%3A+%7B%0D%0A++++++++++path%3A+%5B%22name%22%5D%2C%0D%0A++++++++++operator%3A+Like%2C%0D%0A++++++++++valueString%3A+%22New+%2A%22%0D%0A++++++%7D%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
+<br/>
 
-#### Notes
+### Notes
 Each query using the `Like` operator iterates over the entire inverted index for that property. The search time will go up linearly with the dataset size. Be aware that there might be a point where this query is too expensive and will not work anymore. We will improve this implementation in a future release. You can leave feedback or feature requests in a [GitHub issue](https://github.com/weaviate/weaviate/issues).
 
-#### Example response
+### Example response
 
 ```json
 {
@@ -264,7 +276,7 @@ Each query using the `Like` operator iterates over the entire inverted index for
 }
 ```
 
-### Beacon (reference) filters
+## Beacon (reference) filters
 
 You can also search for the value of the property of a beacon.
 
@@ -275,8 +287,9 @@ import GraphQLFiltersWhereBeacon from '/_includes/code/graphql.filters.where.bea
 <GraphQLFiltersWhereBeacon/>
 
 <MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28where%3A+%7B%0D%0A++++++++path%3A+%5B%22inPublication%22%2C+%22Publication%22%2C+%22name%22%5D%2C%0D%0A++++++++operator%3A+Equal%2C%0D%0A++++++++valueString%3A+%22New+Yorker%22%0D%0A++++++%7D%29+%7B%0D%0A++++++title%0D%0A++++++inPublication%7B%0D%0A++++++++...+on+Publication%7B%0D%0A++++++++++name%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
+<br/>
 
-### Filter objects by count of reference
+## Filter objects by count of reference
 
 Above example shows how filter by reference can solve straightforward questions like "Find all articles that are published by New Yorker". But questions like "Find all articles that are written by authors that wrote at least two articles", cannot be answered by the above query structure. It is however possible to filter by reference count. To do so, simply provide one of the existing compare operators (`Equal`, `LessThan`, `LessThanEqual`, `GreaterThan`, `GreaterThanEqual`) and use it directly on the reference element. For example:
 
@@ -285,8 +298,9 @@ import GraphQLFiltersWhereBeaconCount from '/_includes/code/graphql.filters.wher
 <GraphQLFiltersWhereBeaconCount/>
 
 <MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Author%28%0D%0A++++++where%3A%7B%0D%0A++++++++valueInt%3A+2%2C%0D%0A++++++++operator%3A+GreaterThanEqual%2C%0D%0A++++++++path%3A+%5B%22wroteArticles%22%5D%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++++wroteArticles+%7B%0D%0A++++++++...+on+Article+%7B%0D%0A++++++++++title%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A+%7D'/>
+<br/>
 
-### GeoCoordinates filter
+## GeoCoordinates filter
 
 A special case of the `Where` filter is with geoCoordinates. This filter is only supported by the `Get{}` function. If you've set the `geoCoordinates` property type, you can search in an area based on kilometers.
 
@@ -297,8 +311,9 @@ import GraphQLFiltersWhereGeocoords from '/_includes/code/graphql.filters.where.
 <GraphQLFiltersWhereGeocoords/>
 
 <MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28where%3A+%7B%0D%0A++++++operator%3A+WithinGeoRange%2C%0D%0A++++++valueGeoRange%3A+%7B%0D%0A++++++++geoCoordinates%3A+%7B%0D%0A++++++++++latitude%3A+51.51%2C++++%23+latitude%0D%0A++++++++++longitude%3A+-0.09++++%23+longitude%0D%0A++++++++%7D%2C%0D%0A++++++++distance%3A+%7B%0D%0A++++++++++max%3A+2000+++++++++++%23+distance+in+meters%0D%0A++++++++%7D%0D%0A++++++%7D%2C%0D%0A++++++path%3A+%5B%22headquartersGeoLocation%22%5D+%23+property+needs+to+be+of+geoLocation+type.%0D%0A++++%7D%29+%7B%0D%0A++++++name%0D%0A++++++headquartersGeoLocation+%7B%0D%0A++++++++latitude%0D%0A++++++++longitude+%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
+<br/>
 
-#### Example response
+### Example response
 
 ```json
 {
@@ -326,7 +341,7 @@ import GraphQLFiltersWhereGeocoords from '/_includes/code/graphql.filters.where.
 }
 ```
 
-### Filter by null state
+## Filter by null state
 
 Using the `IsNull` operator allows you to do filter for objects where given properties are `null` or `not null`. Note that zero-length arrays and empty strings are equivalent to a null value.
 
@@ -343,173 +358,6 @@ Using the `IsNull` operator allows you to do filter for objects where given prop
 
 :::note
 Filtering by null-state requires the target class to be configured to index this. See [here](../../config-refs/schema.md#invertedindexconfig--indexnullstate) for details.
-:::
-
-## Sorting
-
-:::info
-Support for sorting was added in `v1.13.0`.
-:::
-
-You can sort results by any primitive property, typically a `text`, `string`, `number`, or `int` property. When a query has a natural order (e.g. because of a `near<Media>` vector search), adding a sort operator will override the order.
-
-### Cost of sorting / architecture
-
-Weaviate's sorting implementation is built in a way that it does not lead to massive memory spikes; it does not need to load all objects to be sorted into memory completely. Only the property value being sorted is kept in memory.
-
-As of now, Weaviate does not have any data structures on disk specific to sorting, such as a column-oriented storage mechanism. As a result when an object should be sorted, the whole object is identified on disk and the relevant property extracted. This works reasonably well for small scales (100s of thousand or millions), but comes with a high cost at large lists of objects to be sorted (100s of millions, billions).  A column-oriented storage mechanism may be introduced in the future to  overcome this performance limitation.
-
-### Sorting decisions
-
-#### booleans order
-`false` is considered smaller than `true`. `false` comes before `true` in ascending order and after `true` in descending order.
-
-#### nulls order
-`null` values are considered smaller than any non-`null` values. `null` values come first in ascending order and last in descending order.
-
-#### arrays order
-Arrays are compared by each element separately. Elements at the same position are compared to each other, starting from the beginning of an array. First element smaller than its counterpart makes whole array smaller.
-
-Arrays are equal if they have the same size and all elements are equal. If array is subset of other array it is considered smaller.
-
-Examples:
-- `[1, 2, 3] = [1, 2, 3]`
-- `[1, 2, 4] < [1, 3, 4]`
-- `[2, 2] > [1, 2, 3, 4]`
-- `[1, 2, 3] < [1, 2, 3, 4]`
-
-### Sorting API
-
-import GraphQLGetSorting from '/_includes/code/graphql.get.sorting.mdx';
-
-### Additional properties
-
-Sometimes sorting by an additional property is required, such as `id`, `creationTimeUnix`, or `lastUpdateTimeUnix`.  This can be achieved by prefixing the property name with an underscore.
-
-For example:
-```graphql
-{
-  Get {
-    Article(sort: [{path: ["_creationTimeUnix"], order: asc}]) {
-      title
-    }
-  }
-}
-```
-
-<GraphQLGetSorting/>
-
-<MoleculeGQLDemo query='%7B%0A++Get+%7B%0A++++Article%28sort%3A+%5B%7B%0A++++++path%3A+%5B%22title%22%5D%0A++++++order%3A+asc%0A++++%7D%5D%29+%7B%0A++++++title%0A++++++url%0A++++++wordCount%0A++++%7D%0A++%7D%0A%7D'/>
-
-## Limit argument
-
-Supported by the `Get{}`, `Explore{}` and `Aggregate{}` function.
-
-A `limit` argument limits the number of results.
-
-An example of a stand-alone `limit` filter:
-
-import GraphQLFiltersLimit from '/_includes/code/graphql.filters.limit.mdx';
-
-<GraphQLFiltersLimit/>
-
-<MoleculeGQLDemo query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28limit%3A5%29+%7B%0D%0A++++++title%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D'/>
-
-#### Example response
-
-```json
-{
-  "data": {
-    "Get": {
-      "Article": [
-        {
-          "title": "The War Vet, the Dating Site, and the Phone Call From Hell"
-        },
-        {
-          "title": "Opinion | John Lennon Told Them ‘Girls Don't Play Guitar.' He Was So Wrong."
-        },
-        {
-          "title": "The press pressed - Brazilian prosecutors go after Glenn Greenwald, an American journalist"
-        },
-        {
-          "title": "Not to Ruin the Super Bowl, but the Sea Is Consuming Miami"
-        },
-        {
-          "title": "Coca-Cola Resurrects Post of Chief Marketing Officer"
-        }
-      ]
-    }
-  },
-  "errors": null
-}
-```
-
-## Pagination with `offset`
-
-Supported by the `Get{}`, `Explore{}` and `Aggregate{}` function.
-
-The offset parameter works in conjunction with the existing limit parameter. For example, to list the first ten results, set `limit: 10`. Then, to "display the second page of 10", set `offset: 10`, `limit:10` and so on. E.g. to show the 9th page of 10 results, set `offset:80, limit:10` to effectively display results 81-90.
-
-An example of a stand-alone `limit` filter:
-
-import GraphQLFiltersOffset from '/_includes/code/graphql.filters.offset.mdx';
-
-<GraphQLFiltersOffset/>
-
-<MoleculeGQLDemo query='%7B%0A%20%20Get%20%7B%0A%20%20%20%20Article(%0A%20%20%20%20%20%20limit%3A%205%2C%0A%20%20%20%20%20%20offset%3A%202%0A%20%20%20%20)%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D'/>
-
-#### Example response
-
-```json
-{
-  "data": {
-    "Get": {
-      "Article": [
-        {
-          "title": "Hong Kong tries its best to spoil China's big anniversary"
-        },
-        {
-          "title": "‘People don't want any of them': Peru election sees unpredictable contest"
-        },
-        {
-          "title": "Brazil: homes of Bolsonaro associates raided in sweeping anti-corruption operation"
-        },
-        {
-          "title": "If Convicting Trump Is Out of Reach, Managers Seek a Verdict From the Public and History"
-        },
-        {
-          "title": "Watch The Juliana Plaintiffs Vic Barrett, Kelsey Juliana, and Levi Draheim in Conversation with Sandra Upson | Wired Video | CNE | Wired.com"
-        }
-      ]
-    }
-  }
-}
-```
-
-### Performance and resource considerations & limitations
-
-The pagination implementation is an offset-based implementation, not a cursor-based implementation. This has the following implications:
-
-- The cost of retrieving one further page is higher than that of the last. Effectively when searching for search results 91-100, Weaviate will internally retrieve 100 search results and discard results 0-90 before serving them to the user. This effect is amplified if running in a multi-shard setup, where each shard would retrieve 100 results, then the results aggregated and ultimately cut off. So in a 10-shard setup asking for results 91-100 Weaviate will effectively have to retrieve 1000 results (100 per shard) and discard 990 of them before serving. This means, high page numbers lead to longer response times and more load on the machine/cluster.
-- Due to the increasing cost of each page outlined above, there is a limit to how many objects can be retrieved using pagination. By default setting the sum of `offset` and `limit` to higher than 10,000 objects, will lead to an error. If you must retrieve more than 10,000 objects, you can increase this limit by setting the environment variable `QUERY_MAXIMUM_RESULTS=<desired-value>`. Warning: Setting this to arbitrarily high values can make the memory consumption of a single query explode and single queries can slow down the entire cluster. We recommend setting this value to the lowest possible value that does not interfere with your users' expectations.
-- The pagination setup is not stateful. If the database state has changed between retrieving two pages there is no guarantee that your pages cover all results. If no writes happened, then pagination can be used to retrieve all possible within the maximum limit. This means asking for a single page of 10,000 objects will lead to the same results overall as asking for 100 pages of 100 results.
-
-## Cursor with `after`
-
-Starting with version `1.18`, the `after` parameter can be used to sequentially retrieve class objects from Weaviate. This may be useful for retrieving an entire set of objects from Weaviate, for example.
-
-The `after` parameter relies on the order of ids. It can therefore only be applied to list queries without any search operators. In other words, `after` is not compatible with `where`, `near<Media>`, `bm25`, `hybrid`, etc.
-
-For those cases, use pagination with `offset`.
-
-An example of the `after` parameter usage:
-
-import GraphQLFiltersAfter from '/_includes/code/graphql.filters.after.mdx';
-
-<GraphQLFiltersAfter/>
-
-:::note
-The `after` cursor is available on both single-shard and multi-shard set-ups.
 :::
 
 ## More Resources

--- a/developers/weaviate/api/graphql/vector-search-parameters.md
+++ b/developers/weaviate/api/graphql/vector-search-parameters.md
@@ -1,6 +1,6 @@
 ---
 title: GraphQL - Vector search parameters
-sidebar_position: 5
+sidebar_position: 7
 image: og/docs/api.jpg
 # tags: ['graphql', 'vector search parameters']
 ---


### PR DESCRIPTION
### What's being changed:

[docs] split filter into two pages

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
