### PR TITLE
169 link to release notes

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -23,6 +23,11 @@ const sidebars = {
       value: '<div class="separator"></div>',
     },
     {
+     type: 'link',
+     label: '→ Release notes',
+     href: 'https://github.com/weaviate/weaviate/releases/',
+    },
+    {
       type: 'link',
       label: '→ Weaviate Cloud Services docs',
       href: '/developers/wcs',


### PR DESCRIPTION
[issue](https://github.com/weaviate/weaviate-edu-team-tasks/issues/169)
[staging](https://169-link-to-release-notes--tangerine-buttercream-20c32f.netlify.app/developers/weaviate)


### What's being changed:

adds a link to the release notes

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)


### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

