### PR TITLE
added an edit link to the console guide

### DIFF
--- a/developers/wcs/guides/console.mdx
+++ b/developers/wcs/guides/console.mdx
@@ -87,3 +87,5 @@ If you are having any issues providing additional headers on a WCS instance, che
 import WCSDocsMoreResources from '/_includes/wcs-more-resources-docs.md';
 
 <WCSDocsMoreResources />
+
+Edit this [page](https://github.com/weaviate/weaviate-io/blob/main/developers/wcs/guides/console.mdx).


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

While reading the console documentation, I noticed that this page is missing an edit page link. That's why I added the link and redirected it to the github docs page in which it is written. Here is the [issue link](https://github.com/weaviate/weaviate-io/issues/1514) in which this problem is discussed.

![image](https://github.com/weaviate/weaviate-io/assets/64713734/d6a9363f-42b7-4272-9053-1e3067410b24)

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
