### PR TITLE
20240131/updates for pyv4 release

### DIFF
--- a/_includes/code/quickstart/clients.install.mdx
+++ b/_includes/code/quickstart/clients.install.mdx
@@ -8,12 +8,10 @@ Add `weaviate-client` to your Python environment with `pip`.
 
 <br/>
 
-**Please use the `v4` client with Weaviate `1.23` or higher.**
-
-(The `v4` client is currently in beta, and there may be breaking changes.)
+**Please use the `v4` client with Weaviate `1.23.7` or higher.**
 
 ```bash
-pip install -U --pre "weaviate-client==v4.4b2"
+pip install -U weaviate-client
 ```
 
 </TabItem>

--- a/_includes/code/quickstart/connect.withkey.mdx
+++ b/_includes/code/quickstart/connect.withkey.mdx
@@ -8,17 +8,10 @@ import EndToEndTSCode from '!!raw-loader!/_includes/code/quickstart/endtoend.ts'
 <Tabs groupId="languages">
 <TabItem value="py" label="Python (v4)">
 
-<!-- <FilteredTextBlock
+<FilteredTextBlock
   text={EndToEndPyCode}
   startMarker="# InstantiationExample"
   endMarker="# END InstantiationExample"
-  language="py"
-/> -->
-
-<FilteredTextBlock
-  text={EndToEndPyCode}
-  startMarker="# DockerInstantiationExample"
-  endMarker="# END DockerInstantiationExample"
   language="py"
 />
 

--- a/_includes/code/quickstart/endtoend.py
+++ b/_includes/code/quickstart/endtoend.py
@@ -23,16 +23,13 @@ import weaviate.classes as wvc
 import requests
 import json
 import os
-
 # END EndToEndExample  # Test import
 
-# TODO -> Replace this with WCS example when sandbox ready
 # EndToEndExample  # InstantiationExample  # NearTextExample
 
-# As of November 2023, we are working towards making all WCS instances compatible with the new API introduced in the v4 Python client.
-# Accordingly, we show you how to connect to a local instance of Weaviate.
-# Here, authentication is switched off, which is why you do not need to provide the Weaviate API key.
-client = weaviate.connect_to_local(
+client = weaviate.connect_to_wcs(
+    cluster_url=os.getenv("WCS_CLUSTER_URL"),
+    auth_client_secret=os.getenv("WCS_API_KEY"),
     headers={
         "X-OpenAI-Api-Key": os.environ["OPENAI_APIKEY"]  # Replace with your inference API key
     }

--- a/developers/weaviate/client-libraries/python.md
+++ b/developers/weaviate/client-libraries/python.md
@@ -10,29 +10,15 @@ import TabItem from '@theme/TabItem';
 import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBlock';
 import PythonCode from '!!raw-loader!/_includes/code/client-libraries/python_v4.py';
 
-:::caution Beta version
-
-The Python client `v4` is currently in beta. Please note the following:
-<br/>
-
-- We strongly encourage you to use the latest version of the Python client *and* the Weaviate server.
-- You can test the new client locally, or on paid instances of Weaviate Cloud Services (WCS).
-- It is not yet available on the free (sandbox) tier of WCS.
-- Please report any bugs or feedback on [this forum thread](https://forum.weaviate.io/t/python-v4-client-feedback-megathread/892)
-
-:::
-
 ## Overview
 
-This page discuses key ideas and aspects of `v4` release of the Weaviate Python client (`v4` client). For Weaviate usage information not specific to the Python client, see the relevant pages in the [Weaviate documentation](../index.md).
+This page broadly covers the Weaviate Python client (`v4` release). For usage information not specific to the Python client, such as code examples, see the relevant pages in the [Weaviate documentation](../index.md).
 
-For changes in the client between beta releases, please see the [migration guide](../client-libraries/python#migration-guides).
-
-## Key changes from `v3`
+## High-level ideas
 
 ### Helper classes
 
-This client also includes numerous additional Python classes to provide IDE assistance and typing help. You can import them individually, like so:
+The client library provides numerous additional Python classes to provide IDE assistance and typing help. You can import them individually, like so:
 
 ```
 from weaviate.classes.config import Property, ConfigFactory
@@ -40,7 +26,7 @@ from weaviate.classes.data import DataObject
 from weaviate.classes.query import Filter
 ```
 
-But it may be convenient to import the whole set of classes like this. For brevity, the documentation uses this import style.
+But it may be convenient to import the whole set of classes like this. You will see both usage styles in our documentation.
 
 ```
 import weaviate.classes as wvc
@@ -91,7 +77,7 @@ This will close the client connection when you leave the `with` block.
 
 ## Installation
 
-The Python client library is developed and tested using Python 3.8 to 3.12. It is available on [PyPI.org](https://pypi.org/project/weaviate-client/), and can be installed with:
+The Python client library is developed and tested using Python 3.8+. It is available on [PyPI.org](https://pypi.org/project/weaviate-client/), and can be installed with:
 
 ```bash
 pip install -U "weaviate-client==4.*"  # For beta versions: `pip install --pre -U "weaviate-client==4.*"`
@@ -101,7 +87,7 @@ pip install -U "weaviate-client==4.*"  # For beta versions: `pip install --pre -
 
 #### gRPC
 
-The `v4` client uses remote procedure calls (RPCs) under-the-hood. Accordingly, a port for gRPC must be open on your Weaviate server.
+The `v4` client uses remote procedure calls (RPCs) under-the-hood. Accordingly, a port for gRPC must be open to your Weaviate server.
 
 <details>
   <summary>docker-compose.yml example</summary>
@@ -118,7 +104,7 @@ If you are running Weaviate with Docker, you can map the default port (`50051`) 
 
 #### WCS compatibility
 
-The free (sandbox) tier of WCS is currently not compatible with the `v4` client. (Last updated: January, 2024)
+The free (sandbox) tier of WCS is compatible with the `v4` client as of 31 January, 2024. Sandboxes created before this date will not be compatible with the `v4` client.
 
 #### Weaviate server version
 
@@ -141,8 +127,6 @@ There are multiple ways to connect to your Weaviate instance. To instantiate a c
 
 <Tabs groupId="languages">
 <TabItem value="wcs" label="WCS">
-
-<p><small>Note: WCS sandboxes are not compatible with the <code>v4</code> client. (Updated, January, 2024)</small></p>
 
 <FilteredTextBlock
   text={PythonCode}

--- a/developers/weaviate/client-libraries/python.md
+++ b/developers/weaviate/client-libraries/python.md
@@ -108,7 +108,7 @@ The free (sandbox) tier of WCS is compatible with the `v4` client as of 31 Janua
 
 #### Weaviate server version
 
-Generally, we encourage you to use the latest version of the Python client *and* the Weaviate server.
+The `v4` client requires Weaviate `1.23.7` or higher. Generally, we encourage you to use the latest version of the Python client *and* the Weaviate server.
 
 ## Instantiate a client
 

--- a/developers/weaviate/quickstart/index.md
+++ b/developers/weaviate/quickstart/index.md
@@ -66,10 +66,6 @@ You need a Weaviate instance to work with. We recommend creating a free cloud sa
 
 Go to the [WCS quickstart](developers/wcs/quickstart.mdx) and follow the instructions to create a sandbox instance, and come back here.  Collect the **API key** and **URL** from the `Details` tab in WCS.
 
-:::note For v4 Python client users
-As of November 2023, WCS sandbox instances are not yet compatible with the new API introduced in the v4 Python client. We suggest creating a Weaviate instance using another method, such as Docker Compose.
-:::
-
 :::info To use another deployment method (e.g. Docker Compose)
 If you prefer another method, see [this section](#can-i-use-another-deployment-method).
 :::


### PR DESCRIPTION
### What's being changed:

Minor updates for v4 py client release
- Remove note re: sandbox incompatible with v4
- Update quickstart instantiation to use WCS
- Update version notes (i.e. require 1.23.7+ for v4)

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
