### PR TITLE
[blog] update pq subhead in 1.20 release blog

### DIFF
--- a/blog/2023-07-11-weaviate-1-20-release/index.mdx
+++ b/blog/2023-07-11-weaviate-1-20-release/index.mdx
@@ -47,7 +47,7 @@ The result is a multi-tenancy solution that we are very proud of. This is an opt
 
 ## PQ + Re-scoring
 
-> **Compress vectors for faster speeds with little to no recall loss.**
+> **Compress vectors with little to no recall loss.**
 
 ![Conceptual diagram of query speed vs recall](./img/Weaviate-release-1-20_qps_recall_light.png#gh-light-mode-only)
 ![Conceptual diagram of query speed vs recall](./img/Weaviate-release-1-20_qps_recall_dark.png#gh-dark-mode-only)


### PR DESCRIPTION
### What's being changed:

Uupdate pq subhead in 1.20 release blog

### Type of change:

- [x] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)

### How Has This Been Tested?


- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
