### PR TITLE
[docs] update quickstart golang examples

### DIFF
--- a/_includes/code/quickstart.autoschema.connect.withkey.mdx
+++ b/_includes/code/quickstart.autoschema.connect.withkey.mdx
@@ -28,6 +28,17 @@ import EndToEndTSCode from '!!raw-loader!/_includes/code/quickstart.autoschema.e
 <TabItem value="go" label="Go">
 
 ```go
+package main
+
+import (
+  "context"
+  "encoding/json"
+  "net/http"
+
+  "github.com/weaviate/weaviate-go-client/v4/weaviate"
+  "github.com/weaviate/weaviate/entities/models"
+)
+
 cfg := weaviate.Config{
   Host:   "some-endpoint.weaviate.network/",  // Replace with your endpoint
   Scheme: "https",

--- a/_includes/code/quickstart.autoschema.import.mdx
+++ b/_includes/code/quickstart.autoschema.import.mdx
@@ -62,7 +62,7 @@ if err != nil {
 }
 for _, res := range batchRes {
   if res.Result.Errors != nil {
-    panic("batch load failed: %v", res.Result.Errors.Error)
+    panic(res.Result.Errors.Error)
   }
 }
 ```

--- a/_includes/code/quickstart.clients.install.mdx
+++ b/_includes/code/quickstart.clients.install.mdx
@@ -25,7 +25,7 @@ npm install weaviate-ts-client
 Add `weaviate-go-client` to your project with `go get`:<br/><br/>
 
 ```bash
-go get github.com/semi-technologies/weaviate-go-client/v4
+go get github.com/weaviate/weaviate-go-client/v4
 ```
 
 </TabItem>


### PR DESCRIPTION
### What's being changed:

Updating GoLang code examples in the quickstart, following feedback from a user:

>The quick start tutorial here:
https://weaviate.io/developers/weaviate/quickstart for golang doesn't work. Other than mentioning old go module paths which is easy to fix, it uses a 'models' library, but never imports it, or mentions how to import it. What is 'models'?
> It seems that the code doesn't even compile. Here for example:
> `panic("batch load failed: %v", res.Result.Errors.Error)`
> it seems that panic() takes only one argument, but two are provided here.

* add required imports to the first goland example
* fix wrong syntax with a panic call
* update the `weaviate-go-client` installation link to the current location

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

