### PR TITLE
[docs] Fix default vectorize property name

### DIFF
--- a/_includes/vectorization.behavior.mdx
+++ b/_includes/vectorization.behavior.mdx
@@ -4,6 +4,7 @@ Unless specified otherwise in the schema, the default behavior is to:
 
 - Only vectorize properties that use the `text` data type (unless [skip](/developers/weaviate/configuration/schema-configuration#property-level-module-settings)ped)
 - Sort properties in alphabetical (a-z) order before concatenating values
-- Prepend the property name to each property value (unless `vectorizePropertyName` is false) then join them with spaces, and
+- If `vectorizePropertyName` is `true` (`false` by default) prepend the property name to each property value
+- Join the (prepended) property values with spaces
 - Prepend the class name (unless `vectorizeClassName` is false)
 - Convert the produced string to lowercase

--- a/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind.md
@@ -117,7 +117,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
 #### Property-level
 
 - `skip` – whether to skip vectorizing the property altogether. Default: `false`
-- `vectorizePropertyName` – whether to vectorize the property name. Default: `true`
+- `vectorizePropertyName` – whether to vectorize the property name. Default: `false`
 - `dataType` - the data type of the property. For use in the appropriate `<media>Fields`, must be set to `text` or `blob` as appropriate.
 
 #### Example

--- a/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip.md
@@ -115,7 +115,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
 #### Property-level
 
 - `skip` – whether to skip vectorizing the property altogether. Default: `false`
-- `vectorizePropertyName` – whether to vectorize the property name. Default: `true`
+- `vectorizePropertyName` – whether to vectorize the property name. Default: `false`
 - `dataType` - the data type of the property. For use in the appropriate `<media>Fields`, must be set to `text` or `blob` as appropriate.
 
 #### Example

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-cohere.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-cohere.md
@@ -119,7 +119,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
 #### Property-level
 
 - `skip` – whether to skip vectorizing the property altogether. Default: `false`
-- `vectorizePropertyName` – whether to vectorize the property name. Default: `true`
+- `vectorizePropertyName` – whether to vectorize the property name. Default: `false`
 
 #### Example
 

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md
@@ -115,7 +115,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
 #### Property-level
 
 - `skip` – whether to skip vectorizing the property altogether. Default: `false`
-- `vectorizePropertyName` – whether to vectorize the property name. Default: `true`
+- `vectorizePropertyName` – whether to vectorize the property name. Default: `false`
 
 #### Example
 

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-gpt4all.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-gpt4all.md
@@ -112,7 +112,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
 #### Property-level
 
 - `skip` – whether to skip vectorizing the property altogether. Default: `false`
-- `vectorizePropertyName` – whether to vectorize the property name. Default: `true`
+- `vectorizePropertyName` – whether to vectorize the property name. Default: `false`
 
 #### Example
 

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface.md
@@ -126,7 +126,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
 #### Property-level
 
 - `skip` – whether to skip vectorizing the property altogether. Default: `false`
-- `vectorizePropertyName` – whether to vectorize the property name. Default: `true`
+- `vectorizePropertyName` – whether to vectorize the property name. Default: `false`
 
 #### Example
 

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-palm.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-palm.md
@@ -113,7 +113,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
 #### Property-level
 
 - `skip` – whether to skip vectorizing the property altogether. Default: `false`
-- `vectorizePropertyName` – whether to vectorize the property name. Default: `true`
+- `vectorizePropertyName` – whether to vectorize the property name. Default: `false`
 
 #### Example
 

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers.md
@@ -129,7 +129,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
 #### Property-level
 
 - `skip` – whether to skip vectorizing the property altogether. Default: `false`
-- `vectorizePropertyName` – whether to vectorize the property name. Default: `true`
+- `vectorizePropertyName` – whether to vectorize the property name. Default: `false`
 
 #### Example
 


### PR DESCRIPTION
### What's being changed:

Fix default vectorizepropertyname

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
