### PR TITLE
Update get.md - fix query description

### DIFF
--- a/developers/weaviate/api/graphql/get.md
+++ b/developers/weaviate/api/graphql/get.md
@@ -81,7 +81,7 @@ As of `1.19`, the `groupBy` `path` is limited to one property or cross-reference
 
 Take a collection of `Passage` objects for example, each object belonging to a `Document`. If searching through `Passage` objects, you can group the results according to any property of the `Passage`, including the cross-reference property that represents the `Document` each `Passage` is associated with.
 
-The `groups` and `objectsPerGroup` limits are customizable. So in this example, you could retrieve the top 1000 objects and group them to identify the 3 most relevant `Document` objects, based on the top 3 `Passage` objects from each `Document`.
+The `groups` and `objectsPerGroup` limits are customizable. So in this example, you could retrieve the top 100 objects and group them to identify the 2 most relevant `Document` objects, based on the top 2 `Passage` objects from each `Document`.
 
 More concretely, a query such as below:
 


### PR DESCRIPTION
The description of the query did not match the query. Please double check this before merging!

Query excerpt:
```
{
  Get{
    Passage(
      limit: 100
      nearObject: {
        id: "00000000-0000-0000-0000-000000000001"
      }
      groupBy: {
        path: ["content"]
        groups: 2
        objectsPerGroup: 2
      }
```

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
