### PR TITLE
fixed a typo mistake in the cicd guide

### DIFF
--- a/developers/contributor-guide/weaviate-core/cicd.md
+++ b/developers/contributor-guide/weaviate-core/cicd.md
@@ -30,7 +30,7 @@ In practice this means:
 
   There might be situations, especially when developing complex features, where
   you explicitly make commits which are "not production-ready". For example to
-  get a get an integration test to pass you might require several commits.
+  get an integration test to pass you might require several commits.
   Please, clearly mark such commits as "WIP".
 
 * The best time to merge a PR is yesterday. There is no harm in having a


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

In this Pull Request, I fixed a typo mistake in which the `get` was repeated multiple times. So I removed one `get` to make it understandable. Here is the [page](https://weaviate.io/developers/contributor-guide/weaviate-core/cicd) in which this error was present

![photofunny net_](https://github.com/weaviate/weaviate-io/assets/64713734/249ed5ce-09fc-4e98-a20a-e3bc337a9b89)


### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
