### PR TITLE
[filters] Mention that operators are case sensitive

### DIFF
--- a/developers/weaviate/api/graphql/filters.md
+++ b/developers/weaviate/api/graphql/filters.md
@@ -79,6 +79,11 @@ The `where` filter is an [algebraic object](https://en.wikipedia.org/wiki/Algebr
   - `Like`
   - `WithinGeoRange`
   - `IsNull`
+  
+  :::info
+  These operators are case sensitive. The query will error if the operators are not capitalized as above.
+  :::
+
 - `Operands`: Is a list of `Operator` objects of this same structure, only used if the parent `Operator` is set to `And` or `Or`.
 - `Path`: Is a list of strings in [XPath](https://en.wikipedia.org/wiki/XPath#Abbreviated_syntax) style, indicating the property name of the class.
   If the property is a beacon (i.e., cross-reference), the path should be followed to the property of the beacon which should be specified as a list of strings. For a schema structure like:


### PR DESCRIPTION
### What's being changed:

Add an info block stating that filtering operators such as `And` and `Or` are case sensitive. I spent a good hour and a half trying to figure out why my queries weren't going through... turns out that these operators are case sensitive. Thought I'd spare someone else the trouble by including that detail in the documentation.

### Type of change:

- [X] **Documentation** updates (non-breaking change to fix/update documentation)


### How Has This Been Tested?

- [X] **Github action** – automated build completed without errors
- [X] **Local build** - the site works as expected when running `yarn start`
