### PR TITLE
[docs] remove refs to returnDocuments in reranker

### DIFF
--- a/developers/weaviate/modules/retriever-vectorizer-modules/reranker-cohere.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/reranker-cohere.md
@@ -61,7 +61,7 @@ import T2VInferenceYamlNotes from './_components/text2vec.inference.yaml.notes.m
 
 ## Schema configuration
 
-The `reranker-cohere` module can be configured for any class in the schema. You can also specify options such as the `model` to use, and whether to `returnDocuments` in the response.
+The `reranker-cohere` module can be configured for any class in the schema. You can also specify options such as the `model` to use.
 
 This example configures the `Document` class to use the `reranker-cohere` module, with the `rerank-multilingual-v2.0` model, and to return the documents in the response.
 
@@ -74,7 +74,6 @@ This example configures the `Document` class to use the `reranker-cohere` module
       "moduleConfig": {
         "reranker-cohere": {
             "model": "rerank-multilingual-v2.0",
-            "returnDocuments": false
         },
       }
     }

--- a/developers/weaviate/modules/retriever-vectorizer-modules/reranker-transformers.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/reranker-transformers.md
@@ -65,26 +65,6 @@ services:
 
 The `reranker-transformers` module can be configured for any class in the schema.
 
-<!-- TODO: does `reranker-transformers` also have a returnDocuments flag? -->
-
-<!-- This example configures the `Document` class to use the `reranker-transformers` module, with the `cross-encoder/ms-marco-MiniLM-L-6-v2` model, and to return the documents in the response.
-
-```json
-{
-  "classes": [
-    {
-      "class": "Document",
-      ...,
-      "moduleConfig": {
-        "reranker-transformers": {
-            "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
-        },
-      }
-    }
-  ]
-}
-``` -->
-
 
 ### Reranker selection
 


### PR DESCRIPTION
### What's being changed:

- Update reranker docs to remove refs to returnDocuments

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
