### PR TITLE
1103 release matrix python

### DIFF
--- a/_includes/clients/matrix-intro.md
+++ b/_includes/clients/matrix-intro.md
@@ -1,0 +1,5 @@
+This chart matches Weaviate database releases with Weaviate client releases. It
+lists the most recent database version when each client version was released.
+
+The chart includes point releases for the most recent major and minor versions
+of the client. Earlier client releases have less detailed version information.

--- a/_includes/more-resources-docs.md
+++ b/_includes/more-resources-docs.md
@@ -1,10 +1,10 @@
-If you can't find the answer to your question here, please look at the:
+For additional information, try these sources.
 
-1. [Frequently Asked Questions](/developers/weaviate/more-resources/faq). Or,
-1. [Knowledge base of old issues](https://github.com/weaviate/weaviate/issues?utf8=%E2%9C%93&q=label%3Abug). Or,
-1. For questions: [Stackoverflow](https://stackoverflow.com/questions/tagged/weaviate). Or,
-1. For more involved discussion: [Weaviate Community Forum](https://forum.weaviate.io/). Or,
-1. We also have a [Slack channel](https://weaviate.io/slack).
+1. [Frequently Asked Questions](/developers/weaviate/more-resources/faq)
+1. [Weaviate Community Forum](https://forum.weaviate.io/)
+1. [Knowledge base of old issues](https://github.com/weaviate/weaviate/issues?utf8=%E2%9C%93&q=label%3Abug)
+1. [Stackoverflow](https://stackoverflow.com/questions/tagged/weaviate)
+1. [Weaviate slack channel](https://weaviate.io/slack)
 
 import { GiscusDocComment } from '/src/components/GiscusComment';
 

--- a/developers/weaviate/client-libraries/python.md
+++ b/developers/weaviate/client-libraries/python.md
@@ -785,9 +785,52 @@ query_result.build()
 
 ```
 
+## Releases
+
+import MatrixIntro from '/_includes/clients/matrix-intro.md';
+
+<MatrixIntro />
+
+|Client Version|Release Date|Weaviate Version|
+|:-|:-|:|
+|[3.24.1](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.24.1)|2023-09-11|[1.21.3](https://github.com/weaviate/weaviate/releases/tag/v1.21.3)|
+|[3.24.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.24.0)|2023-09-11|[1.21.3](https://github.com/weaviate/weaviate/releases/tag/v1.21.3)|
+|[3.23.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.23.0)|2023-08-22|[1.21.1](https://github.com/weaviate/weaviate/releases/tag/v1.21.1)|
+|[3.22.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.22.0)|2023-07-06|[1.20.0](https://github.com/weaviate/weaviate/releases/tag/v1.20.0)|
+|[3.21.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.21.0)|2023-06-18|[1.19.8](https://github.com/weaviate/weaviate/releases/tag/v1.19.8)|
+|[3.20.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.20.0)|2023-06-12|[1.19.7](https://github.com/weaviate/weaviate/releases/tag/v1.19.7)|
+|[3.19.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.19.0)|2023-05-18|[1.19.5](https://github.com/weaviate/weaviate/releases/tag/v1.19.5)|
+|[3.18.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.18.0)|2023-05-09|[1.19.0](https://github.com/weaviate/weaviate/releases/tag/v1.19.0)|
+|[3.17.0](https://github.com/weaviate/weaviate-python-client/releases/tag/3.17.0)|2023-05-04|[1.19.0](https://github.com/weaviate/weaviate/releases/tag/v1.19.0)|
+|[3.16.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.16.0)|2023-04-24|[1.18.4](https://github.com/weaviate/weaviate/releases/tag/v1.18.4)|
+|[3.15.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.15.0)|2023-03-13|[1.18.0](https://github.com/weaviate/weaviate/releases/tag/v1.18.0)|
+|[3.14.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.14.0)|2023-03-12|[1.18.0](https://github.com/weaviate/weaviate/releases/tag/v1.18.0)|
+|[3.13.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.13.0)|2023-03-07|[1.18.0](https://github.com/weaviate/weaviate/releases/tag/v1.18.0)|
+|[3.12.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.12.0)|2023-02-24|[1.17.4](https://github.com/weaviate/weaviate/releases/tag/v1.17.4)|
+|[3.11.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.11.0)|2023-01-20|[1.17.1](https://github.com/weaviate/weaviate/releases/tag/v1.17.1)|
+|[3.10.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.10.0)|2022-12-21|[1.16.9](https://github.com/weaviate/weaviate/releases/tag/v1.16.9)|
+|[3.9.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.9.0)|2022-11-09|[1.16.0](https://github.com/weaviate/weaviate/releases/tag/v1.16.0)|
+|[3.8.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.8.0)|2022-09-07|[1.15.0](https://github.com/weaviate/weaviate/releases/tag/v1.15.0)|
+|[3.7.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.7.0)|2022-07-29|[1.14.1](https://github.com/weaviate/weaviate/releases/tag/v1.14.1)|
+|[3.6.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.6.0)|2022-07-06|[1.13.2](https://github.com/weaviate/weaviate/releases/tag/v1.13.2)|
+|[3.5.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.5.0)|2022-05-08|[1.13.1](https://github.com/weaviate/weaviate/releases/tag/v1.13.1)|
+|[3.4.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.4.0)|2022-04-04|[1.11.0](https://github.com/weaviate/weaviate/releases/tag/v1.11.0)|
+|[3.3.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.3.0)|2021-11-29|[1.7.2](https://github.com/weaviate/weaviate/releases/tag/v1.7.2)|
+|[3.2.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.2.0)|2021-09-02|[1.7.0](https://github.com/weaviate/weaviate/releases/tag/v1.7.0)|
+|[3.1.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.1.0)|2021-08-17|[1.6.0](https://github.com/weaviate/weaviate/releases/tag/v1.6.0)|
+|[3.0.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v3.0.0)|2021-08-17|[1.6.0](https://github.com/weaviate/weaviate/releases/tag/v1.6.0)|
+|[2.0.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v2.0.0)|2021-01-11|[0.23.2](https://github.com/weaviate/weaviate/releases/tag/v0.23.2)|
+|[1.0.0](https://github.com/weaviate/weaviate-python-client/releases/tag/1.0.0)|2020-09-15|[0.22.16](https://github.com/weaviate/weaviate/releases/tag/v0.22.16)|
+
+
+
 ## Change logs
 
-Check the [change logs on GitHub](https://github.com/weaviate/weaviate-python-client/releases) or [readthedocs](https://weaviate-python-client.readthedocs.io/en/stable/changelog.html) for updates on the latest Python client changes.
+For more detailed information on client updates, check the change logs. The logs
+are hosted here:
+
+- [GitHub](https://github.com/weaviate/weaviate-python-client/releases)
+- [Read the Docs](https://weaviate-python-client.readthedocs.io/en/stable/changelog.html)
 
 ## More Resources
 

--- a/developers/weaviate/client-libraries/python.md
+++ b/developers/weaviate/client-libraries/python.md
@@ -822,8 +822,6 @@ import MatrixIntro from '/_includes/clients/matrix-intro.md';
 |[2.0.0](https://github.com/weaviate/weaviate-python-client/releases/tag/v2.0.0)|2021-01-11|[0.23.2](https://github.com/weaviate/weaviate/releases/tag/v0.23.2)|
 |[1.0.0](https://github.com/weaviate/weaviate-python-client/releases/tag/1.0.0)|2020-09-15|[0.22.16](https://github.com/weaviate/weaviate/releases/tag/v0.22.16)|
 
-
-
 ## Change logs
 
 For more detailed information on client updates, check the change logs. The logs


### PR DESCRIPTION
### What's being changed:
[issue](https://github.com/weaviate/weaviate-io/issues/1103)

Creates a matrix for which db version was current when a particular client was released. Similar PRs to follow for other clients. 

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
