### PR TITLE
Fixed typo in grpc.md

### DIFF
--- a/developers/weaviate/api/grpc.md
+++ b/developers/weaviate/api/grpc.md
@@ -48,7 +48,7 @@ services:
 
 ### Client-side
 
-You can use the gRPC interace through the ([`v4` Weaviate Python client library](/developers/weaviate/client-libraries/python)). gRPC support in the other client libraries will follow.
+You can use the gRPC interface through the ([`v4` Weaviate Python client library](/developers/weaviate/client-libraries/python)). gRPC support in the other client libraries will follow.
 
 Alternatively, you can use other tools, such as the `grpcurl` command-line tool, to interact with the gRPC API. Some options include:
 


### PR DESCRIPTION
Just fixed a typo:

interace -> interface

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

I fixed a typo in this section:
https://weaviate.io/developers/weaviate/api/grpc#client-side

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

No tests needed. Just a typo fix.