### PR TITLE
227 updates for howto search refactor

### DIFF
--- a/_includes/code/howto/search.aggregate.py
+++ b/_includes/code/howto/search.aggregate.py
@@ -331,10 +331,10 @@ import weaviate.classes as wvc
 jeopardy = client.collections.get("JeopardyQuestion")
 response = jeopardy.aggregate.near_text(
     query="animals in space",
-    return_metrics=wvc.Metrics("points").number(sum_=True),
     # highlight-start
     object_limit=10,
     # highlight-end
+    return_metrics=wvc.Metrics("points").number(sum_=True),
 )
 
 print(response.properties["points"].sum_)
@@ -397,11 +397,10 @@ import weaviate.classes as wvc
 
 jeopardy = client.collections.get("JeopardyQuestion")
 response = jeopardy.aggregate.near_text(
-    # highlight-start
     query="animals in space",
+    # highlight-start
     distance=0.19,
     # highlight-end
-    object_limit=10,
     return_metrics=wvc.Metrics("points").number(sum_=True),
 )
 

--- a/_includes/code/howto/search.filters.py
+++ b/_includes/code/howto/search.filters.py
@@ -291,6 +291,8 @@ from weaviate.classes import Filter
 jeopardy = client.collections.get("JeopardyQuestion")
 response = jeopardy.query.fetch_objects(
     # highlight-start
+    # Use & as AND
+    #     | as OR 
     filters=Filter("round").equal("Double Jeopardy!") &
             Filter("points").less_than(600),
     # highlight-end

--- a/_includes/code/howto/search.similarity.py
+++ b/_includes/code/howto/search.similarity.py
@@ -226,8 +226,8 @@ jeopardy = client.collections.get("JeopardyQuestion")
 response = jeopardy.query.near_text(
     query="animals in movies",
     # highlight-start
-    # offset=1, # offset is currently not supported with the Weaviate Client v4
-    limit=2
+    # offset=1, # `offset` support is being added to the client
+    limit=2,  # return 2 objects
     # highlight-end
 )
 
@@ -549,7 +549,7 @@ response = jeopardy.query.near_text(
     # highlight-start
     filters=wvc.Filter("round").equal("Double Jeopardy!"),
     # highlight-end
-    limit=2, # number of close groups
+    limit=2,
 )
 
 for o in response.objects:

--- a/developers/weaviate/_parking-lot-old-how-tos/generative.md
+++ b/developers/weaviate/_parking-lot-old-how-tos/generative.md
@@ -302,7 +302,7 @@ It should produce a response like the one below:
 
 ### Grouped task property selection
 
-:::info Available from version `v1.18.3`
+:::info Added in `v1.18.3`
 :::
 
 You can specify which properties will be included in the `grouped task` prompt. Use this to limit the information provided in the prompt, and to reduce the prompt length.

--- a/developers/weaviate/_parking-lot-old-how-tos/similarity.md
+++ b/developers/weaviate/_parking-lot-old-how-tos/similarity.md
@@ -16,6 +16,8 @@ import TSCode from '!!raw-loader!/_includes/code/howto/search.similarity.ts';
 
 ## Overview
 
+Vector search is a similarity based search based on vector representations. Objects in the database have vector representations called "vector embeddings".
+
 This page shows you how to perform similarity-based searches with the `nearXXX` operators.
 
 These operators work by searching for objects with the most similar vector representation to the query. Note that due to differences in configuration and data, we have a [separate page for image searches](./image.md).
@@ -266,7 +268,7 @@ The example below searches the `JeopardyQuestion` class for objects best matchin
       language="python"
     />
   </TabItem>
-  
+
   <TabItem value="py3" label="Python (v3)">
     <FilteredTextBlock
       text={PyCodeV3}
@@ -365,7 +367,7 @@ It should produce a response like the one below:
 
 ## Group results by a property or cross-reference
 
-:::info Available from version `v1.19`
+:::info Added in `v1.19`
 :::
 
 You can group search results by any arbitrary property or cross-reference.
@@ -442,7 +444,7 @@ The example below searches the `JeopardyQuestion` class for the top 2 objects be
       language="python"
     />
   </TabItem>
-  
+
   <TabItem value="py3" label="Python (v3)">
     <FilteredTextBlock
       text={PyCodeV3}

--- a/developers/weaviate/search/aggregate.md
+++ b/developers/weaviate/search/aggregate.md
@@ -12,7 +12,7 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.aggregate.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.aggregate-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.aggregate.ts';
 
-`Aggregate` queries process multiple objects and return a calculated result. Use `aggregate` to group values across objects or to perform an operation that returns a single result.
+`Aggregate` queries process the result set to return calculated results. Use `aggregate` queries for groups of objects or the entire result set.
 
 <details>
   <summary>
@@ -22,7 +22,7 @@ import TSCode from '!!raw-loader!/_includes/code/howto/search.aggregate.ts';
 To run an `Aggregate` query, specify the following:
 
 - A target collection to search
-- One or more aggregated properties
+- One or more aggregated properties, such as:
 
    - A meta property
    - An object property
@@ -30,7 +30,7 @@ To run an `Aggregate` query, specify the following:
 
 - Select at least one sub-property for each selected property
 
-For details, see <a href="https://weaviate.io/developers/weaviate/api/graphql/aggregate">Aggregate</a>.  
+For details, see <a href="https://weaviate.io/developers/weaviate/api/graphql/aggregate">Aggregate</a>.
 
 </details>
 
@@ -91,7 +91,7 @@ Return the number  of objects matched by the query.
 
 ## Aggregate `text` properties
 
-This example counts frequencies in the `question` property:
+This example counts occurrence frequencies in the `question` property:
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -201,7 +201,9 @@ This  example sums the `points` property.
 
 ## Aggregate `groupedBy` properties
 
-To group your results, use `groupBy`. To retrieve aggregate data for each group, use the `groupedBy` properties.
+To group your results, use `groupBy` in the query.
+
+To retrieve aggregate data for each group, use the `groupedBy` properties.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -259,9 +261,12 @@ import GroupbyLimitations from '/_includes/groupby-limitations.mdx';
 
 <GroupbyLimitations />
 
-## Limit the input size
+## Aggregate with a `similarity search`
 
-If you use `Aggregate` with a [similarity search](./similarity.md) operator (one of the `nearXXX` operators), [limit your search results](../api/graphql/aggregate.md#limiting-the-search-space). Use `objectLimit` to specify the maximum number of objects to aggregate.
+You can use `Aggregate` with a [similarity search](./similarity.md) operator (one of the `Near` operators).
+
+<!-- Make sure to [limit your search results](../api/graphql/aggregate.md#limiting-the-search-space).<br/> -->
+Use `objectLimit` to specify the maximum number of objects to aggregate.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -316,7 +321,12 @@ If you use `Aggregate` with a [similarity search](./similarity.md) operator (one
 
 ## Set a similarity `distance`
 
-If you use `Aggregate` with a [similarity search](./similarity.md) operator (one of the `nearXXX` operators), [limit your search results](../api/graphql/aggregate.md#limiting-the-search-space). To specify how similar the objects should be, use the `distance` operator.
+You can use `Aggregate` with a [similarity search](./similarity.md) operator (one of the `Near` operators).
+
+<!-- Make sure to [limit your search results](../api/graphql/aggregate.md#limiting-the-search-space).<br/> -->
+Use `distance` to specify how similar the objects should be.
+
+<!-- If you use `Aggregate` with a [similarity search](./similarity.md) operator (one of the `nearXXX` operators), [limit your search results](../api/graphql/aggregate.md#limiting-the-search-space). To specify how similar the objects should be, use the `distance` operator. -->
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -369,9 +379,9 @@ If you use `Aggregate` with a [similarity search](./similarity.md) operator (one
   />
 </details>
 
-## Use a `where` filter
+## Filter results
 
-For more specific results, use `where` to narrow your search.
+For more specific results, use a `filter` to narrow your search.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">

--- a/developers/weaviate/search/aggregate.md
+++ b/developers/weaviate/search/aggregate.md
@@ -12,7 +12,7 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.aggregate.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.aggregate-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.aggregate.ts';
 
-`Aggregate` queries return values that are calculated over result objects. Aggregate queries don't return the underlying result objects.
+`Aggregate` queries process multiple objects and return a calculated result. Use `aggregate` to group values across objects or to perform an operation that returns a single result.
 
 <details>
   <summary>

--- a/developers/weaviate/search/basics.md
+++ b/developers/weaviate/search/basics.md
@@ -12,7 +12,9 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.basics.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.basics-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.basics.ts';
 
-With Weaviate you can query your data for exact matches ([keyword search](/developers/weaviate/search/bm25)), similar items ([vector search](/developers/weaviate/search/similarity))), or a mix of both ([hybrid search](/developers/weaviate/search/hybrid)). You can query database objects ([properties](#specify-object-properties)) or information about the objects ([meta-properties](#retrieve-other-metadata-values)). This page provides fundamental search syntax to get you started. 
+With Weaviate you can query your data using [vector similarity search](./similarity.md), [keyword search](./bm25.md), or a mix of both with [hybrid search](./hybrid.md). You can control what object [properties](#specify-object-properties) and [metadata](#retrieve-metadata-values) to return.
+
+This page provides fundamental search syntax to get you started.
 
 ## Basic search
 
@@ -78,13 +80,13 @@ The output is like this:
 <details>
   <summary>Additional information</summary>
 
-  Specify the information that you want your query to return. You can return object properties, object IDs, and object metadata. Weaviate search is based on the [GraphQL API](../api/graphql/index.md).
+  Specify the information that you want your query to return. You can return object properties, object IDs, and object metadata.
 
 </details>
 
 ## `limit` returned objects
 
-To return a limited number of objects, set a `limit`.
+Use `limit` to set a fixed maximum number of objects to return.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">
@@ -202,10 +204,12 @@ The output is like this:
 
 </details>
 
+To paginate through the entire database, use a [cursor](../manage-data/read-all-objects.mdx#list-every-object) instead of offset and limit.
+
 
 ## Specify object `properties`
 
-You can specify object properties to be returned as below.
+You can specify which object properties to return.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">
@@ -266,7 +270,7 @@ The output is like this:
 
 ## Retrieve the object `vector`
 
-You can retrieve the object vector as shown below.
+You can retrieve the object vector.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">
@@ -325,12 +329,10 @@ The output is like this:
 
 ## Retrieve the object `id`
 
-You can retrieve the object `id` (uuid) as shown below.
+You can retrieve the object `id` (uuid).
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">
-
- The new Python client always returns the object ID.
 
 <FilteredTextBlock
   text={PyCode}
@@ -450,9 +452,9 @@ The output is like this:
 
 </details>
 
-## Retrieve other metadata values
+## Retrieve metadata values
 
-You can specify metadata fields to be returned as shown below.
+You can specify metadata fields to be returned.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">

--- a/developers/weaviate/search/basics.md
+++ b/developers/weaviate/search/basics.md
@@ -12,7 +12,7 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.basics.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.basics-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.basics.ts';
 
-With Weaviate you can query your data for exact matches ([keyword search](./bm25)), similar items ([vector search](./similarity))), or a mix of both ([hybrid search](./hybrid)). You can query database objects ([properties](#specify-object-properties)) or information about the objects ([meta-properties](#retrieve-other-metadata-values)). This page provides fundamental search syntax to get you started. 
+With Weaviate you can query your data for exact matches ([keyword search](/developers/weaviate/search/bm25)), similar items ([vector search](/developers/weaviate/search/similarity))), or a mix of both ([hybrid search](/developers/weaviate/search/hybrid)). You can query database objects ([properties](#specify-object-properties)) or information about the objects ([meta-properties](#retrieve-other-metadata-values)). This page provides fundamental search syntax to get you started. 
 
 ## Basic search
 

--- a/developers/weaviate/search/basics.md
+++ b/developers/weaviate/search/basics.md
@@ -12,17 +12,6 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.basics.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.basics-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.basics.ts';
 
-import ClassToCollectionNote from '/_includes/class-to-collection-transition-note.mdx' ;
-
-<ClassToCollectionNote /> 
-
-<details>
-  <summary>Additional information</summary>
-
-  - For tutorials, see [Queries](/developers/academy/zero_to_mvp/queries_1).
-  - For search using the GraphQL API, see [GraphQL API](../api/graphql/get.md).
-
-</details>
 
 ## Basic search
 
@@ -504,6 +493,8 @@ If [multi-tenancy](../concepts/data.md#multi-tenancy) is enabled, specify the te
 ## Related pages
 
 - [API References: GraphQL: Get](../api/graphql/get.md)
+- For tutorials, see [Queries](/developers/academy/zero_to_mvp/queries_1)
+- For search using the GraphQL API, see [GraphQL API](../api/graphql/get.md)
 
 import DocsMoreResources from '/_includes/more-resources-docs.md';
 

--- a/developers/weaviate/search/basics.md
+++ b/developers/weaviate/search/basics.md
@@ -12,6 +12,8 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.basics.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.basics-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.basics.ts';
 
+With Weaviate you can query your data for exact matches ([keyword search](./bm25)), similar items ([vector search](./similarity))), or a mix of both ([hybrid search](./hybrid)). You can query database objects ([properties](#specify-object-properties)) or information about the objects ([meta-properties](#retrieve-other-metadata-values)). This page provides fundamental search syntax to get you started. 
+
 ## Basic search
 
 You can get objects without specifying any parameters. This returns objects ordered by their UUID.

--- a/developers/weaviate/search/bm25.md
+++ b/developers/weaviate/search/bm25.md
@@ -12,7 +12,7 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.bm25.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.bm25-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.bm25.ts';
 
-Keyword search is also called "BM25 (Best match 25)" or "sparse vector" search. Keyword search looks for exact matches and returns objects that have the highest matching keyword scores.  
+`Keyword` search, also called "BM25 (Best match 25)" or "sparse vector" search, returns objects that have the highest BM25F scores.
 
 ## Basic BM25 search
 
@@ -70,9 +70,9 @@ It should produce a response like the one below:
 
 </details>
 
-## Retrieve BM25 scores
+## Retrieve BM25F scores
 
-You can retrieve the BM25 `score` values for each returned object.
+You can retrieve the BM25F `score` values for each returned object.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -128,10 +128,10 @@ It should produce a response like the one below:
 
 ## Search on selected properties only
 
-:::info Available from version `v1.19.0`
+:::info Added in `v1.19.0`
 :::
 
-A keyword search can be directed to a only search a subset of object properties. In this example, the BM25 search only uses the `question` property to produce the BM25F score.
+A keyword search can be directed to only search a subset of object properties. In this example, the BM25 search only uses the `question` property to produce the BM25F score.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -188,7 +188,7 @@ It should produce a response like the one below:
 
 ## Use weights to boost properties
 
-:::info Available from version `v1.19.0`
+:::info Added in `v1.19.0`
 :::
 
 You can weight how much each property affects the overall BM25F score. This example boosts the `question` property by a factor of 2 while the `answer` property remains static.
@@ -285,9 +285,11 @@ import TknTsCode from '!!raw-loader!/_includes/code/howto/configure.schema.ts';
   </TabItem>
 </Tabs>
 
-## Set a fixed results limit
+## `limit` & `offset`
 
-You can set a fixed limit on the number of result objects.
+Use `limit` to set a fixed maximum number of objects to return.
+
+Optionally, use `offset` to paginate the results.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -327,9 +329,9 @@ You can set a fixed limit on the number of result objects.
   </TabItem>
 </Tabs>
 
-## Set an `Autocut` limit
+## Limit result groups
 
-You can set a maximum groups to be returned with the `autocut` operator.
+To limit results to groups of similar distances to the query, use the [`autocut`](../api/graphql/additional-operators.md#autocut) filter to set the number of groups to return.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -384,10 +386,9 @@ It should produce a response like the one below:
 </details>
 
 
+## Filter results
 
-## Add a conditional (`where`) filter
-
-You can add a conditional filter to any BM25 search query.
+For more specific results, use a [`filter`](../api/graphql/filters.md) to narrow your search.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">

--- a/developers/weaviate/search/bm25.md
+++ b/developers/weaviate/search/bm25.md
@@ -1,11 +1,9 @@
 ---
-title: Keyword (BM25) search
+title: Keyword search
 sidebar_position: 40
 image: og/docs/howto.jpg
 # tags: ['how to', 'similarity search']
 ---
-
-
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -14,13 +12,11 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.bm25.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.bm25-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.bm25.ts';
 
-## Overview
-
-A keyword search, also called a sparse vector search, looks for objects with highest keyword matching scores.
+Keyword search is also called "BM25 (Best match 25)" or "sparse vector" search. Keyword search looks for exact matches and returns objects that have the highest matching keyword scores.  
 
 ## Basic BM25 search
 
-A search string is required for a BM25 search.
+To use BM25 keyword search, define a search string.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">

--- a/developers/weaviate/search/filters.md
+++ b/developers/weaviate/search/filters.md
@@ -12,11 +12,12 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.filters.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.filters-v3.py';
 import JavaScriptCode from '!!raw-loader!/_includes/code/howto/search.filters.ts';
 
-Use filters to define a set of conditions. Filters let you include, or exclude, particular objects from your result set based on those conditions. For a list of filter operators, see [Filters](../api/graphql/filters.md#filter-structure).
+Filters let you include, or exclude, particular objects from your result set based on provided conditions.<br/>
+For a list of filter operators, see [Filters](../api/graphql/filters.md#filter-structure).
 
 ## Filter with one condition
 
-To filter your results, add a `where` condition to your query. For a list of filter parameters, see [Filter structure](../api/graphql/filters.md#filter-structure).
+Add a `filter` to your query, to limit the result set.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -254,7 +255,7 @@ The output is like this:
 
 ## Filter text on partial matches
 
-If the object property is a `text` data type, use `Like` to filter on partial text matches.
+If the object property is a `text`, or `text`-like data type such as object ID, use `Like` to filter on partial text matches.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">

--- a/developers/weaviate/search/generative.md
+++ b/developers/weaviate/search/generative.md
@@ -12,7 +12,8 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.generative.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.generative-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.generative.ts';
 
-Generative search, also know as "retrieval augmented generation" (RAG), is a multi-stage process. Weaviate passes search results and a prompt to a large language model (LLM). The LLM generates a new output based on that input.
+`Generative` search, also known as "Retrieval Augmented Generation" (RAG), is a multi-stage process.<br/>
+First Weaviate performs a query, then it passes the retrieved results and a prompt to a large language model (LLM), to generate a new output.
 
 <details>
   <summary>
@@ -26,75 +27,22 @@ Generative search, also know as "retrieval augmented generation" (RAG), is a mul
    - [`generative-openai`](../modules/reader-generator-modules/generative-openai.md)
    - [`generative-cohere`](../modules/reader-generator-modules/generative-cohere.md)
    - [`generative-palm`](../modules/reader-generator-modules/generative-palm.md)
-   
- 2. Configure the target collection to use the generator module. For details, see schema configuration on the module reference page. 
+
+ 2. Configure the target collection to use the generator module. For details, see schema configuration on the module reference page.
  3. Query your database to retrieve one or more objects.
  4. Use the query results to generate a new result.
- 
+
     - [`single prompt`](#single-prompt)
     - [`grouped task`](#grouped-task)
 
 </details>
 
-## Run a single prompt search
 
-Single prompt search returns a generated response for each object in the query results. Specify the object `properties` to use in the prompt.
+## Single prompt search
 
-<Tabs groupId="languages">
-  <TabItem value="py" label="Python (v4)">
-    <FilteredTextBlock
-      text={PyCode}
-      startMarker="# SingleGenerativePython"
-      endMarker="# END SingleGenerativePython"
-      language="py"
-    />
-  </TabItem>
-
-  <TabItem value="py3" label="Python (v3)">
-    <FilteredTextBlock
-      text={PyCodeV3}
-      startMarker="# SingleGenerativePython"
-      endMarker="# END SingleGenerativePython"
-      language="py"
-    />
-  </TabItem>
-
-  <TabItem value="js" label="JavaScript/TypeScript">
-    <FilteredTextBlock
-      text={TSCode}
-      startMarker="// SingleGenerative TS"
-      endMarker="// END SingleGenerative TS"
-      language="js"
-    />
-  </TabItem>
-
-  <TabItem value="graphql" label="GraphQL">
-    <FilteredTextBlock
-      text={PyCode}
-      startMarker="# SingleGenerativeGraphQL"
-      endMarker="# END SingleGenerativeGraphQL"
-      language="graphql"
-    />
-  </TabItem>
-</Tabs>
-
-<details>
-  <summary>Example response</summary>
-
-The output is like this:
-
-<FilteredTextBlock
-  text={PyCode}
-  startMarker="# SingleGenerative Expected Results"
-  endMarker="# END SingleGenerative Expected Results"
-  language="json"
-/>
-
-</details>
-
-## Set single prompt search properties
-
-Define object `properties` to use in the prompt. The properties you use in the prompt do not have to be among the properties you retrieve in the query.
+Single prompt search returns a generated response for each object in the query results.<br/>
+Define object `properties` – using `{prop-name}` syntax – to interpolate retrieved content in the prompt.<br/>
+The properties you use in the prompt do not have to be among the properties you retrieve in the query.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -148,9 +96,9 @@ The output is like this:
 
 </details>
 
-## Run a grouped task search
+## Grouped task search
 
-Grouped task search returns a single response that includes all of the query results. By default grouped task search uses all object `properties` in the prompt.
+Grouped task search returns one response that includes all of the query results. By default grouped task search uses all object `properties` in the prompt.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -204,7 +152,7 @@ The output is like this:
 
 </details>
 
-## Set grouped task search properties
+## Set grouped task prompt properties
 
 :::info Added in `v1.18.3`
 :::

--- a/developers/weaviate/search/generative.md
+++ b/developers/weaviate/search/generative.md
@@ -14,7 +14,12 @@ import TSCode from '!!raw-loader!/_includes/code/howto/search.generative.ts';
 
 Generative search, also know as "retrieval augmented generation" (RAG), is a multi-stage process. Weaviate passes search results and a prompt to a large language model (LLM). The LLM generates a new output based on that input.
 
-## Generative search steps
+<details>
+  <summary>
+    Additional information
+  </summary>
+
+### Configure generative search
 
 1. Configure Weaviate to use a generator module. For details, see the module reference page:
 
@@ -29,6 +34,7 @@ Generative search, also know as "retrieval augmented generation" (RAG), is a mul
     - [`single prompt`](#single-prompt)
     - [`grouped task`](#grouped-task)
 
+</details>
 
 ## Run a single prompt search
 

--- a/developers/weaviate/search/hybrid.md
+++ b/developers/weaviate/search/hybrid.md
@@ -12,12 +12,11 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.hybrid.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.hybrid-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.hybrid.ts';
 
-`hybrid` search combines a vector search and a keyword (BM25F) search. By default, the results are equally weighted. To improve search precision, change the [weights](#balance-keyword-and-vector-search) or the [ranking method](#change-the-ranking-method).
+`Hybrid` search combines results of a vector search and a keyword (BM25F) search. You can set the [weights](#balance-keyword-and-vector-search) or the [ranking method](#change-the-ranking-method).
 
 ## Basic hybrid search
 
-- Match if an object contains the search keyword.
-- Match if an object's vector is similar to the vector for the search string
+Combines results of a vector search and a keyword search based on the query string.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">
@@ -130,7 +129,7 @@ The output is like this:
 Use the `alpha` argument to change how much each search affects the results.
 
 - An `alpha` of `1` is a pure vector search.
-- An `alpha` of `0` is a pure keyword search. 
+- An `alpha` of `0` is a pure keyword search.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">
@@ -188,7 +187,7 @@ The output is like this:
 :::info Added in `v1.20`
 :::
 
-`rankedFusion` is the default fusion algorithm. To scale keyword and vector search scores before combining them, use `relativeScoreFusion`.
+`Ranked Fusion` is the default fusion algorithm. To use objects' keyword and vector search scores instead of ranks, use `Relative Score Fusion`.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">
@@ -245,19 +244,17 @@ The output is like this:
   <summary>
     Additional information
   </summary>
-  <div>
-    In relativeScoreFusion the vector search and keyword search scores are scaled between 0 and 1. The highest raw score becomes 1 in the scaled scores. The lowest value is assigned 0. The remaining values are ranked between 0 and 1. The total score is a scaled sum of the normalized vector similarity and normalized BM25 scores.
 
-    For a discussion of fusion methods, see [this blog post](/blog/hybrid-search-fusion-algorithms)
-  </div>
+For a discussion of fusion methods, see [this blog post](/blog/hybrid-search-fusion-algorithms) and [this reference page](../api/graphql/search-operators.md#variables-2)
+
 </details>
 
-## Specify keyword search properties
+## Specify properties to keyword search
 
 :::info Added in `v1.19.0`
 :::
 
-Specify `properties` to fine tune your keyword search. The vector search does not change.
+The keyword search portion of hybrid search can be directed to only search a subset of object properties. This does not affect the vector search portion.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">
@@ -365,9 +362,9 @@ The output is like this:
 
 </details>
 
-## Use a custom vector
+## Specify a vector
 
-To use your own vector, pass it to the vector search and use a query string for the keyword search.
+To specify a vector instead of using a vector of the query string, pass it in addition to the query string for the keyword search.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">
@@ -420,9 +417,11 @@ The output is like this:
 
 </details>
 
-## Limit the size of the result set
+## `limit` & `offset`
 
-To specify a maximum number of result objects, use `limit`.
+Use `limit` to set a fixed maximum number of objects to return.
+
+Optionally, use `offset` to paginate the results.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -464,7 +463,7 @@ To specify a maximum number of result objects, use `limit`.
 
 ## Limit result groups
 
-To limit results to similar groups of objects, use the [`autocut`](../api/graphql/additional-operators.md#autocut) filter to set the number of groups to return.
+To limit results to groups of similar distances to the query, use the [`autocut`](../api/graphql/additional-operators.md#autocut) filter to set the number of groups to return.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -518,9 +517,9 @@ The output is like this:
 
 </details>
 
-## Use a `where` filter
+## Filter results
 
-For more specific results, use `where` to narrow your search.
+For more specific results, use a [`filter`](../api/graphql/filters.md) to narrow your search.
 
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">

--- a/developers/weaviate/search/hybrid.md
+++ b/developers/weaviate/search/hybrid.md
@@ -12,9 +12,7 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.hybrid.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.hybrid-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.hybrid.ts';
 
-import ClassToCollectionNote from '/_includes/class-to-collection-transition-note.mdx' ;
-
-<ClassToCollectionNote /> 
+`hybrid` search combines a vector search and a keyword (BM25F) search. By default, the results are equally weighted. To improve search precision, change the [weights](#balance-keyword-and-vector-search) or the [ranking method](#change-the-ranking-method).
 
 ## Basic hybrid search
 

--- a/developers/weaviate/search/image.md
+++ b/developers/weaviate/search/image.md
@@ -5,7 +5,6 @@ image: og/docs/howto.jpg
 # tags: ['how to', 'image']
 ---
 
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBlock';
@@ -13,6 +12,24 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.image.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.image-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.image.ts';
 
+Image search uses an image as input. The module that vectorizes the input image has to be the same module that vectorizes the images in the database.
+
+<details>
+  <summary>
+    Additional information
+  </summary>
+
+### Configure image search
+
+To use images as search inputs, configure a vectorizer [module](../configuration/modules.md) for your collection. For details, see the module's reference page:
+
+- [img2vec-neural](../modules/retriever-vectorizer-modules/img2vec-neural)
+- [multi2vec-clip](../modules/retriever-vectorizer-modules/multi2vec-clip)
+- [multi2vec-bind](../modules/retriever-vectorizer-modules/multi2vec-bind)
+
+Use the same module to vectorize the search input image and the images in your database. 
+ 
+</details>
 
 ## By local image path
 

--- a/developers/weaviate/search/image.md
+++ b/developers/weaviate/search/image.md
@@ -12,28 +12,28 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.image.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.image-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.image.ts';
 
-Image search uses an image as input. The module that vectorizes the input image has to be the same module that vectorizes the images in the database.
+`Image` search uses an **image as a search input** to perform vector similarity search.
 
 <details>
   <summary>
     Additional information
   </summary>
 
-### Configure image search
+**Configure image search**
 
-To use images as search inputs, configure a vectorizer [module](../configuration/modules.md) for your collection. For details, see the module's reference page:
+To use images as search inputs, configure an image vectorizer [module](../configuration/modules.md) for your collection.
 
+For details, see the modules reference page:
 
 - [img2vec-neural](/developers/weaviate/modules/retriever-vectorizer-modules/img2vec-neural.md)
 - [multi2vec-clip](/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip.md)
 - [multi2vec-bind](/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind.md)
-
-Use the same module to vectorize the search input image and the images in your database. 
  
 </details>
 
 ## By local image path
 
+Use the `Near Image` operator to execute image search.<br/>
 If your query image is stored in a file, you can use the client library to search by its filename.
 
 <Tabs groupId="languages">
@@ -154,7 +154,7 @@ You can create a base64 representation of an online image, and use it as input f
 
 ## Combination with other operators
 
-A `nearImage` search can be combined with any other operators, just as other similarity search operators such as `nearText` or `nearVector` can.
+A `Near Image` search can be combined with any other operators (like filter, limit, etc.), just as other similarity search operators.
 
 See the [`similarity search`](./similarity.md) page for more details.
 

--- a/developers/weaviate/search/image.md
+++ b/developers/weaviate/search/image.md
@@ -23,9 +23,10 @@ Image search uses an image as input. The module that vectorizes the input image 
 
 To use images as search inputs, configure a vectorizer [module](../configuration/modules.md) for your collection. For details, see the module's reference page:
 
-- [img2vec-neural](../modules/retriever-vectorizer-modules/img2vec-neural)
-- [multi2vec-clip](../modules/retriever-vectorizer-modules/multi2vec-clip)
-- [multi2vec-bind](../modules/retriever-vectorizer-modules/multi2vec-bind)
+
+- [img2vec-neural](/developers/weaviate/modules/retriever-vectorizer-modules/img2vec-neural.md)
+- [multi2vec-clip](/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip.md)
+- [multi2vec-bind](/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind.md)
 
 Use the same module to vectorize the search input image and the images in your database. 
  

--- a/developers/weaviate/search/index.md
+++ b/developers/weaviate/search/index.md
@@ -7,11 +7,11 @@ image: og/docs/howto.jpg
 
 Use these **search** how-to guides to find the data you want.
 
-The [query basics](./basics.md) page covers basic search syntax, and how to specify the properties you want to retrieve.
+The [query basics](./basics.md) page covers basic search syntax and how to specify the properties you want to retrieve.
 
-We have separate how-to guides for additional search topics:
+These guides cover additional search topics:
 
-- [Vector similarity search](./similarity.md): Covers `nearXXX` searches, which work by searching for objects with the most similar vector representation to the query.
+- [Vector similarity search](./similarity.md): Covers `nearXXX` searches that search for objects with the most similar vector representations to the query.
 - [Image search](./image.md): Use images as input for a similarity search.
 - [Keyword search](./bm25.md): A keyword search that uses the BM25F algorithm to rank results.
 - [Hybrid search](./hybrid.md): Combines BM25 and similarity search to rank results.

--- a/developers/weaviate/search/index.md
+++ b/developers/weaviate/search/index.md
@@ -5,31 +5,20 @@ image: og/docs/howto.jpg
 # tags: ['how to', 'perform a search']
 ---
 
+Use these **search** how-to guides to find the data you want.
 
+The [query basics](./basics.md) page covers basic search syntax, and how to specify the properties you want to retrieve.
 
-## Overview
+We have separate how-to guides for additional search topics:
 
-These **search** how-to guides aim to help you find the data you want using Weaviate.
-
-import BasicPrereqs from '/_includes/prerequisites-quickstart.md';
-
-<BasicPrereqs />
-
-We recommend starting with the [query basics](./basics.md) page.
-- It covers the basic syntax of a search (i.e. `Get`) query, and how to specify the properties you want to retrieve.
-
-Then, move onto a how-to guide of your choice. We have separate how-to guides for:
-
-- [Similarity](./similarity.md): Covers `nearXXX` searches, which work by searching for objects with the most similar vector representation to the query.
-- [Image](./image.md): Similarity search involving images.
-- [BM25](./bm25.md): A keyword search that ranks results with the BM25F search function.
-- [Hybrid](./hybrid.md): Combines BM25 and similarity search to rank results.
-- [Generative](./generative.md): Feed search results to an LLM with a prompt using a `generative` module.
+- [Vector similarity search](./similarity.md): Covers `nearXXX` searches, which work by searching for objects with the most similar vector representation to the query.
+- [Image search](./image.md): Use images as input for a similarity search.
+- [Keyword search](./bm25.md): A keyword search that uses the BM25F algorithm to rank results.
+- [Hybrid search](./hybrid.md): Combines BM25 and similarity search to rank results.
+- [Generative search](./generative.md): Use search results as a prompt for an LLM.
 - [Reranking](./rerank.md): Rerank retrieved search results using a `reranker` module.
-- [Aggregate](./aggregate.md): Aggregate data from a results set.
+- [Aggregation](./aggregate.md): Aggregate data from a results set.
 - [Filters](./filters.md): Apply conditional filters to the search.
-
-Each guide is self-contained. So you can read them in any order.
 
 import DocsMoreResources from '/_includes/more-resources-docs.md';
 

--- a/developers/weaviate/search/rerank.md
+++ b/developers/weaviate/search/rerank.md
@@ -12,7 +12,8 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.rerank.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.rerank-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.rerank.ts';
 
-Use a reranking method to reorder results after a search returns the initial result set. 
+Search finds results and returns them in a particular order. Reranking modules let you reorder the result set according to a different set of criteria. 
+To reorder your initial search results, configure a reranking method. 
 
 <details>
   <summary>
@@ -145,6 +146,7 @@ The response should look like this:
 ## Related pages
 
 - [API References: GraphQL - Additional properties](../api/graphql/additional-properties.md#rerank)
+- [API References: GraphQL - Sorting](../api/graphql/additional-operators#sorting-api)
 - [Concepts: Reranking](../concepts/reranking.md)
 - [References: Modules: reranker-cohere](../modules/retriever-vectorizer-modules/reranker-cohere.md)
 - [References: Modules: reranker-transformers](../modules/retriever-vectorizer-modules/reranker-transformers.md)

--- a/developers/weaviate/search/rerank.md
+++ b/developers/weaviate/search/rerank.md
@@ -14,28 +14,21 @@ import TSCode from '!!raw-loader!/_includes/code/howto/search.rerank.ts';
 
 Use a reranking method to reorder results after a search returns the initial result set. 
 
-## Enable reranking
+<details>
+  <summary>
+    Additional information
+  </summary>
 
-To rerank search results, enable a reranker [module](../configuration/modules.md) for your collection. These modules are available:
+### Configure reranking
+
+To rerank search results, enable a reranker [module](../configuration/modules.md) for your collection. For details, see the reranker's reference page:
 
 - [reranker-cohere](../modules/retriever-vectorizer-modules/reranker-cohere.md)
 - [reranker-transformers](../modules/retriever-vectorizer-modules/reranker-transformers.md)
 
 A collection can have multiple rerankers. If multiple `reranker` modules are enabled, specify the module you want to use in the `moduleConfig` section of your schema.
 
-```json
-{
-  "classes": [
-    {
-      "class": "Article",
-      ...,
-      "moduleConfig": {
-        "reranker-cohere": {},  // This will configure the 'Article' class to use the 'reranker-cohere' module
-      }
-    }
-  ]
-}
-```
+</details>
 
 ## Rerank vector search results
 

--- a/developers/weaviate/search/rerank.md
+++ b/developers/weaviate/search/rerank.md
@@ -146,7 +146,7 @@ The response should look like this:
 ## Related pages
 
 - [API References: GraphQL - Additional properties](../api/graphql/additional-properties.md#rerank)
-- [API References: GraphQL - Sorting](../api/graphql/additional-operators#sorting-api)
+- [API References: GraphQL - Sorting](/developers/weaviate/api/graphql/additional-operators#sorting-api)
 - [Concepts: Reranking](../concepts/reranking.md)
 - [References: Modules: reranker-cohere](../modules/retriever-vectorizer-modules/reranker-cohere.md)
 - [References: Modules: reranker-transformers](../modules/retriever-vectorizer-modules/reranker-transformers.md)

--- a/developers/weaviate/search/rerank.md
+++ b/developers/weaviate/search/rerank.md
@@ -12,15 +12,14 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.rerank.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.rerank-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.rerank.ts';
 
-Search finds results and returns them in a particular order. Reranking modules let you reorder the result set according to a different set of criteria. 
-To reorder your initial search results, configure a reranking method. 
+Reranking modules reorder the search result set according to a different set of criteria or a different (e.g. more expensive) algorithm.
 
 <details>
   <summary>
     Additional information
   </summary>
 
-### Configure reranking
+**Configure reranking**
 
 To rerank search results, enable a reranker [module](../configuration/modules.md) for your collection. For details, see the reranker's reference page:
 

--- a/developers/weaviate/search/similarity.md
+++ b/developers/weaviate/search/similarity.md
@@ -16,19 +16,7 @@ import ClassToCollectionNote from '/_includes/class-to-collection-transition-not
 
 <ClassToCollectionNote /> 
 
-This page has examples of vector search. 
-
-<details>
-  <summary>Additional information</summary>
-
-  Vector search is a similarity based search. The vector search operators look for objects with vector representations that are similar to the query's vector representation.
-     
-    - For search concepts, see [Search](/developers/weaviate/concepts/search).
-    - For image search, see [Image search](/developers/weaviate/search/image).
-    - For tutorials, see [Queries](/developers/academy/zero_to_mvp/queries_1).
-    - For search using the GraphQL API, see [GraphQL API](/developers/weaviate/api/graphql).
-
-</details>
+Vector search is a similarity based search. The vector search operators look for objects with vector representations that are similar to the query's vector representation.
 
 ## Search with unvectorized input
 
@@ -445,6 +433,11 @@ The output is like this:
 </details>
 
 ## Related pages
+
+- For search concepts, see [Search](/developers/weaviate/concepts/search).
+- For image search, see [Image search](/developers/weaviate/search/image).
+- For tutorials, see [Queries](/developers/academy/zero_to_mvp/queries_1).
+- For search using the GraphQL API, see [GraphQL API](/developers/weaviate/api/graphql).
 
 import DocsMoreResources from '/_includes/more-resources-docs.md';
 

--- a/developers/weaviate/search/similarity.md
+++ b/developers/weaviate/search/similarity.md
@@ -466,7 +466,6 @@ The output is like this:
 
 ## Related pages
 
-- For search concepts, see [Search](/developers/weaviate/concepts/search).
 - For image search, see [Image search](/developers/weaviate/search/image).
 - For tutorials, see [Queries](/developers/academy/zero_to_mvp/queries_1).
 - For search using the GraphQL API, see [GraphQL API](/developers/weaviate/api/graphql).

--- a/developers/weaviate/search/similarity.md
+++ b/developers/weaviate/search/similarity.md
@@ -12,11 +12,11 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.similarity.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.similarity-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.similarity.ts';
 
-Vector search is a similarity based search based on vector representations. Objects in the database have vector representations called "vector embeddings". Vector search returns the objects with embeddings that are the most similar to the embedded version of the search query.  
+Vector search returns the objects with most similar vectors to that of the query.
 
 ## Search with text
 
- To find objects with the nearest vector to an input, use [`nearText`](../api/graphql/search-operators.md#neartext).
+Use the [`Near Text`](../api/graphql/search-operators.md#neartext) operator to find objects with the nearest vector to an input text.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -76,7 +76,8 @@ import ImgSrchPyCode from '!!raw-loader!/_includes/code/howto/search.image.py';
 import ImgSrchPyCodeV3 from '!!raw-loader!/_includes/code/howto/search.image-v3.py';
 import ImgSrchTSCode from '!!raw-loader!/_includes/code/howto/search.image.ts';
 
-To find objects with the nearest vector to an input image, use [`nearImage`](../api/graphql/search-operators.md#nearimage). This example uses a base64 representation of an image.
+Use the [`Near Image`](../api/graphql/search-operators.md#nearimage) operator to find objects with the nearest vector to an image.<br/>
+This example uses a base64 representation of an image.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -112,7 +113,7 @@ See [Image search](./image.md) for more information.
 
 ## Search with an existing object
 
-If you have an object ID, use the [`nearObject` operator](../api/graphql/search-operators.md#nearobject) to find objects similar to that object.
+If you have an object ID, use the [`Near Object`](../api/graphql/search-operators.md#nearobject) operator to find similar objects to that object.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -164,7 +165,7 @@ If you have an object ID, use the [`nearObject` operator](../api/graphql/search-
 
 ## Search with a vector
 
-If you have an input vector, use the [`nearVector`](../api/graphql/search-operators.md#nearvector) operator to find objects with similar vectors
+If you have an input vector, use the [`Near Vector`](../api/graphql/search-operators.md#nearvector) operator to find objects with similar vectors
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -206,7 +207,7 @@ If you have an input vector, use the [`nearVector`](../api/graphql/search-operat
 
 ## Set a similarity threshold
 
-To set a similarity threshold between the search and target vectors, define a maximum `distance`.
+To set a similarity threshold between the search and target vectors, define a maximum `distance` (or `certainty`).
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -255,9 +256,11 @@ To set a similarity threshold between the search and target vectors, define a ma
 
 </details>
 
-## Limit the size of the result set
+## `limit` & `offset`
 
-To limit the size of the result set and return results in groups, use `limit` and `offset` to paginate the results.
+Use `limit` to set a fixed maximum number of objects to return.
+
+Optionally, use `offset` to paginate the results.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -299,7 +302,7 @@ To limit the size of the result set and return results in groups, use `limit` an
 
 ## Limit result groups
 
-To limit results to similar groups of objects, use the [`autocut`](../api/graphql/additional-operators.md#autocut) filter to set the number of groups to return.
+To limit results to groups of similar distances to the query, use the [`autocut`](../api/graphql/additional-operators.md#autocut) filter to set the number of groups to return.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -355,7 +358,7 @@ The output is like this:
 
 ## Group results
 
-Use properties or cross-references to group results. To group returned objects, the query must include a `near...` search operator such as `nearText` or `nearVector`.
+Use a property or a cross-reference to group results. To group returned objects, the query must include a `Near` search operator, such as `Near Text` or `Near Object`.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -408,9 +411,9 @@ The output is like this:
 
 </details>
 
-## Use a `where` filter
+## Filter results
 
-For more specific results, use [`where`](../api/graphql/filters.md) to narrow your search.
+For more specific results, use a [`filter`](../api/graphql/filters.md) to narrow your search.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">

--- a/developers/weaviate/search/similarity.md
+++ b/developers/weaviate/search/similarity.md
@@ -12,15 +12,11 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.similarity.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.similarity-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.similarity.ts';
 
-import ClassToCollectionNote from '/_includes/class-to-collection-transition-note.mdx' ;
-
-<ClassToCollectionNote />
-
-Vector search is a similarity based search. The vector search operators look for objects with vector representations that are similar to the query's vector representation.
+Vector search is a similarity based search based on vector representations. Objects in the database have vector representations called "vector embeddings". Vector search returns the objects with embeddings that are the most similar to the embedded version of the search query.  
 
 ## Search with text
 
-You can use use [`nearText`](../api/graphql/search-operators.md#neartext) to find objects with the nearest vector to an input.
+ To find objects with the nearest vector to an input, use [`nearText`](../api/graphql/search-operators.md#neartext).
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">
@@ -74,14 +70,13 @@ The output is like this:
 
 </details>
 
-
 ## Search with image
 
 import ImgSrchPyCode from '!!raw-loader!/_includes/code/howto/search.image.py';
 import ImgSrchPyCodeV3 from '!!raw-loader!/_includes/code/howto/search.image-v3.py';
 import ImgSrchTSCode from '!!raw-loader!/_includes/code/howto/search.image.ts';
 
-You can use [`nearImage`](../api/graphql/search-operators.md#nearimage) to find objects with the nearest vector to an input image. This example uses a base64 representation of an image.
+To find objects with the nearest vector to an input image, use [`nearImage`](../api/graphql/search-operators.md#nearimage). This example uses a base64 representation of an image.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python (v4)">


### PR DESCRIPTION
[issue](https://github.com/weaviate/weaviate-edu-team-tasks/issues/227)
[staging](https://227-updates-for-howto-search-refa--tangerine-buttercream-20c32f.netlify.app/)


FROM [PR 1397](https://github.com/weaviate/weaviate-io/pull/1397#issuecomment-1837840619)
TODO:
- [x] Add a short description for each search page
  - [x] Basic
  - [x] Vector Similarity (needs a better description)
  - [x] Image
  - [x] Keyword
  - [x] Hybrid
  - [x] RAG
  - [x] Reranking (to review)
  - [x] Aggregate (needs a better description)
  - [x] Filters
- [x] Let's keep print command active (not commented) – if print examples are not useful, then we could consider removing them completely, but in the end the commented out code looks odd, as if we forgot to do something. (Also, in some cases we commented out `# # highlight-start`, which appeared in the rendered docs)
- [x] We should avoid segments without code examples (i.e. [retrieve-other-metadata-values](https://202311-howto-refactor--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/search/basics#retrieve-other-metadata-values)). We should either move that to "Related pages" or add code examples.
- [x] Can we change [Retrieve other metadata values](https://202311-howto-refactor--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/search/basics#retrieve-other-metadata-values) to `Retrieve Metadata` and add code examples? (Added links to module config as per discussion)
- [x] Can we update [Search with unvectorized input](http://localhost:3000/developers/weaviate/search/similarity#search-with-unvectorized-input) to `Search Text` and `Search Image` examples? And then add a link on where to find more for image search. (i.e. the how to search images 😉)
- [x] Do we need the [enable reranking](http://localhost:3000/developers/weaviate/search/rerank#enable-reranking) section? Can we remove this or update to make it work across all languages (not just Python v3) and move inside an expandable segment?
- [x] [similarity#related-pages](https://202311-howto-refactor--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/search/similarity#related-pages) is empty. Let's fix this.