### PR TITLE
153 update OAuth token

### DIFF
--- a/_includes/gcp.token.expiry.notes.mdx
+++ b/_includes/gcp.token.expiry.notes.mdx
@@ -1,13 +1,13 @@
 :::caution Important
 :::
 
-Google Cloud's OAuth 2.0 access tokens are configured to have a standard lifetime of 1 hour.
+By default, Google Cloud's OAuth 2.0 access tokens have a lifetime of 1 hour. You can create tokens that last up to 12 hours. To create longer lasting tokens, follow the [instructions in the Google Cloud IAM Guide](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#rest_2).
 
-Therefore, you **must** periodically replace the token with a valid one and supply it to Weaviate by re-instantiating the client with the new key.
+Since the OAuth token is only valid for a limited time, you **must** periodically replace the token with a new one. After you generate the new token, you have to re-instantiate your Weaviate client to use it.
 
-You can do this manually.
+You can update the OAuth token manually, but manual updates may not be appropriate for your use case.
 
-Automating this is a complex, advanced process that is outside the scope of our control. However, here are a couple of possible options for doing so:
+You can also automate the OAth token update. Automating this procedure is a complex process that is outside our control. However, here are some automation options:
 
 <details>
   <summary>With Google Cloud CLI</summary>

--- a/developers/weaviate/modules/reader-generator-modules/generative-palm.md
+++ b/developers/weaviate/modules/reader-generator-modules/generative-palm.md
@@ -80,7 +80,7 @@ During the **configuration** of your Docker instance, by adding `PALM_APIKEY` un
 
 </details>
 
-### Token expiry for Google Cloud users
+### Token expiration for Google Cloud users
 
 import GCPTokenExpiryNotes from '/_includes/gcp.token.expiry.notes.mdx';
 


### PR DESCRIPTION
[issue](https://github.com/weaviate/weaviate-edu-team-tasks/issues/153)
[staging](https://153-longer-lasting-tokens-in-gcp--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/modules/reader-generator-modules/generative-palm#token-expiry-for-google-cloud-users)

### What's being changed:

adds link howto on extending OAuth token life 

### Type of change:

- [X] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
