### PR TITLE
173 truncate long branch names

### DIFF
--- a/_build_scripts/publish-draft-to-netlify.sh
+++ b/_build_scripts/publish-draft-to-netlify.sh
@@ -6,7 +6,7 @@ mv build/robots.txt build/robots.txt.live
 echo -e "User-agent: *
 Disallow: /" >> build/robots.txt
 
-# Trunctate branch names since netifly label is too long
+# Trunctate branch names since netifly label is too long for DNS
 BR_NAME=$(cat .git/HEAD | cut -c 17-49)
 
 ./node_modules/.bin/netlify deploy --dir=build --alias ${BR_NAME} --site=tangerine-buttercream-20c32f > netlify.out

--- a/_build_scripts/publish-draft-to-netlify.sh
+++ b/_build_scripts/publish-draft-to-netlify.sh
@@ -7,7 +7,7 @@ echo -e "User-agent: *
 Disallow: /" >> build/robots.txt
 
 # Trunctate branch names since netifly label is too long
-BR_NAME=$(cat .git/HEAD | cut -c 17-50)
+BR_NAME=$(cat .git/HEAD | cut -c 17-49)
 
 ./node_modules/.bin/netlify deploy --dir=build --alias ${BR_NAME} --site=tangerine-buttercream-20c32f > netlify.out
 

--- a/_build_scripts/publish-draft-to-netlify.sh
+++ b/_build_scripts/publish-draft-to-netlify.sh
@@ -6,7 +6,8 @@ mv build/robots.txt build/robots.txt.live
 echo -e "User-agent: *
 Disallow: /" >> build/robots.txt
 
-BR_NAME=$(cat .git/HEAD | cut -c 17-)
+# Trunctate branch names since netifly label is too long
+BR_NAME=$(cat .git/HEAD | cut -c 17-50)
 
 ./node_modules/.bin/netlify deploy --dir=build --alias ${BR_NAME} --site=tangerine-buttercream-20c32f > netlify.out
 


### PR DESCRIPTION
[issue](https://github.com/weaviate/weaviate-edu-team-tasks/issues/173)
[staging](https://173-long-branch-names234567890123--tangerine-buttercream-20c32f.netlify.app/)


### What's being changed:
 Trunctate long branch names so they comply with DNS label limit

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

