### PR TITLE
fix: cli need auth.type

### DIFF
--- a/developers/weaviate/client-libraries/cli.md
+++ b/developers/weaviate/client-libraries/cli.md
@@ -63,6 +63,7 @@ You need to configure the CLI tool before you can interact with you Weaviate ins
   {
     "url": "http://localhost:8080",
     "auth": {
+        "type": "client_secret",
         "secret": <your_client_secret>
     }
   }
@@ -73,8 +74,20 @@ You need to configure the CLI tool before you can interact with you Weaviate ins
   {
     "url": "http://localhost:8080",
     "auth": {
+        "type": "username_and_password",
         "user": <user name>,
         "pass": <user password>
+    }
+  }
+  ```
+  or
+
+  ```json
+  {
+    "url": "http://localhost:8080",
+    "auth": {
+        "type": "api_key",
+        "api_key": <api key>
     }
   }
   ```


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Auth method in the cli documentation

- Due to the `weaviate-cli` code: https://github.com/weaviate/weaviate-cli/blob/v2.2.0/semi/config/commands.py#L101 , The auth object in config.json needs to contain the type field.
- Add `api_key` auth type. So this PR could be merged after this [PR](https://github.com/weaviate/weaviate-cli/pull/66) has been merged.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [x] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
