### PR TITLE
Update Azure OpenAI Documentation to include baseURL

### DIFF
--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai.md
@@ -127,6 +127,7 @@ The following example configures the `Document` class by setting the vectorizer 
 |:-|:-|
 |`resourceName`|Azure resource name|
 |`deploymentId`|Azure deployment ID (your model name)|
+| `baseURL` |Set the endpoint of your Azure Open AI Deployments e.g. `https://eastus.api.cognitive.microsoft.com`|
 
 #### Example
 


### PR DESCRIPTION
* This is the documentation to go with the proposed fix

  https://github.com/weaviate/weaviate/pull/3966

* That PR is a proposed fix for https://github.com/weaviate/weaviate/issues/3588

* This updates the documentation to indicate for AzureOpenAI you can use baseURL to set the endpoint

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:


- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
This is the corresponding documentation  for the proposed fix mentioned in the PR description

### How Has This Been Tested?

Sorry. I tried to run `yarn start` and got an error.

```
yarn start
yarn run v1.22.21
warning ../package.json: No license field
$ docusaurus start
/bin/sh: docusaurus: command not found
error Command failed with exit code 127.
```

Rather than try to fix the issues with my local setup; I'm opening this PR to use the presubmits to identify any errors.

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
