### PR TITLE
[Howto search basics] Add TS example for cross-ref prop retrieval

### DIFF
--- a/_includes/code/howto/search.basics.js
+++ b/_includes/code/howto/search.basics.js
@@ -195,17 +195,32 @@ getObjectIdQuery();
 // Test
 getObjectIdQuery().then(res => {
   assert('JeopardyQuestion' in res.data.Get);
-  assert.deepEqual(res.data.Get.JeopardyQuestion.length, 1)
+  assert.deepEqual(res.data.Get.JeopardyQuestion.length, 1);
   const additionalKeys = new Set(Object.keys(res.data.Get.JeopardyQuestion[0]._additional));
   assert.deepEqual(additionalKeys, new Set(['id']));
 });
 // End test
 
-// ==================================
+// =======================================
 // ===== GET WITH CROSS-REF EXAMPLES =====
-// ==================================
+// =======================================
 
 
 // GetWithCrossRefsJS
-// Coming soon
+const response = await client.graphql
+  .get()
+  .withClassName('JeopardyQuestion')
+  // highlight-start
+  .withFields(`
+  question
+  hasCategory {
+    ... on JeopardyCategory {
+      title
+    }
+  }`)
+  // highlight-end
+  .withLimit(2)
+  .do();
+
+console.log(JSON.stringify(response, null, 2));
 // END GetWithCrossRefsJS

--- a/_includes/code/howto/search.basics.py
+++ b/_includes/code/howto/search.basics.py
@@ -401,7 +401,12 @@ assert gqlresponse == response
 # GetWithCrossRefsPython
 response = (
     client.query
-    .get("JeopardyQuestion", ["question", "hasCategory { ... on JeopardyCategory { title } }"])
+    # highlight-start
+    .get("JeopardyQuestion", [
+      "question",
+      "hasCategory { ... on JeopardyCategory { title } }"
+    ])
+    # highlight-end
     .with_limit(2)
     .do()
 )
@@ -447,10 +452,16 @@ gql_query = """
     JeopardyQuestion (
       limit: 2
     )
+    # highlight-start
     {
       question
-      hasCategory { ... on JeopardyCategory { title } }
+      hasCategory {
+        ... on JeopardyCategory {
+          title
+        }
+      }
     }
+    # highlight-end
   }
 }
 # END GetWithCrossRefsGraphQL

--- a/developers/weaviate/search/basics.md
+++ b/developers/weaviate/search/basics.md
@@ -351,7 +351,7 @@ You can retrieve any properties of cross-referenced objects by specifying:
 - The target cross-referenced object class, and
 - The desired properties to retrieve (of the cross-referenced objects).
 
-The following example, retrieves for each `JeopardyQuestion` object the cross-referenced `JeopardyCategory` object, and the `JeopardyCategory` object's `title` property is returned.
+The following example, retrieves for each `JeopardyQuestion` object the cross-referenced `JeopardyCategory` object, and the `JeopardyCategory` object's `title` property is returned. The property is accessed using the [inline fragment](http://spec.graphql.org/June2018/#sec-Inline-Fragments) GraphQL syntax.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python">
@@ -364,7 +364,7 @@ The following example, retrieves for each `JeopardyQuestion` object the cross-re
 />
 
 </TabItem>
-<TabItem value="js" label="JavaScript/TypeScript">
+<TabItem value="js" label="TypeScript">
 
 <FilteredTextBlock
   text={JSCode}


### PR DESCRIPTION
For https://weaviate.io/developers/weaviate/search/basics#retrieve-cross-referenced-properties.

Added a brief mention about GraphQL inline fragments to explain the "... on" syntax.