### PR TITLE
150 add baseURL to OpenAI

### DIFF
--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai.md
@@ -83,6 +83,7 @@ You can configure how the module will behave in each class through the [Weaviate
 - `model` (Optional): A model family, e.g. `davinci`.
 - `modelVersion` (Optional): Version string, e.g. `003`.
 - `type` (Optional): Model type. Can be `text` or `code`.
+- `baseURL` (Optional): Sets a proxy or other URL instead of the default OpenAI URL. To specify the URL, use protocol domain format. `https://your.domain.com`. The default value is: `https://api.openai.com`.
 
 The default model is `text-embedding-ada-002`.
 
@@ -103,6 +104,7 @@ The following example configures the `Document` class by setting the vectorizer 
           "model": "ada",
           "modelVersion": "002",
           "type": "text"
+          "baseURL": "https://proxy.yourCompanyDomain.com"
         }
       },
       // highlight-end

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai.md
@@ -81,11 +81,15 @@ You can configure how the module will behave in each class through the [Weaviate
 #### Parameters
 
 - `model` (Optional): A model family, e.g. `davinci`.
+
+   The default model is `text-embedding-ada-002`.
 - `modelVersion` (Optional): Version string, e.g. `003`.
 - `type` (Optional): Model type. Can be `text` or `code`.
-- `baseURL` (Optional): Sets a proxy or other URL instead of the default OpenAI URL. To specify the URL, use protocol domain format. `https://your.domain.com`. The default value is: `https://api.openai.com`.
+- `baseURL` (Optional): Sets a proxy or other URL instead of the default OpenAI URL. To specify the URL, use protocol domain format: `https://your.domain.com`.
 
-The default model is `text-embedding-ada-002`.
+   The default value is: `https://api.openai.com`.
+
+
 
 #### Example
 


### PR DESCRIPTION
[issue](https://github.com/weaviate/weaviate-edu-team-tasks/issues/150)
[staging(https://6511c8c8717a3f0095a07a0a--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai#parameters-1)

### What's being changed:

adds new optional parameter

### Type of change:

- [X] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
