### PR TITLE
correct helm upgrade command in doc

### DIFF
--- a/developers/weaviate/installation/kubernetes.md
+++ b/developers/weaviate/installation/kubernetes.md
@@ -124,10 +124,9 @@ You can deploy the helm charts as follows:
 $ kubectl create namespace weaviate
 
 # Deploy
-$ helm install \
+$ helm upgrade --install \
   "weaviate" \
   weaviate/weaviate \
-  --install \
   --namespace "weaviate" \
   --values ./values.yaml
 ```


### PR DESCRIPTION
previously `helm install ... --install ...` is an invalid command. The comment that follows show that it should be an upgrade command instead.

### What's being changed:

Documentation for Helm - correct a command.

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
