### PR TITLE
[fix] Ctrl/Cmd+K subsequent search failure

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,21 +1,30 @@
-export const analyticsSiteSearched = (searchTerm) =>
-    plausible('Site Search', {
-        props: { searchTerm }
-    });
+export function analyticsSiteSearched(searchTerm) {
+    // Plausible might not be loaded, e.g. if blocked by an ad blocker
+    if (typeof plausible === 'function')
+        plausible('Site Search', {
+            props: { searchTerm }
+        });
+}
 
-export const analyticsSiteSearchSelected = (searchTerm, uri, title) =>
-    plausible('Site Search Selected', {
-        props: {
-            searchTerm,
-            uri,
-            title,
-            summary: JSON.stringify({searchTerm, uri, title})
-        }
-    });
+export function analyticsSiteSearchSelected (searchTerm, uri, title) {
+    // Plausible might not be loaded, e.g. if blocked by an ad blocker
+    if (typeof plausible === 'function')
+        plausible('Site Search Selected', {
+            props: {
+                searchTerm,
+                uri,
+                title,
+                summary: JSON.stringify({searchTerm, uri, title})
+            }
+        });
+}
 
-export const analyticsSiteSearchResultsRejected = (searchTerm) =>
-    plausible('Site Search Results Rejected', {
-        props: {
-            searchTerm
-        }
-    });
+export function analyticsSiteSearchResultsRejected(searchTerm) {
+    // Plausible might not be loaded, e.g. if blocked by an ad blocker
+    if (typeof plausible === 'function')
+        plausible('Site Search Results Rejected', {
+            props: {
+                searchTerm
+            }
+        });
+}


### PR DESCRIPTION
Test at https://6487230689a5c337feb7be98--tangerine-buttercream-20c32f.netlify.app/:
1. Enable an ad blocker
2. Search for a term, wait for results to appear
3. Keep the search modal open, delete the query, and search for another term