### PR TITLE
Update index.mdx with correct link

### DIFF
--- a/blog/2023-10-02-hacktoberfest-2023/index.mdx
+++ b/blog/2023-10-02-hacktoberfest-2023/index.mdx
@@ -108,7 +108,7 @@ Share your process online and tag us on [Twitter](https://twitter.com/weaviate_i
 - **Will this count towards Hacktoberfest?** Yes, it definitely does! If your PR/MR is created between **October 1** and **October 31** (in any time zone, UTC-12 thru UTC+14), we will add the "HACKTOBERFEST-ACCEPTED" label to it.
 - **Where do I get help?** For any questions or assistance, contact us on our [Discourse](https://forum.weaviate.io/) and [Slack](https://weaviate.slack.com/) channels.
 - **I have a cool contribution idea. Can I still participate?** Awesome! Connect with us on our [Discourse](https://forum.weaviate.io/) or [Slack](https://weaviate.slack.com/) channels and we will figure it out.
-- **I don’t know how to write code. Can I still contribute?** Yes, of course! You can make no-code contributions, e.g., by updating the [README.md](http://README.md) files. If you want to learn how to write code with a concrete example, we can help you find a good issue. Just ping us on our [Discourse](https://forum.weaviate.io/) or [Slack](https://weaviate.slack.com/) channels.
+- **I don’t know how to write code. Can I still contribute?** Yes, of course! You can make no-code contributions, e.g., by updating the [README.md](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) files. If you want to learn how to write code with a concrete example, we can help you find a good issue. Just ping us on our [Discourse](https://forum.weaviate.io/) or [Slack](https://weaviate.slack.com/) channels.
 
 ---
 


### PR DESCRIPTION
Currently, it is `http://readme.md` which redirects to an irrelevant website, and therefore misleading. I changed it to github official doc about markdown.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

`http://markdown.md` is a misleading link and the PR changes it to github official docs about markdown and readme.


### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [x ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
