### PR TITLE
[docs] Add links to Go inline docs

### DIFF
--- a/developers/weaviate/concepts/prefiltering.md
+++ b/developers/weaviate/concepts/prefiltering.md
@@ -58,6 +58,10 @@ If you are using Weaviate version `< 1.18.0`, you can take advantage of roaring 
 
 This behavior is set through the <code>REINDEX<wbr />_SET_TO<wbr />_ROARINGSET<wbr />_AT_STARTUP</code> [environment variable](../config-refs/env-vars.md). If you do not wish for reindexing to occur, you can set this to `false` prior to upgrading.
 
+:::into Read more
+To learn more about Weaviate's roaring bitmaps implementation, see the [in-line documentation](https://pkg.go.dev/github.com/weaviate/weaviate/adapters/repos/db/lsmkv/roaringset).
+:::
+
 ## Recall on Pre-Filtered Searches
 
 Thanks to Weaviate's custom HNSW implementation, which persists in following all links in the HNSW graph normally and only applying the filter condition when considering the result set, graph integrity is kept intact. The recall of a filtered search is typically not any worse than that of an unfiltered search.


### PR DESCRIPTION
### What's being changed:

Add links to Go inline docs

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
