### PR TITLE
[site] Fix workshop not loading

### DIFF
--- a/src/pages/learn/workshops.jsx
+++ b/src/pages/learn/workshops.jsx
@@ -5,6 +5,13 @@ import styles from '/src/components/Workshop/styles.module.scss';
 export default function Workshops() {
   return (
     <Layout title="Workshops" description="Weaviate Workshops Page">
+      <Head>
+        <script
+          src="https://static.elfsight.com/platform/platform.js"
+          data-use-service-core
+          async
+        ></script>
+      </Head>
       <div className="custom-page">
         <div className="container">
           <div className={styles.box}>
@@ -16,11 +23,6 @@ export default function Workshops() {
               information and details on our service.
             </p>
           </div>
-          <script
-            src="https://static.elfsight.com/platform/platform.js"
-            data-use-service-core
-            async
-          ></script>
           <div className="elfsight-app-01a3e7d9-f320-4491-a464-8339fafe3e80"></div>
         </div>
       </div>

--- a/src/pages/learn/workshops.jsx
+++ b/src/pages/learn/workshops.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Layout from '@theme/Layout';
 import styles from '/src/components/Workshop/styles.module.scss';
+import Head from '@docusaurus/Head';
 
 export default function Workshops() {
   return (

--- a/src/pages/learn/workshops.jsx
+++ b/src/pages/learn/workshops.jsx
@@ -19,9 +19,9 @@ export default function Workshops() {
           <script
             src="https://static.elfsight.com/platform/platform.js"
             data-use-service-core
-            defer
+            async
           ></script>
-          <div class="elfsight-app-01a3e7d9-f320-4491-a464-8339fafe3e80"></div>
+          <div className="elfsight-app-01a3e7d9-f320-4491-a464-8339fafe3e80"></div>
         </div>
       </div>
     </Layout>

--- a/src/pages/learn/workshops.jsx
+++ b/src/pages/learn/workshops.jsx
@@ -9,7 +9,7 @@ export default function Workshops() {
         <script
           src="https://static.elfsight.com/platform/platform.js"
           data-use-service-core
-          async
+          defer
         ></script>
       </Head>
       <div className="custom-page">


### PR DESCRIPTION
### What's being changed:

Moved the workshop load widget to the page head.

### Type of change:

- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`