### PR TITLE
limit p selector to box

### DIFF
--- a/src/components/Careers/Header/styles.module.scss
+++ b/src/components/Careers/Header/styles.module.scss
@@ -65,7 +65,7 @@ p {
       -webkit-text-fill-color: transparent;
   }
 
-  .box h3, p {
+  .box h3, .box p {
     color: rgba(46, 49, 143);
   }
 


### PR DESCRIPTION
### What's being changed:

Limit the `p` selector in component to within `box`

### Type of change:

- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
