### PR TITLE
Changed CamelCase to PascalCase in schema.md

### DIFF
--- a/developers/weaviate/tutorials/schema.md
+++ b/developers/weaviate/tutorials/schema.md
@@ -94,7 +94,7 @@ import CodeCreateSchema from '/_includes/code/quickstart.schema.create.mdx';
 <CodeCreateSchema />
 
 :::note Classes and Properties - best practice
-Classes always start with a capital letter. Properties always begin with a small letter. You can use `CamelCase` class names, and property names allow underscores. Read more about schema classes, properties and data types [here](../config-refs/schema/index.md).
+Classes always start with a capital letter. Properties always begin with a small letter. You can use `PascalCase` class names, and property names allow underscores. Read more about schema classes, properties and data types [here](../config-refs/schema/index.md).
 :::
 
 The result should look something like this:


### PR DESCRIPTION
Class names require the first letter to be capitalized, so that is likely referring to PascalCase rather than camelCase

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

Changed CamelCase to PascalCase
<img width="806" alt="image" src="https://github.com/weaviate/weaviate-io/assets/55062649/47db8dc6-c417-4e3b-a889-cd475d5f5272">


### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
