### PR TITLE
changes default embedded port, and add py stop method

### DIFF
--- a/_includes/code/embedded.instantiate.mdx
+++ b/_includes/code/embedded.instantiate.mdx
@@ -28,6 +28,9 @@ import PyCode from '!!raw-loader!/_includes/code/install/embedded.py';
   }
 
   client.data_object.create(data_obj, "Wine")
+
+  # Optionally, stop the server:
+  # client._connection.embedded_db.stop()
   ```
 
   </TabItem>
@@ -50,8 +53,8 @@ import PyCode from '!!raw-loader!/_includes/code/install/embedded.py';
     .do();
 
   console.log(JSON.stringify(response, null, 2));
-
-  client.embedded.stop();
+  // optionally, stop the server
+  //client.embedded.stop();
   ```
 
   </TabItem>

--- a/_includes/code/install/embedded.py
+++ b/_includes/code/install/embedded.py
@@ -10,8 +10,10 @@ client = weaviate.connect_to_embedded(
 )
 
 # DO SOMETHING
-
 client.close()
+
+# Optionally, stop the server:
+# client._connection.embedded_db.stop()
 # END SimpleInstantiationEmbedded
 
 
@@ -30,6 +32,8 @@ client = weaviate.WeaviateClient(
 )
 
 # DO SOMETHING
-
 client.close()
+
+# Optionally, stop the server:
+# client._connection.embedded_db.stop()
 # END VerboseInstantiationEmbedded

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -36,7 +36,7 @@ The Weaviate server spawned from the client can be configured via parameters pas
 | persistence_data_path | string | Directory where the files making up the database are stored. | When the `XDG_DATA_HOME` env variable is set, the default value is:<br/>`XDG_DATA_HOME/weaviate/`<br/><br/>Otherwise it is:<br/>`~/.local/share/weaviate` |
 | binary_path | string | Directory where to download the binary. If deleted, the client will download the binary again. | When the `XDG_CACHE_HOME` env variable is set, the default value is:<br/>`XDG_CACHE_HOME/weaviate-embedded/`<br/><br/>Otherwise it is:<br/>`~/.cache/weaviate-embedded` |
 | version | string | Version takes two types of input:<br/>- **version number** - for example `"1.19.6"` or `"latest"`<br/>- **full URL** pointing to a Linux AMD64 or ARM64 binary | Latest stable version |
-| port | integer | Which port the Weaviate server will listen to. Useful when running multiple instances in parallel. | 6666 |
+| port | integer | Which port the Weaviate server will listen to. Useful when running multiple instances in parallel. | 8079 |
 | hostname | string | Hostname/IP to bind to. | 127.0.0.1 |
 | additional_env_vars | key: value | Useful to pass additional environment variables to the server, such as API keys. |
 
@@ -73,9 +73,9 @@ import EmbeddedInstantiationVerbose from '/_includes/code/embedded.instantiate.v
 
 Here's what happens behind the scenes when the client uses the embedded options in the instantiation call:
 1. The client downloads a Weaviate release from GitHub and caches it
-2. It then spawns a Weaviate process with a data directory configured to a specific location, and listening to the specified port (by default 6666)
+2. It then spawns a Weaviate process with a data directory configured to a specific location, and listening to the specified port (by default [8079](http://127.0.0.1:8079))
 3. The server's STDOUT and STDERR are piped to the client
-4. The client connects to this server process (e.g. to `http://127.0.0.1:6666`) and runs the client code
+4. The client connects to this server process (e.g. to `http://127.0.0.1:8079`) and runs the client code
 5. After running the code (when the application terminates), the client shuts down the Weaviate process
 6. The data directory is preserved, so subsequent invocations have access to the data from all previous invocations, across all clients using the embedded option.
 

--- a/developers/weaviate/installation/embedded.md
+++ b/developers/weaviate/installation/embedded.md
@@ -73,7 +73,7 @@ import EmbeddedInstantiationVerbose from '/_includes/code/embedded.instantiate.v
 
 Here's what happens behind the scenes when the client uses the embedded options in the instantiation call:
 1. The client downloads a Weaviate release from GitHub and caches it
-2. It then spawns a Weaviate process with a data directory configured to a specific location, and listening to the specified port (by default [8079](http://127.0.0.1:8079))
+2. It then spawns a Weaviate process with a data directory configured to a specific location, and listening to the specified port (by default 8079)
 3. The server's STDOUT and STDERR are piped to the client
 4. The client connects to this server process (e.g. to `http://127.0.0.1:8079`) and runs the client code
 5. After running the code (when the application terminates), the client shuts down the Weaviate process


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:
Embedded default port was changed from 6666 to 8079
the python method to stop the embedded server was not documented.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
