### PR TITLE
Change pyv4 "migration guide" heading to plural

### DIFF
--- a/developers/weaviate/client-libraries/python.md
+++ b/developers/weaviate/client-libraries/python.md
@@ -683,7 +683,7 @@ You can choose to provide a generic type to a query or data operation. This can 
   language="py"
 />
 
-## Migration guide
+## Migration guides
 
 ### Beta releases
 


### PR DESCRIPTION
Change pyv4 "migration guide" heading to plural