### PR TITLE
Fix outdated go client path in Quickstart

### DIFF
--- a/_includes/code/quickstart.clients.install.mdx
+++ b/_includes/code/quickstart.clients.install.mdx
@@ -25,7 +25,7 @@ npm install weaviate-ts-client
 Add `weaviate-go-client` to your project with `go get`:<br/><br/>
 
 ```bash
-go get github.com/semi-technologies/weaviate-go-client/v4
+go get github.com/weaviate/weaviate-go-client/v4
 ```
 
 </TabItem>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

This commit fixes #869.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
