### PR TITLE
[Docs] Fix typo in contributor-guide/weaviate-core/cicd.md

### DIFF
--- a/developers/contributor-guide/weaviate-core/cicd.md
+++ b/developers/contributor-guide/weaviate-core/cicd.md
@@ -25,7 +25,7 @@ In practice this means:
 * Keep every single commit production ready. Do not use the comfort of a branch
   to temporarily ignore quality standards, knowing that you can still fix them
   before creating a Pull Request. As a rule of thumb, every commit should have a
-  passing test suite and should contain anything that you wouldn't want to be
+  passing test suite and should not contain anything that you wouldn't want to be
   used at scale.
 
   There might be situations, especially when developing complex features, where


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Fixed a typo on the CICD Philosophy page. The text is probably meant to say "....and should **not** contain anything that you wouldn't want to be used at scale."

 
![image](https://github.com/weaviate/weaviate-io/assets/31365542/43868fc8-739c-4146-ac41-1dd0390454d4)


### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
