### PR TITLE
Add 1.23 to the roadmap

### DIFF
--- a/developers/weaviate/roadmap/index.md
+++ b/developers/weaviate/roadmap/index.md
@@ -18,6 +18,10 @@ If you find any of the issues of interest, follow the link and upvote <i classNa
 
 Please feel free to engage with us about the roadmap on [Weaviate's GitHub](https://github.com/weaviate/weaviate) or on [the forum](https://forum.weaviate.io/).
 
+## Planned for Weaviate 1.23
+
+<Roadmap label="planned-1.23"/>
+
 ## Planned for Weaviate 1.22
 
 <Roadmap label="planned-1.22"/>


### PR DESCRIPTION
### What's being changed:

Add 1.23 to the roadmap

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
