### PR TITLE
157 broken link checker work around

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ To disable link checking, add the broken URL to the `URL_IGNORES` lists in these
 - [verify-links.sh](https://github.com/weaviate/weaviate-io/blob/main/_build_scripts/verify-links.sh)
 - [verify-links-build-dev.sh](https://github.com/weaviate/weaviate-io/blob/main/_build_scripts/verify-links-build-dev.sh)
 
-Be sure to restore normal link checking before creating a pull request.
-
+Check the link again before you submit a merge request. If the link works, remove it from the `URL_IGNORES` list. If the link doesn't work, tell us about it in the pull request.
 
 ### Deployment
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ The `build` command is useful when you are finished editing. If you ran
 `yarn start` to start a local web server, you do not need to use `yarn build` to
 see you changes while you are editing.
 
+The build command runs a link checker. If you are having trouble with broken links, you can update the `URL_IGNORES` variable to disable checking for that link.
+
+To disable link checking, add the broken URL to the `URL_IGNORES` list in these scripts:
+
+- [verify-links.sh](https://github.com/weaviate/weaviate-io/blob/main/_build_scripts/verify-links.sh)
+- [verify-links-build-dev.sh](https://github.com/weaviate/weaviate-io/blob/main/_build_scripts/verify-links-build-dev.sh).
+
+Be sure to restore normal link checking before creating a pull request.
+
+
 ### Deployment
 
 Using SSH:

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The build command runs a link checker. If you are having trouble with temporaril
 To disable link checking, add the broken URL to the `URL_IGNORES` lists in these scripts:
 
 - [verify-links.sh](https://github.com/weaviate/weaviate-io/blob/main/_build_scripts/verify-links.sh)
-- [verify-links-build-dev.sh](https://github.com/weaviate/weaviate-io/blob/main/_build_scripts/verify-links-build-dev.sh).
+- [verify-links-build-dev.sh](https://github.com/weaviate/weaviate-io/blob/main/_build_scripts/verify-links-build-dev.sh)
 
 Be sure to restore normal link checking before creating a pull request.
 

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ The `build` command is useful when you are finished editing. If you ran
 `yarn start` to start a local web server, you do not need to use `yarn build` to
 see you changes while you are editing.
 
-The build command runs a link checker. If you are having trouble with broken links, you can update the `URL_IGNORES` variable to disable checking for that link.
+The build command runs a link checker. If you are having trouble with temporarily broken links, you can update the `URL_IGNORES` variable to disable checking for that link.
 
-To disable link checking, add the broken URL to the `URL_IGNORES` list in these scripts:
+To disable link checking, add the broken URL to the `URL_IGNORES` lists in these scripts:
 
 - [verify-links.sh](https://github.com/weaviate/weaviate-io/blob/main/_build_scripts/verify-links.sh)
 - [verify-links-build-dev.sh](https://github.com/weaviate/weaviate-io/blob/main/_build_scripts/verify-links-build-dev.sh).

--- a/developers/weaviate/client-libraries/python.md
+++ b/developers/weaviate/client-libraries/python.md
@@ -160,7 +160,7 @@ client = weaviate.Client(
 There is a variety of neural search frameworks that use Weaviate under the hood to store, search through, and retrieve vectors.
 
 - deepset's [haystack](https://www.deepset.ai/weaviate-vector-search-engine-integration)
-- Jina's [DocArray](https://docarray.jina.ai/advanced/document-store/weaviate/)
+- Jina's [DocArray](https://github.com/docarray/docarray)
 
 # References documentation
 


### PR DESCRIPTION
[issue](https://github.com/weaviate/weaviate-edu-team-tasks/issues/157)
[staging](https://github.com/weaviate/weaviate-io/tree/157-broken-link-workaround)

### What's being changed:
work aroudn for broken links

### Type of change:
- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without build errors
- [x] **Local build** - the site works as expected when running `yarn start`
