### PR TITLE
docs(QuickStart): fix a typo

### DIFF
--- a/developers/weaviate/quickstart/index.md
+++ b/developers/weaviate/quickstart/index.md
@@ -109,7 +109,7 @@ For the Weaviate API key, click on the <kbd><i class="fa-solid fa-key"></i></kbd
 
 ## Install a client library
 
-We suggest useing a [Weaviate client](../client-libraries/index.md). To install your preferred client <i class="fa-solid fa-down"></i>:
+We suggest using a [Weaviate client](../client-libraries/index.md). To install your preferred client <i class="fa-solid fa-down"></i>:
 
 import CodeClientInstall from '/_includes/code/quickstart.clients.install.mdx';
 


### PR DESCRIPTION
### What's being changed:

This PR fixes a typo on the [Quick Start](https://weaviate.io/developers/weaviate/quickstart) page.

### Type of change:

<!--Please delete options that are not relevant.-->

- [X] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
