### PR TITLE
[Quickstart] Fix TypeScript example for importing without vectors

### DIFF
--- a/_includes/code/quickstart.autoschema.endtoend.ts
+++ b/_includes/code/quickstart.autoschema.endtoend.ts
@@ -23,18 +23,18 @@ const client: WeaviateClient = weaviate.client({
 
 // EndToEndExample  // CustomVectorExample
 // Add the schema
-let classObj = {
+const classObj = {
   'class': 'Question',
   'vectorizer': 'text2vec-huggingface',  // If set to "none" you must always provide vectors yourself. Could be any other "text2vec-*" also.
   'moduleConfig': {
     'text2vec-huggingface': {
-        'model': 'sentence-transformers/all-MiniLM-L6-v2',  // Can be any public or private Hugging Face model.
-        'options': {
-            'waitForModel': true
-        }
-    }
-  }
-}
+      'model': 'sentence-transformers/all-MiniLM-L6-v2',  // Can be any public or private Hugging Face model.
+      'options': {
+        'waitForModel': true,
+      },
+    },
+  },
+};
 
 async function addSchema() {
   const res = await client.schema.classCreator().withClass(classObj).do();
@@ -56,7 +56,7 @@ async function importQuestions() {
   // Prepare a batcher
   let batcher: ObjectsBatcher = client.batch.objectsBatcher();
   let counter = 0;
-  let batchSize = 100;
+  const batchSize = 100;
 
   for (const question of data) {
     // Construct an object with a class and properties 'answer' and 'question'
@@ -67,7 +67,7 @@ async function importQuestions() {
         question: question.Question,
         category: question.Category,
       },
-    }
+    };
 
     // add the object to the batch queue
     batcher = batcher.withObject(obj);
@@ -102,7 +102,7 @@ async function nearTextQuery() {
     .do();
 
   console.log(JSON.stringify(res, null, 2));
-  return res
+  return res;
 }
 
 // END NearTextExample
@@ -117,13 +117,13 @@ async function nearTextWhereQuery() {
     .withWhere({
       'path': ['category'],
       'operator': 'Equal',
-      'valueText': 'ANIMALS'
+      'valueText': 'ANIMALS',
     })
     .withLimit(2)
     .do();
 
   console.log(JSON.stringify(res, null, 2));
-  return res
+  return res;
 }
 
 // END NearTextWhereExample
@@ -140,7 +140,7 @@ async function generativeSearchQuery() {
     .do();
 
   console.log(JSON.stringify(res, null, 2));
-  return res
+  return res;
 }
 
 // END GenerativeSearchExample
@@ -155,7 +155,7 @@ async function getNumObjects() {
 }
 
 async function cleanup() {
-  client.schema.classDeleter().withClassName('Question').do();
+  await client.schema.classDeleter().withClassName('Question').do();
 }
 // END Define test functions
 
@@ -232,7 +232,7 @@ await importQuestions();
 
 
 /*
-// Import data function with custom vectors
+// Import data with custom vectors
 async function getJsonData() {
   const fname = 'jeopardy_tiny_with_vectors_all-MiniLM-L6-v2.json';
   const url = 'https://raw.githubusercontent.com/weaviate-tutorials/quickstart/main/data/' + fname
@@ -282,5 +282,5 @@ async function importQuestions() {
   const res = await batcher.do();
   console.log(res);
 }
-// END Import data function with custom vectors
+// END Import data with custom vectors
 */

--- a/_includes/code/quickstart.autoschema.import.custom.vectors.mdx
+++ b/_includes/code/quickstart.autoschema.import.custom.vectors.mdx
@@ -19,8 +19,8 @@ import EndToEndTSCode from '!!raw-loader!/_includes/code/quickstart.autoschema.e
 
 <FilteredTextBlock
   text={EndToEndTSCode}
-  startMarker="// Import data function with custom vectors"
-  endMarker="// END Import data function with custom vectors"
+  startMarker="// Import data with custom vectors"
+  endMarker="// END Import data with custom vectors"
   language="ts"
 />
 

--- a/_includes/code/quickstart.autoschema.import.mdx
+++ b/_includes/code/quickstart.autoschema.import.mdx
@@ -2,7 +2,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBlock';
 import EndToEndPyCode from '!!raw-loader!/_includes/code/quickstart.autoschema.endtoend.py';
-import EndToEndJSCode from '!!raw-loader!/_includes/code/quickstart.autoschema.endtoend.js';
 import EndToEndTSCode from '!!raw-loader!/_includes/code/quickstart.autoschema.endtoend.ts';
 
 <Tabs groupId="languages">

--- a/developers/weaviate/quickstart/index.md
+++ b/developers/weaviate/quickstart/index.md
@@ -273,7 +273,7 @@ First, you will use the `vectorizer` to create object vectors.
 
 ### *Option 1*: `vectorizer`
 
-The below passes object data without a vector. This causes Weaviate to use the specified `vectorizer` to create a vector embedding for each object.
+The code below imports object data without specifying a vector. This causes Weaviate to use the `vectorizer` defined for the class to create a vector embedding for each object.
 
 import CodeAutoschemaImport from '/_includes/code/quickstart.autoschema.import.mdx'
 


### PR DESCRIPTION
This fixes the TypeScript code sample in [the QuickStart](https://weaviate.io/developers/weaviate/quickstart#option-1-vectorizer) to only include the correct section (without vectors).

The overinclusion was caused by the start and end markers for non-vector section being a substring of the start&end markers for the vector section:
* `// Import data function`
* `// Import data with custom vectors`.

This wasn't a problem for the Python code because the markers ended with '=====':
* `# ===== import data =====` and
* `# ===== import with custom vectors =====`.

As a best practice, we might want to adopt ending markers with a non-word terminator.