### PR TITLE
Minor corrections

### DIFF
--- a/developers/weaviate/configuration/persistence.md
+++ b/developers/weaviate/configuration/persistence.md
@@ -104,7 +104,7 @@ changed the thresholds) you can use the [Shards API](../api/rest/schema.md#inspe
 :::info Available from version `v1.21`
 :::
 
-You can choose between `mmap` (DEFAULT) and `pread` functions to access virtual memory by setting the `PERSISTENCE_LSM_ACCESS` environment variable.
+You can choose between `mmap` (DEFAULT) and `pread` functions to access virtual memory by setting the `PERSISTENCE_LSM_ACCESS_STRATEGY` environment variable.
 
 The two functions reflect different under-the-hood memory management behaviors. `mmap` uses a memory-mapped file, which means that the file is mapped into the virtual memory of the process. `pread` is a function that reads data from a file descriptor at a given offset.
 

--- a/developers/weaviate/modules/index.md
+++ b/developers/weaviate/modules/index.md
@@ -32,7 +32,7 @@ This section describes Weaviate's individual modules, including their capabiliti
 
 Modules can be "vectorizers" (defines how the numbers in the vectors are chosen from the data) or other modules providing additional functions like question answering, custom classification, etc. Modules have the following characteristics:
 - Naming convention:
-  - Vectorizer (Retriever module): `<media>2vec-<name>-<optional>`, for example `text2vec-contextionary`, `image2vec-RESNET` or `text2vec-transformers`.
+  - Vectorizer (Retriever module): `<media>2vec-<name>-<optional>`, for example `text2vec-contextionary`, `img2vec-neural` or `text2vec-transformers`.
   - Other modules: `<functionality>-<name>-<optional>`, for example `qna-transformers`.
   - A module name must be url-safe, meaning it must not contain any characters which would require url-encoding.
   - A module name is not case-sensitive. `text2vec-bert` would be the same module as `text2vec-BERT`.

--- a/developers/weaviate/modules/other-modules/custom-modules.md
+++ b/developers/weaviate/modules/other-modules/custom-modules.md
@@ -71,7 +71,7 @@ A module is a custom code that can extend Weaviate by hooking into specific life
 
 Modules can be "vectorizers" (defines how the numbers in the vectors are chosen from the data) or other modules providing additional functions like question answering, custom classification, etc. Modules have the following characteristics:
 - Naming convention:
-  - Vectorizer: `<media>2vec-<name>-<optional>`, for example `text2vec-contextionary`, `image2vec-RESNET` or `text2vec-transformers`.
+  - Vectorizer: `<media>2vec-<name>-<optional>`, for example `text2vec-contextionary`, `img2vec-neural` or `text2vec-transformers`.
   - Other modules: `<functionality>-<name>-<optional>`.
   - A module name must be url-safe, meaning it must not contain any characters which would require url-encoding.
   - A module name is not case-sensitive. `text2vec-bert` would be the same module as `text2vec-BERT`.

--- a/developers/weaviate/modules/retriever-vectorizer-modules/img2vec-neural.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/img2vec-neural.md
@@ -40,8 +40,8 @@ While you can do so manually, we recommend using the [Weaviate configuration too
 
 Weaviate:
 
-- `ENABLE_MODULES` (Required): The modules to enable. Include `image2vec-neural` to enable the module.
-- `DEFAULT_VECTORIZER_MODULE` (Optional): The default vectorizer module. You can set this to `image2vec-neural` to make it the default for all classes.
+- `ENABLE_MODULES` (Required): The modules to enable. Include `img2vec-neural` to enable the module.
+- `DEFAULT_VECTORIZER_MODULE` (Optional): The default vectorizer module. You can set this to `img2vec-neural` to make it the default for all classes.
 - `IMAGE_INFERENCE_API` (Required): The URL of the inference container.
 
 Inference container:
@@ -114,7 +114,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
 
 #### Example
 
-The following example class definition sets the `image2vec-neural` module as the `vectorizer` for the class `FashionItem`. It also sets:
+The following example class definition sets the `img2vec-neural` module as the `vectorizer` for the class `FashionItem`. It also sets:
 
 - `image` property as a `blob` datatype and as the image field,
 
@@ -178,7 +178,7 @@ cat my_image.png | base64
 
 ## Additional search operator
 
-The `image2vec-neural` vectorizer module will enable the `nearImage` search operator.
+The `img2vec-neural` vectorizer module will enable the `nearImage` search operator.
 
 ## Usage example
 
@@ -206,7 +206,7 @@ There are two different inference models you can choose from. Depending on your 
 
 ## Model license(s)
 
-The `image2vec-neural` module uses the `resnet50` model.
+The `img2vec-neural` module uses the `resnet50` model.
 
 It is your responsibility to evaluate whether the terms of its license(s), if any, are appropriate for your intended use.
 

--- a/developers/weaviate/modules/retriever-vectorizer-modules/ref2vec-centroid.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/ref2vec-centroid.md
@@ -58,7 +58,7 @@ For example, here is an `Article` class which is configured to use ref2vec-centr
 
 The `Article` class specifies its `hasParagraphs` property as the only reference property to be used in the calculation of an `Article` object's vector.
 
-It is important to note that unlike the other vectorizer modules (e.g. text2vec/multi2vec/image2vec), ref2vec-centroid does not generate embeddings based on the contents of an object. Rather, the point of this module is to calculate an object's vector based on vectors of its *references*.
+It is important to note that unlike the other vectorizer modules (e.g. text2vec/multi2vec/img2vec), ref2vec-centroid does not generate embeddings based on the contents of an object. Rather, the point of this module is to calculate an object's vector based on vectors of its *references*.
 
 In this case, the `Paragraph` class is configured to generate vectors using the text2vec-contextionary module. Thus, the vector representation of the `Article` class is an average of text2vec-contextionary vectors sourced from referenced `Paragraph` instances.
 


### PR DESCRIPTION
### What's being changed:

- Change PERSISTENCE_LSM_ACCESS to PERSISTENCE_LSM_ACCESS_STRATEGY
- Change `image2vec` to `img2vec`

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
