### PR TITLE
PR: 20231117/update-autotext-ref

### DIFF
--- a/developers/weaviate/api/graphql/search-operators.md
+++ b/developers/weaviate/api/graphql/search-operators.md
@@ -409,7 +409,7 @@ This operator allows you to find data objects in the vicinity of the vector repr
 | `concepts` | yes | `[string]` | An array of strings that can be natural language queries, or single words. If multiple strings are used, a centroid is calculated and used. Learn more about how the concepts are parsed [here](#concept-parsing). |
 | `distance` | no | `float` | The maximum allowed distance to the provided search input. Cannot be used together with the `certainty` variable. The interpretation of the value of the distance field depends on the [distance metric used](/developers/weaviate/config-refs/distances.md). |
 | `certainty` | no | `float` | Normalized Distance between the result item and the search vector. Normalized to be between 0 (perfect opposite) and 1 (identical vectors). Can't be used together with the `distance` variable. |
-| `autocorrect` | no | `boolean` | Autocorrect input text values |
+| `autocorrect` | no | `boolean` | Autocorrect input text values. Requires the [`text-spellcheck` module](../../modules/other-modules/spellcheck.md) to be present & enabled.  |
 | `moveTo` | no | `object{}` | Move your search term closer to another vector described by keywords |
 | `moveTo{concepts}`| no | `[string]` | An array of strings - natural language queries or single words. If multiple strings are used, a centroid is calculated and used. |
 | `moveTo{objects}`| no | `[UUID]` | Object IDs to move the results to. This is used to "bias" NLP search results into a certain direction in vector space. |


### PR DESCRIPTION
This git diff adds a clarification to the `autocorrect` parameter in the API. It now states that the parameter requires the `text-spellcheck` module to be present and enabled.