### PR TITLE
[docs/bugfix] Fix erroneous examples for vectorizeClassName

### DIFF
--- a/_includes/vectorization.behavior.mdx
+++ b/_includes/vectorization.behavior.mdx
@@ -6,5 +6,5 @@ Unless specified otherwise in the schema, the default behavior is to:
 - Sort properties in alphabetical (a-z) order before concatenating values
 - If `vectorizePropertyName` is `true` (`false` by default) prepend the property name to each property value
 - Join the (prepended) property values with spaces
-- Prepend the class name (unless `vectorizeClassName` is false)
+- Prepend the class name (unless `vectorizeClassName` is `false`)
 - Convert the produced string to lowercase

--- a/developers/weaviate/api/rest/schema.md
+++ b/developers/weaviate/api/rest/schema.md
@@ -256,7 +256,7 @@ Learn more about the schema configuration [here](/developers/weaviate/config-ref
 | `vectorIndexType` | body | string | Defaults to hnsw. Can be omitted in schema definition since this is the only available type for now. |
 | `vectorIndexConfig` | body | object | Vector index type specific settings. |
 | `vectorizer` | body | string | Vectorizer to use for data objects added to this class. Default can be set via Weaviate environment variables. |
-| `moduleConfig` > `text2vec-contextionary`  > `vectorizeClassName` | body | object | Include the class name in vector calculation (default true). Learn more about [semantic indexing in Weaviate](/developers/weaviate/config-refs/schema.md#configure-semantic-indexing). |
+| `moduleConfig` > `text2vec-contextionary`  > `vectorizeClassName` | body | boolean | Include the class name in vector calculation (default true). Learn more about [semantic indexing in Weaviate](/developers/weaviate/config-refs/schema.md#configure-semantic-indexing). |
 | `properties` | body | array | An array of property objects. |
 | `properties` > `dataType` | body | array | See the [available data types](/developers/weaviate/config-refs/datatypes.md). |
 | `properties` > `description` | body | string | Description of the property. |
@@ -354,7 +354,7 @@ Parameters in the PUT body:
 | `vectorIndexType` | body | string | Defaults to hnsw. Can be omitted in schema definition since this is the only available type for now. |
 | `vectorIndexConfig` | body | object | Vector index type specific settings. |
 | `vectorizer` | body | string | Vectorizer to use for data objects added to this class. Default can be set via Weaviate environment variables. |
-| `moduleConfig` > `text2vec-contextionary`  > `vectorizeClassName` | body | object | Include the class name in vector calculation (default true). Learn more about how to [configure indexing in Weaviate](/developers/weaviate/config-refs/schema.md#configure-semantic-indexing). |
+| `moduleConfig` > `text2vec-contextionary`  > `vectorizeClassName` | body | boolean | Include the class name in vector calculation (default true). Learn more about how to [configure indexing in Weaviate](/developers/weaviate/config-refs/schema.md#configure-semantic-indexing). |
 | `properties` | body | array | An array of property objects. |
 | `properties` > `dataType` | body | array | See the [available data types](/developers/weaviate/config-refs/datatypes.md) |
 | `properties` > `description` | body | string | Description of the property. |

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-cohere.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-cohere.md
@@ -138,7 +138,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
           "model": "embed-multilingual-v2.0", // Defaults to embed-multilingual-v2.0 if not set
           "truncate": "RIGHT", // Defaults to RIGHT if not set
           // highlight-start
-          "vectorizeClassName": "false"
+          "vectorizeClassName": false
           // highlight-end
         }
       },

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary.md
@@ -129,7 +129,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
       "moduleConfig": {
         // highlight-start
         "text2vec-contextionary": {
-          "vectorizeClassName": "false"
+          "vectorizeClassName": false
         }
         // highlight-end
       },

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-gpt4all.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-gpt4all.md
@@ -126,7 +126,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
       "moduleConfig": {
         "text2vec-gpt4all": {
           // highlight-start
-          "vectorizeClassName": "false"
+          "vectorizeClassName": false
           // highlight-end
         }
       },

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface.md
@@ -145,7 +145,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
             "useGPU": true,
             "useCache": true
           },
-          "vectorizeClassName": "false"
+          "vectorizeClassName": false
         }
       },
       "properties": [

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai.md
@@ -178,7 +178,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
           "modelVersion": "002",
           "type": "text",
           // highlight-start
-          "vectorizeClassName": "false"
+          "vectorizeClassName": false
           // highlight-end
         }
       },

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-palm.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-palm.md
@@ -130,7 +130,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
           "apiEndpoint": "YOUR-API-ENDPOINT",             // Optional. Defaults to "us-central1-aiplatform.googleapis.com".
           "modelId": "YOUR-GOOGLE-CLOUD-MODEL-ID",        // Optional. Defaults to "textembedding-gecko@001".
           // highlight-start
-          "vectorizeClassName": "false"
+          "vectorizeClassName": false
           // highlight-end
         },
       },

--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers.md
@@ -143,7 +143,7 @@ You can set vectorizer behavior using the `moduleConfig` section under each clas
       "vectorizer": "text2vec-transformers",
       "moduleConfig": {
         "text2vec-transformers": {
-          "vectorizeClassName": "false"
+          "vectorizeClassName": false
         }
       },
       // highlight-end


### PR DESCRIPTION
### What's being changed:

Fix erroneous examples for vectorizeClassName

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
