### PR TITLE
add links to the py migration guide

### DIFF
--- a/developers/weaviate/client-libraries/python/index.md
+++ b/developers/weaviate/client-libraries/python/index.md
@@ -16,6 +16,10 @@ This page broadly covers the Weaviate Python client (`v4` release). For usage in
 
 ## Installation
 
+:::tip Migrating from `v3` to `v4`
+If you are migrating from the `v3` client to the `v4`, please see this [dedicated guide](./v3_v4_migration.md).
+:::
+
 The Python client library is developed and tested using Python 3.8+. It is available on [PyPI.org](https://pypi.org/project/weaviate-client/), and can be installed with:
 
 ```bash
@@ -683,6 +687,10 @@ You can choose to provide a generic type to a query or data operation. This can 
 />
 
 ## Migration guides
+
+:::tip Migrating from `v3` to `v4`
+If you are migrating from the `v3` client to the `v4`, please see this [dedicated guide](./v3_v4_migration.md).
+:::
 
 ### Beta releases
 

--- a/developers/weaviate/client-libraries/python/python_v3.md
+++ b/developers/weaviate/client-libraries/python/python_v3.md
@@ -11,7 +11,9 @@ The current Python client version is `v||site.python_client_version||`
 :::
 
 :::info `v4` client available
-This document relates to the `v3` client. We recommend you upgrade to the [`v4` client](../client-libraries/python/index.md) if possible. The `v3` client is still available for backwards compatibility, and receive with bug fixes and security updates, but it will be updated with new Weaviate features, and may be subset sometime in the second half of 2024.
+This document relates to the `v3` client. We recommend you upgrade to the [`v4` client](./index.md) if possible. The `v3` client is still available for backwards compatibility, and receive with bug fixes and security updates, but it will be updated with new Weaviate features, and may be subset sometime in the second half of 2024.
+
+We also have a [migration guide for moving from `v3` client to the `v4`](./v3_v4_migration.md).
 :::
 
 ## Installation and setup
@@ -174,7 +176,7 @@ There is a variety of neural search frameworks that use Weaviate under the hood 
 
 # References documentation
 
-On this Weaviate documentation website, you will find how to use the Python client for all [RESTful endpoints](../api/rest/index.md) and [GraphQL functions](../api/graphql/index.md). For each reference, a code block is included with an example of how to use the function with the Python (and other) clients. The Python client, however, has additional functionalities, which are covered in the full client documentation on [weaviate-python-client.readthedocs.io](https://weaviate-python-client.readthedocs.io/en/stable/). Some of these additional functions are highlighted here below.
+On this Weaviate documentation website, you will find how to use the Python client for all [RESTful endpoints](../../api/rest/index.md) and [GraphQL functions](../../api/graphql/index.md). For each reference, a code block is included with an example of how to use the function with the Python (and other) clients. The Python client, however, has additional functionalities, which are covered in the full client documentation on [weaviate-python-client.readthedocs.io](https://weaviate-python-client.readthedocs.io/en/stable/). Some of these additional functions are highlighted here below.
 
 ### Example: client.schema.create(schema)
 Instead of adding classes one by one using the RESTful `v1/schema` endpoint, you can upload a full schema in JSON format at once using the Python client. Use the function `client.schema.create(schema)` as follows:

--- a/developers/weaviate/manage-data/import.mdx
+++ b/developers/weaviate/manage-data/import.mdx
@@ -189,7 +189,7 @@ Use the `vector` property to specify a vector for each object.
 The Python clients have built-in batching methods to help you optimize your import speed. Please see the relevant documentation for more information.
 
 - [Batching: Python client `v4`](../client-libraries/python/index.md#batching)
-- [Batching: Python client `v3`](../client-libraries/python_v3.md#batching)
+- [Batching: Python client `v3`](../client-libraries/python/python_v3.md#batching)
 
 ## Stream data from large files
 


### PR DESCRIPTION
add links to the py migration guide
fix broken links due to files being moved