### PR TITLE
185 update 1.21.9 1.22.2 links

### DIFF
--- a/_includes/releases-chart.md
+++ b/_includes/releases-chart.md
@@ -8,7 +8,8 @@ To see release notes for a particular version, click on the version number.
 
 |Weaviate Version|Release Date|Python|TypeScript|Go|Java|
 |:-|:-|:-:|:-:|:-:|:-:|
-|[1.22.1][c1.22.1]|2023-10-30|[3.25.2][p3.25.2]|[1.5.0][ts1.5.0]|[4.10.0][g4.10.0]|[4.3.0][j4.3.0]|
+|[1.22.2][c1.22.2]|2023-11-01|[3.25.2][p3.25.2]|[1.5.0][ts1.5.0]|[4.10.0][g4.10.0]|[4.3.0][j4.3.0]|
+|[1.22.1][c1.22.1]|2023-10-30|''|''|''|''|
 |[1.22.0][c1.22.0]|2023-10-27|''|''|''|''|
 |[1.21.0][c1.21.0]|2023-08-17|[3.22.1][p3.22.1]|[1.4.0][ts1.4.0]|[4.9.0][g4.9.0]|[4.2.1][j4.2.1]|
 |[1.20.0][c1.20.0]|2023-07-06|[3.22.0][p3.22.0]| '' | '' |[4.2.0][j4.2.0]|
@@ -44,8 +45,10 @@ For links to the Weaviate Core releases, expand this section.
 
   |Weaviate Version|Release Date|
   |:-|:-|
+  |[1.22.2][c1.22.2]|2023-11-01|
   |[1.22.1][c1.22.1]|2023-10-30|
   |[1.22.0][c1.22.0]|2023-10-27|
+  |[1.21.9][c1.21.9]|2023-11-01|
   |[1.21.8][c1.21.8]|2023-10-25|
   |[1.21.7][c1.21.7]|2023-10-19|
   |[1.21.6][c1.21.6]|2023-10-13|
@@ -373,8 +376,10 @@ For links to the Java Client releases, expand this section.
 
 
 [comment]: # ( core links )
+[c1.22.2]: https://github.com/weaviate/weaviate/releases/tag/v1.22.2
 [c1.22.1]: https://github.com/weaviate/weaviate/releases/tag/v1.22.1
 [c1.22.0]: https://github.com/weaviate/weaviate/releases/tag/v1.22.0
+[c1.21.9]: https://github.com/weaviate/weaviate/releases/tag/v1.21.9
 [c1.21.8]: https://github.com/weaviate/weaviate/releases/tag/v1.21.8
 [c1.21.7]: https://github.com/weaviate/weaviate/releases/tag/v1.21.7
 [c1.21.6]: https://github.com/weaviate/weaviate/releases/tag/v1.21.6


### PR DESCRIPTION
[issue](https://github.com/weaviate/weaviate-edu-team-tasks/issues/185)
[staging](https://185-update-release-note-links--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/release-notes)

### What's being changed:
add links

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
