### PR TITLE
Fix shardingConfig for v3 snake_case -> camelCase

### DIFF
--- a/_includes/code/howto/manage-data.collections-v3.py
+++ b/_includes/code/howto/manage-data.collections-v3.py
@@ -315,11 +315,11 @@ class_obj = {
     "class": "Article",
     # highlight-start
     "shardingConfig": {
-        "virtual_per_physical": 128,
-        "desired_count": 1,
-        "actual_count": 1,
-        "desired_virtual_count": 128,
-        "actual_virtual_count": 128,
+        "virtualPerPhysical": 128,
+        "desiredCount": 1,
+        "actual_actualCountcount": 1,
+        "desiredVirtualCount": 128,
+        "actualVirtualCount": 128,
     },
     # highlight-end
 }

--- a/_includes/code/howto/manage-data.collections.ts
+++ b/_includes/code/howto/manage-data.collections.ts
@@ -391,11 +391,11 @@ const classWithSharding = {
     distance: 'cosine',
   },
   shardingConfig: {
-    virtual_per_physical: 128,
-    desired_count: 1,
-    actual_count: 1,
-    desired_virtual_count: 128,
-    actual_virtual_count: 128,
+    virtualPerPhysical: 128,
+    desiredCount: 1,
+    actualCount: 1,
+    desiredVirtualCount: 128,
+    actualVirtualCount: 128,
   },
   // highlight-end
 };


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
some python v3 and ts examples had sharding config with snake_case, where the correct is camelCase

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
