### PR TITLE
Update giscus widget with forum links

### DIFF
--- a/_includes/code/embedded.py
+++ b/_includes/code/embedded.py
@@ -9,8 +9,9 @@ client = weaviate.Client(
     additional_headers={
         'X-OpenAI-Api-Key': 'YOUR-OPENAI-API-KEY'  # Replace w/ your OPENAI API key
     }
-    # START 10lines  # END TestExample
+    # START 10lines  # START TestExample
 )
+# END TestExample
 
 uuid = client.data_object.create({
     'hello': 'World!'

--- a/_includes/docs-feedback.mdx
+++ b/_includes/docs-feedback.mdx
@@ -1,0 +1,6 @@
+## Questions and feedback
+
+If you have any questions or feedback, please let us know [on our forum](https://forum.weaviate.io/). For example, you can:
+
+- [Provide feedback on the documentation](https://forum.weaviate.io/new-topic?title=%5BDocs%5D%20YOUR%20TOPIC&body=Details%20here&category=support&tags=documentation)
+- [Ask a technical question](https://forum.weaviate.io/new-topic?title=%5BQuestion%5D%20YOUR%20TOPIC&body=Details%20here&category=support&tags=technical)

--- a/_includes/more-resources-contributor-guide.md
+++ b/_includes/more-resources-contributor-guide.md
@@ -9,6 +9,6 @@ For additional information, try these sources.
 
 #
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/_includes/more-resources-docs.md
+++ b/_includes/more-resources-docs.md
@@ -5,6 +5,6 @@
 
 #
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/deployment/k8s/10_kubernetes_basics.mdx
+++ b/developers/academy/deployment/k8s/10_kubernetes_basics.mdx
@@ -115,6 +115,6 @@ If your output is similar to the one above, then congratulations! You have succe
 Next, you will learn how to deploy Weaviate to the Kubernetes cluster using Helm.
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/deployment/k8s/30_setup_weaviate.mdx
+++ b/developers/academy/deployment/k8s/30_setup_weaviate.mdx
@@ -131,6 +131,6 @@ Note how here, the `weaviate-0` pod went from `Pending` to `Running`.
 
 Congratulations! You have successfully deployed Weaviate on your local Kubernetes cluster. Next, let's confirm some basic interactions with Weaviate.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/deployment/k8s/50_access_weaviate.mdx
+++ b/developers/academy/deployment/k8s/50_access_weaviate.mdx
@@ -143,6 +143,6 @@ Before we go, however, let's take a look at expanding our Weaviate deployment to
 
 We'll take a look at both in the next section.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/deployment/k8s/70_multi_node.mdx
+++ b/developers/academy/deployment/k8s/70_multi_node.mdx
@@ -166,6 +166,6 @@ minikube stop
 minikube delete
 ```
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/deployment/k8s/90_next_steps.mdx
+++ b/developers/academy/deployment/k8s/90_next_steps.mdx
@@ -41,6 +41,6 @@ import CTASocials from '../../py/_snippets/cta_socials.mdx';
 
 See you soon! 👋
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/10_set_up_python.mdx
+++ b/developers/academy/py/10_set_up_python.mdx
@@ -136,6 +136,6 @@ Your Weaviate client library version is: 4.5.4.
 
 Congratulations, you are now set up to use Weaviate with Python and the Weaviate Python client library!
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/_snippets/intro_next_steps.mdx
+++ b/developers/academy/py/_snippets/intro_next_steps.mdx
@@ -25,6 +25,6 @@ import CTASocials from './cta_socials.mdx';
 
 See you soon! 👋
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/compression/100_pq.mdx
+++ b/developers/academy/py/compression/100_pq.mdx
@@ -75,7 +75,7 @@ The example below shows how to configure PQ with custom settings, such as with a
 
 Please refer to the [PQ configuration documentation](/developers/weaviate/configuration/pq-compression.md#pq-parameters) for more information on the available settings.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 

--- a/developers/academy/py/compression/200_bq.mdx
+++ b/developers/academy/py/compression/200_bq.mdx
@@ -60,7 +60,7 @@ Some BQ parameters are configurable. An important one is `rescore_limit`, which 
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 

--- a/developers/academy/py/compression/300_strategy.mdx
+++ b/developers/academy/py/compression/300_strategy.mdx
@@ -36,6 +36,6 @@ And if resource constraints are not a concern, you can always choose to use no c
 
 But do note that you will likely not be able to switch on compression later, as it requires a reindexing of the data. (With an exception of PQ, which [may be enabled later](../../../weaviate/configuration/pq-compression.md#3-enable-pq-and-create-the-codebook) unless your dataset is too large.)
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/compression/900_next_steps.mdx
+++ b/developers/academy/py/compression/900_next_steps.mdx
@@ -19,6 +19,6 @@ import CTASocials from '../_snippets/cta_socials.mdx';
 
 See you soon! 👋
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/named_vectors/101_nv_preparation/index.mdx
+++ b/developers/academy/py/named_vectors/101_nv_preparation/index.mdx
@@ -158,7 +158,7 @@ As a multimodal project, we'll also use [corresponding posters for each movie](h
 
 </details>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 

--- a/developers/academy/py/named_vectors/102_nv_collections/20_create_collection.mdx
+++ b/developers/academy/py/named_vectors/102_nv_collections/20_create_collection.mdx
@@ -57,6 +57,6 @@ Note that the majority of the vector weight is given to the `poster` property (9
 
 As this uses a multimodal vectorizer, you could use this to search for movies using any image, or text, by their similarity to the title or poster.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/named_vectors/102_nv_collections/30_import_data.mdx
+++ b/developers/academy/py/named_vectors/102_nv_collections/30_import_data.mdx
@@ -44,6 +44,6 @@ In this case, recall that we have three named vectors for each object - `title`,
 
 Next, we will explore how these named vectors provide flexibility in searching for our data.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/named_vectors/102_nv_collections/index.mdx
+++ b/developers/academy/py/named_vectors/102_nv_collections/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="nv_collections"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/named_vectors/103_nv_queries/10_searches.mdx
+++ b/developers/academy/py/named_vectors/103_nv_queries/10_searches.mdx
@@ -176,6 +176,6 @@ RAG, or retrieval augmented generation, queries with named vectors work the same
 This, in turn, can improve the quality of the generation. Let's explore a few examples in the [next section](./20_use_cases.mdx).
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/named_vectors/103_nv_queries/20_use_cases.mdx
+++ b/developers/academy/py/named_vectors/103_nv_queries/20_use_cases.mdx
@@ -125,6 +125,6 @@ Moana<br/>
 
 </details>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/named_vectors/103_nv_queries/index.mdx
+++ b/developers/academy/py/named_vectors/103_nv_queries/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="nv_queries"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/named_vectors/900_next_steps.mdx
+++ b/developers/academy/py/named_vectors/900_next_steps.mdx
@@ -18,6 +18,6 @@ import CTASocials from '../_snippets/cta_socials.mdx';
 
 See you soon! 👋
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/standalone/_202_vectorizer_selection/index.mdx
+++ b/developers/academy/py/standalone/_202_vectorizer_selection/index.mdx
@@ -40,6 +40,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 
 <LearningGoals unitName="vectorizer_selection"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/standalone/_203_indexing/_60_indexing_options.mdx
+++ b/developers/academy/py/standalone/_203_indexing/_60_indexing_options.mdx
@@ -26,6 +26,6 @@ Add review exercises
 
 ### <i class="fa-solid fa-lightbulb-on"></i> Key takeaways
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/standalone/_203_indexing/index.mdx
+++ b/developers/academy/py/standalone/_203_indexing/index.mdx
@@ -38,6 +38,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 
 <LearningGoals unitName="indexing"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/standalone/chunking/10_introduction.mdx
+++ b/developers/academy/py/standalone/chunking/10_introduction.mdx
@@ -100,9 +100,9 @@ Try out ...
 Add summary
 ::: -->
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 <!-- import Quiz from '/src/components/Academy/quiz.js'
 const varName = [{

--- a/developers/academy/py/standalone/chunking/20_how_1.mdx
+++ b/developers/academy/py/standalone/chunking/20_how_1.mdx
@@ -169,9 +169,9 @@ Try out ...
 Add summary
 ::: -->
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 <!-- import Quiz from '/src/components/Academy/quiz.js'
 const varName = [{

--- a/developers/academy/py/standalone/chunking/25_how_2.mdx
+++ b/developers/academy/py/standalone/chunking/25_how_2.mdx
@@ -172,9 +172,9 @@ Try out ...
 Add summary
 ::: -->
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 <!-- import Quiz from '/src/components/Academy/quiz.js'
 const varName = [{

--- a/developers/academy/py/standalone/chunking/30_example_chunking.mdx
+++ b/developers/academy/py/standalone/chunking/30_example_chunking.mdx
@@ -206,9 +206,9 @@ Try out ...
 Add summary
 ::: -->
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 <!-- import Quiz from '/src/components/Academy/quiz.js'
 const varName = [{

--- a/developers/academy/py/standalone/chunking/40_example_search.mdx
+++ b/developers/academy/py/standalone/chunking/40_example_search.mdx
@@ -295,9 +295,9 @@ Try out ...
 Add summary
 ::: -->
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 <!-- import Quiz from '/src/components/Academy/quiz.js'
 const varName = [{

--- a/developers/academy/py/standalone/chunking/50_considerations.mdx
+++ b/developers/academy/py/standalone/chunking/50_considerations.mdx
@@ -141,9 +141,9 @@ Try out ...
 Add summary
 ::: -->
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 <!-- import Quiz from '/src/components/Academy/quiz.js'
 const varName = [{

--- a/developers/academy/py/standalone/chunking/90_wrap_up.mdx
+++ b/developers/academy/py/standalone/chunking/90_wrap_up.mdx
@@ -26,6 +26,6 @@ Having finished this unit, you should be able to:
 - Implement various chunking methods and know where to explore others, and
 - Evaluate chunking strategies based on your needs
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/standalone/chunking/index.mdx
+++ b/developers/academy/py/standalone/chunking/index.mdx
@@ -52,6 +52,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 
 <LearningGoals unitName="chunking"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/standalone/which_search/10_strengths.mdx
+++ b/developers/academy/py/standalone/which_search/10_strengths.mdx
@@ -174,9 +174,9 @@ Try out ...
 Add summary
 :::
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const varName = [{

--- a/developers/academy/py/standalone/which_search/20_selection.mdx
+++ b/developers/academy/py/standalone/which_search/20_selection.mdx
@@ -75,9 +75,9 @@ Try out ...
 Add summary
 :::
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const varName = [{

--- a/developers/academy/py/standalone/which_search/30_strategies.mdx
+++ b/developers/academy/py/standalone/which_search/30_strategies.mdx
@@ -180,9 +180,9 @@ Try out ...
 Add summary
 :::
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const varName = [{

--- a/developers/academy/py/standalone/which_search/index.mdx
+++ b/developers/academy/py/standalone/which_search/index.mdx
@@ -45,6 +45,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 
 <LearningGoals unitName="which_search"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/101_setup_weaviate/10_client.mdx
+++ b/developers/academy/py/starter_custom_vectors/101_setup_weaviate/10_client.mdx
@@ -28,6 +28,6 @@ The client provides sets of helper classes (e.g. under `weaviate.classes`) and f
 
 Next, we'll show you how create a Weaviate instance and connect to it.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/101_setup_weaviate/20_create_instance/10_create_wcs.mdx
+++ b/developers/academy/py/starter_custom_vectors/101_setup_weaviate/20_create_instance/10_create_wcs.mdx
@@ -59,6 +59,6 @@ This course uses OpenAI, so you can provide the OpenAI API key to Weaviate throu
 If you have completed this, you can skip the next page [Option 2: A local Weaviate instance](./20_create_docker.mdx) and continue with [Communicate with Weaviate](../30_communicate.mdx).
 :::
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/101_setup_weaviate/20_create_instance/20_create_docker.mdx
+++ b/developers/academy/py/starter_custom_vectors/101_setup_weaviate/20_create_instance/20_create_docker.mdx
@@ -84,6 +84,6 @@ This course uses OpenAI, so you can provide the OpenAI API key to Weaviate throu
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/101_setup_weaviate/20_create_instance/index.mdx
+++ b/developers/academy/py/starter_custom_vectors/101_setup_weaviate/20_create_instance/index.mdx
@@ -11,6 +11,6 @@ For this unit, you can choose to create a Weaviate Cloud Service (WCS) instance 
 
 Either option is fine for this course. If you're not sure which to choose, we recommend starting with a WCS instance.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/101_setup_weaviate/30_communicate.mdx
+++ b/developers/academy/py/starter_custom_vectors/101_setup_weaviate/30_communicate.mdx
@@ -57,6 +57,6 @@ We suggest using a `try`-`finally` block as a best practice. For brevity, we wil
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/101_setup_weaviate/index.mdx
+++ b/developers/academy/py/starter_custom_vectors/101_setup_weaviate/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="byov_setup_weaviate"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/102_object_collections/10_preparation.mdx
+++ b/developers/academy/py/starter_custom_vectors/102_object_collections/10_preparation.mdx
@@ -29,6 +29,6 @@ We are going to use a movie dataset sourced from [TMDB](https://www.themoviedb.o
 
 Next, you will create a corresponding object collection and import the data.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/102_object_collections/20_create_collection.mdx
+++ b/developers/academy/py/starter_custom_vectors/102_object_collections/20_create_collection.mdx
@@ -73,6 +73,6 @@ For convenience, we import the submodule as `wc` and use classes from it.
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/102_object_collections/25_generate_vectors.mdx
+++ b/developers/academy/py/starter_custom_vectors/102_object_collections/25_generate_vectors.mdx
@@ -63,6 +63,6 @@ The embeddings are then saved to a file so that we can use when adding the movie
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/102_object_collections/30_import_data.mdx
+++ b/developers/academy/py/starter_custom_vectors/102_object_collections/30_import_data.mdx
@@ -86,6 +86,6 @@ You can print out the errors to see what went wrong, and then decide how to hand
 
 Note that the list of errors is cleared when a new context manager is entered, so you must handle the errors before initializing a new batcher.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/102_object_collections/index.mdx
+++ b/developers/academy/py/starter_custom_vectors/102_object_collections/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_collections"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/103_object_searches/10_vector.mdx
+++ b/developers/academy/py/starter_custom_vectors/103_object_searches/10_vector.mdx
@@ -69,6 +69,6 @@ The query vector in this example is obtained similarly to how it was in the [dat
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/103_object_searches/20_keyword_hybrid.mdx
+++ b/developers/academy/py/starter_custom_vectors/103_object_searches/20_keyword_hybrid.mdx
@@ -99,6 +99,6 @@ Hybrid score: 0.012
 </details>
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/103_object_searches/30_filters.mdx
+++ b/developers/academy/py/starter_custom_vectors/103_object_searches/30_filters.mdx
@@ -47,6 +47,6 @@ Distance to query: 0.790
 </details>
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/103_object_searches/index.mdx
+++ b/developers/academy/py/starter_custom_vectors/103_object_searches/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_searches"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/104_object_rag/10_setup.mdx
+++ b/developers/academy/py/starter_custom_vectors/104_object_rag/10_setup.mdx
@@ -32,6 +32,6 @@ RAG queries are also called 'generative' queries in Weaviate. You can access the
 
 Each generative query works in addition to the regular search query, and will perform a RAG query on each retrieved object.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/104_object_rag/20_single_prompt.mdx
+++ b/developers/academy/py/starter_custom_vectors/104_object_rag/20_single_prompt.mdx
@@ -49,6 +49,6 @@ Le Labyrinthe
 Each response object is similar to that from a regular search query, with an additional `generated` attribute. This attribute will contain the generated output for each object.
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/104_object_rag/30_grouped_task.mdx
+++ b/developers/academy/py/starter_custom_vectors/104_object_rag/30_grouped_task.mdx
@@ -52,6 +52,6 @@ You can also pass on a list of properties to be used, as the `grouped_properties
 
 A RAG query with the `grouped_task` parameter will return a response with an additional `generated` attribute. This attribute will contain the generated output for the set of objects.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_custom_vectors/104_object_rag/index.mdx
+++ b/developers/academy/py/starter_custom_vectors/104_object_rag/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_rag"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/101_setup_weaviate/10_client.mdx
+++ b/developers/academy/py/starter_multimodal_data/101_setup_weaviate/10_client.mdx
@@ -28,6 +28,6 @@ The client provides sets of helper classes (e.g. under `weaviate.classes`) and f
 
 Next, we'll show you how create a Weaviate instance and connect to it.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/101_setup_weaviate/20_create_docker.mdx
+++ b/developers/academy/py/starter_multimodal_data/101_setup_weaviate/20_create_docker.mdx
@@ -93,6 +93,6 @@ This course uses OpenAI (for retrieval augmented generation), so you can provide
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/101_setup_weaviate/30_communicate.mdx
+++ b/developers/academy/py/starter_multimodal_data/101_setup_weaviate/30_communicate.mdx
@@ -59,6 +59,6 @@ We suggest using a `try`-`finally` block as a best practice. For brevity, we wil
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/101_setup_weaviate/index.mdx
+++ b/developers/academy/py/starter_multimodal_data/101_setup_weaviate/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_setup_weaviate"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/102_mm_collections/10_preparation.mdx
+++ b/developers/academy/py/starter_multimodal_data/102_mm_collections/10_preparation.mdx
@@ -29,6 +29,6 @@ As a multimodal project, we'll also use [corresponding posters for each movie](h
 
 Next, you will create a corresponding object collection and import the data.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/102_mm_collections/20_create_collection.mdx
+++ b/developers/academy/py/starter_multimodal_data/102_mm_collections/20_create_collection.mdx
@@ -79,6 +79,6 @@ For convenience, we import the submodule as `wc` and use classes from it.
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/102_mm_collections/30_import_data.mdx
+++ b/developers/academy/py/starter_multimodal_data/102_mm_collections/30_import_data.mdx
@@ -103,6 +103,6 @@ When the batcher sends the queue to Weaviate, the objects are added to the colle
 
 Recall that the collection has a vectorizer module, and we do not specify vectors here. So Weaviate uses the specified vectorizer to generate vector embeddings from the data.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/102_mm_collections/index.mdx
+++ b/developers/academy/py/starter_multimodal_data/102_mm_collections/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_collections"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/103_mm_searches/10_multimodal.mdx
+++ b/developers/academy/py/starter_multimodal_data/103_mm_searches/10_multimodal.mdx
@@ -140,6 +140,6 @@ Distance to query: 0.683
 The returned object is in the same format as in the previous example.
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/103_mm_searches/20_keyword_hybrid.mdx
+++ b/developers/academy/py/starter_multimodal_data/103_mm_searches/20_keyword_hybrid.mdx
@@ -97,6 +97,6 @@ Hybrid score: 0.012
 </details>
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/103_mm_searches/30_filters.mdx
+++ b/developers/academy/py/starter_multimodal_data/103_mm_searches/30_filters.mdx
@@ -47,6 +47,6 @@ Distance to query: 0.216
 </details>
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/103_mm_searches/index.mdx
+++ b/developers/academy/py/starter_multimodal_data/103_mm_searches/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_searches"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/104_mm_rag/10_setup.mdx
+++ b/developers/academy/py/starter_multimodal_data/104_mm_rag/10_setup.mdx
@@ -32,6 +32,6 @@ RAG queries are also called 'generative' queries in Weaviate. You can access the
 
 Each generative query works in addition to the regular search query, and will perform a RAG query on each retrieved object.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/104_mm_rag/20_single_prompt.mdx
+++ b/developers/academy/py/starter_multimodal_data/104_mm_rag/20_single_prompt.mdx
@@ -49,6 +49,6 @@ Godzilla
 Each response object is similar to that from a regular search query, with an additional `generated` attribute. This attribute will contain the generated output for each object.
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/104_mm_rag/30_grouped_task.mdx
+++ b/developers/academy/py/starter_multimodal_data/104_mm_rag/30_grouped_task.mdx
@@ -52,6 +52,6 @@ You can also pass on a list of properties to be used, as the `grouped_properties
 
 A RAG query with the `grouped_task` parameter will return a response with an additional `generated` attribute. This attribute will contain the generated output for the set of objects.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_multimodal_data/104_mm_rag/index.mdx
+++ b/developers/academy/py/starter_multimodal_data/104_mm_rag/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_rag"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/101_setup_weaviate/10_client.mdx
+++ b/developers/academy/py/starter_text_data/101_setup_weaviate/10_client.mdx
@@ -28,6 +28,6 @@ The client provides sets of helper classes (e.g. under `weaviate.classes`) and f
 
 Next, we'll show you how create a Weaviate instance and connect to it.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/101_setup_weaviate/20_create_instance/10_create_wcs.mdx
+++ b/developers/academy/py/starter_text_data/101_setup_weaviate/20_create_instance/10_create_wcs.mdx
@@ -59,6 +59,6 @@ This course uses OpenAI, so you can provide the OpenAI API key to Weaviate throu
 If you have completed this, you can skip the next page [Option 2: A local Weaviate instance](./20_create_docker.mdx) and continue with [Communicate with Weaviate](../30_communicate.mdx).
 :::
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/101_setup_weaviate/20_create_instance/20_create_docker.mdx
+++ b/developers/academy/py/starter_text_data/101_setup_weaviate/20_create_instance/20_create_docker.mdx
@@ -85,6 +85,6 @@ This course uses OpenAI, so you can provide the OpenAI API key to Weaviate throu
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/101_setup_weaviate/20_create_instance/index.mdx
+++ b/developers/academy/py/starter_text_data/101_setup_weaviate/20_create_instance/index.mdx
@@ -11,6 +11,6 @@ For this unit, you can choose to create a Weaviate Cloud Service (WCS) instance 
 
 Either option is fine for this course. If you're not sure which to choose, we recommend starting with a WCS instance.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/101_setup_weaviate/30_communicate.mdx
+++ b/developers/academy/py/starter_text_data/101_setup_weaviate/30_communicate.mdx
@@ -57,6 +57,6 @@ We suggest using a `try`-`finally` block as a best practice. For brevity, we wil
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/101_setup_weaviate/index.mdx
+++ b/developers/academy/py/starter_text_data/101_setup_weaviate/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_setup_weaviate"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/102_text_collections/10_preparation.mdx
+++ b/developers/academy/py/starter_text_data/102_text_collections/10_preparation.mdx
@@ -33,6 +33,6 @@ We are going to use a movie dataset sourced from [TMDB](https://www.themoviedb.o
 
 Next, you will create a corresponding object collection and import the data.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/102_text_collections/20_create_collection.mdx
+++ b/developers/academy/py/starter_text_data/102_text_collections/20_create_collection.mdx
@@ -75,6 +75,6 @@ For convenience, we import the submodule as `wc` and use classes from it.
   language="py"
 />
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/102_text_collections/30_import_data.mdx
+++ b/developers/academy/py/starter_text_data/102_text_collections/30_import_data.mdx
@@ -90,6 +90,6 @@ When the batcher sends the queue to Weaviate, the objects are added to the colle
 
 Recall that the collection has a vectorizer module, and we do not specify vectors here. So Weaviate uses the specified vectorizer to generate vector embeddings from the data.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/102_text_collections/index.mdx
+++ b/developers/academy/py/starter_text_data/102_text_collections/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_collections"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/103_text_searches/10_semantic.mdx
+++ b/developers/academy/py/starter_text_data/103_text_searches/10_semantic.mdx
@@ -59,6 +59,6 @@ Each returned object will:
 - Not include any other information (e.g. references, metadata, vectors.) by default.
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/103_text_searches/20_keyword_hybrid.mdx
+++ b/developers/academy/py/starter_text_data/103_text_searches/20_keyword_hybrid.mdx
@@ -97,6 +97,6 @@ Hybrid score: 0.012
 </details>
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/103_text_searches/30_filters.mdx
+++ b/developers/academy/py/starter_text_data/103_text_searches/30_filters.mdx
@@ -11,7 +11,7 @@ Filters can be used to precisely refine search results. You can filter by proper
 
 ### <i class="fa-solid fa-code"></i> Code
 
-This example finds entries in "Movie" based on their similarity to the query "dystopian future", only from those released after 2010. It prints out the title and release year of the top 5 matches.
+This example finds entries in "Movie" based on their similarity to the query "dystopian future", only from those released after 2020. It prints out the title and release year of the top 5 matches.
 
 <FilteredTextBlock
   text={PyCode}
@@ -47,6 +47,6 @@ Distance to query: 0.216
 </details>
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/103_text_searches/index.mdx
+++ b/developers/academy/py/starter_text_data/103_text_searches/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_searches"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/104_text_rag/10_setup.mdx
+++ b/developers/academy/py/starter_text_data/104_text_rag/10_setup.mdx
@@ -32,6 +32,6 @@ RAG queries are also called 'generative' queries in Weaviate. You can access the
 
 Each generative query works in addition to the regular search query, and will perform a RAG query on each retrieved object.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/104_text_rag/20_single_prompt.mdx
+++ b/developers/academy/py/starter_text_data/104_text_rag/20_single_prompt.mdx
@@ -49,6 +49,6 @@ Les enfants des hommes
 Each response object is similar to that from a regular search query, with an additional `generated` attribute. This attribute will contain the generated output for each object.
 
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/104_text_rag/30_grouped_task.mdx
+++ b/developers/academy/py/starter_text_data/104_text_rag/30_grouped_task.mdx
@@ -52,6 +52,6 @@ You can also pass on a list of properties to be used, as the `grouped_properties
 
 A RAG query with the `grouped_task` parameter will return a response with an additional `generated` attribute. This attribute will contain the generated output for the set of objects.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/starter_text_data/104_text_rag/index.mdx
+++ b/developers/academy/py/starter_text_data/104_text_rag/index.mdx
@@ -18,6 +18,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="text_rag"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/101_hello_weaviate/10_intro_weaviate.mdx
+++ b/developers/academy/py/zero_to_mvp/101_hello_weaviate/10_intro_weaviate.mdx
@@ -259,9 +259,9 @@ Input box for user to put answer in and get back a similarity score & our defini
 
 <a name="1"></a>(1) Subject to terms of its license, of course.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const weaviateOpenSource = [

--- a/developers/academy/py/zero_to_mvp/101_hello_weaviate/15_overview_vectors.mdx
+++ b/developers/academy/py/zero_to_mvp/101_hello_weaviate/15_overview_vectors.mdx
@@ -75,9 +75,9 @@ Can you describe, in your own words, what vectors are?
 - Machine learning models help quantify similarity between different objects, which is essential for vector searches.
 - Weaviate uses a combination of approximate nearest neighbor (ANN) index and an inverted index to perform fast vector searches with filtering.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const howWeaviateWorks = [{

--- a/developers/academy/py/zero_to_mvp/101_hello_weaviate/20_examples_1.mdx
+++ b/developers/academy/py/zero_to_mvp/101_hello_weaviate/20_examples_1.mdx
@@ -218,6 +218,6 @@ Input box for user to put answer in and get back a similarity score & our defini
 - Smaller distances indicate greater similarity.
 - Vector searches can be combined with keyword searches and filtering techniques for more refined search results.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/101_hello_weaviate/25_examples_2.mdx
+++ b/developers/academy/py/zero_to_mvp/101_hello_weaviate/25_examples_2.mdx
@@ -138,6 +138,6 @@ Input box for user to put answer in and get back a similarity score & our defini
 - Generative search allows you to retrieve information and reshape or repurpose the content, such as generating a tweet based on a Wikipedia entry.
 - These advanced capabilities of Weaviate transform how you interact with and utilize information in your data.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/101_hello_weaviate/40_set_up.mdx
+++ b/developers/academy/py/zero_to_mvp/101_hello_weaviate/40_set_up.mdx
@@ -139,9 +139,9 @@ import CodeClientInstall from '/_includes/code/quickstart/clients.install.mdx';
 - Weaviate clients are available in multiple languages.
 - Currently, the Academy material is available in Python only.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const instanceOptions = [{

--- a/developers/academy/py/zero_to_mvp/101_hello_weaviate/50_hands_on.mdx
+++ b/developers/academy/py/zero_to_mvp/101_hello_weaviate/50_hands_on.mdx
@@ -227,9 +227,9 @@ What happens if you remove {wiki_summary}?
 - Client libraries are used to access both REST and GraphQL APIs, providing a convenient way to interact with Weaviate instances.
 - You have connected to a demo Weaviate instance to run vector searches, question-answering queries, and generative searches.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const apiRecap = [{

--- a/developers/academy/py/zero_to_mvp/101_hello_weaviate/90_wrap_up.mdx
+++ b/developers/academy/py/zero_to_mvp/101_hello_weaviate/90_wrap_up.mdx
@@ -20,6 +20,6 @@ Having finished this unit, you should be able to:
 - Install your preferred Weaviate client (Python for Weaviate Academy).
 - Describe some of Weaviate's capabilities.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/101_hello_weaviate/index.mdx
+++ b/developers/academy/py/zero_to_mvp/101_hello_weaviate/index.mdx
@@ -34,6 +34,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 
 <LearningGoals unitName="hello_weaviate"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/102_queries_1/10_get.mdx
+++ b/developers/academy/py/zero_to_mvp/102_queries_1/10_get.mdx
@@ -291,6 +291,6 @@ const nearText = [{
   ]
 }];
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/102_queries_1/20_vector_parameters.mdx
+++ b/developers/academy/py/zero_to_mvp/102_queries_1/20_vector_parameters.mdx
@@ -291,6 +291,6 @@ const nearVectorFunction = [{
   ]
 }];
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/102_queries_1/40_aggregate.mdx
+++ b/developers/academy/py/zero_to_mvp/102_queries_1/40_aggregate.mdx
@@ -349,6 +349,6 @@ const varName = [{
   ]
 }];
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/102_queries_1/50_filters.mdx
+++ b/developers/academy/py/zero_to_mvp/102_queries_1/50_filters.mdx
@@ -357,6 +357,6 @@ const offsetExample = [{
   ]
 }];
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/102_queries_1/80_inside_queries_1.mdx
+++ b/developers/academy/py/zero_to_mvp/102_queries_1/80_inside_queries_1.mdx
@@ -213,6 +213,6 @@ const varName = [{
   ]
 }];
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/102_queries_1/90_wrap_up.mdx
+++ b/developers/academy/py/zero_to_mvp/102_queries_1/90_wrap_up.mdx
@@ -19,6 +19,6 @@ Now, you should be able to:
 - Add filters to queries.
 - Describe how Weaviate applies search operators and filters to perform searches.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/102_queries_1/index.mdx
+++ b/developers/academy/py/zero_to_mvp/102_queries_1/index.mdx
@@ -36,6 +36,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 
 <LearningGoals unitName="queries_1"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/103_schema_and_imports/05_preparation.mdx
+++ b/developers/academy/py/zero_to_mvp/103_schema_and_imports/05_preparation.mdx
@@ -101,6 +101,6 @@ We'll see you in the next section.
 - Access your Weaviate instance with API key authentication or without authentication as appropriate.
 - Confirm access to your Weaviate instance by running the provided code snippet.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/103_schema_and_imports/10_data_structure.mdx
+++ b/developers/academy/py/zero_to_mvp/103_schema_and_imports/10_data_structure.mdx
@@ -217,9 +217,9 @@ Any missing information required for schema definition will be automatically inf
     - So, any objects you want to search together should be in the same class.
 - Any missing information required for schema definition will be automatically inferred by Weaviate based on default values and the imported data.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const invertedIndex = [

--- a/developers/academy/py/zero_to_mvp/103_schema_and_imports/20_schema.mdx
+++ b/developers/academy/py/zero_to_mvp/103_schema_and_imports/20_schema.mdx
@@ -241,6 +241,6 @@ Try to construct a schema for that dataset based on what you've learned here.
 - The vectorizer parameter determines which Weaviate module will be used to generate vector embeddings for a class.
 - Module configurations at the class and property levels allow customization of module behavior across the entire class or per property, respectively.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/103_schema_and_imports/30_import.mdx
+++ b/developers/academy/py/zero_to_mvp/103_schema_and_imports/30_import.mdx
@@ -181,6 +181,6 @@ With these parameters, you have the option of manually specifying the object ID 
     - If a vector is not specified, Weaviate will create one if a vectorizer is specified.
     - The vectorizer setting can be set in the schema.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/103_schema_and_imports/40_example.mdx
+++ b/developers/academy/py/zero_to_mvp/103_schema_and_imports/40_example.mdx
@@ -281,6 +281,6 @@ We have:
 - Built a schema and imported our data.
 - Verified the successful import by checking the object count in Weaviate.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/103_schema_and_imports/90_wrap_up.mdx
+++ b/developers/academy/py/zero_to_mvp/103_schema_and_imports/90_wrap_up.mdx
@@ -17,6 +17,6 @@ Having finished this unit, you should be able to:
 - Understand how classes and properties represent your data, and how to define them.
 - Populate Weaviate with data, using batch imports.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/103_schema_and_imports/index.mdx
+++ b/developers/academy/py/zero_to_mvp/103_schema_and_imports/index.mdx
@@ -37,6 +37,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 
 <LearningGoals unitName="schema_and_import"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/104_queries_2/10_bm25.mdx
+++ b/developers/academy/py/zero_to_mvp/104_queries_2/10_bm25.mdx
@@ -163,9 +163,9 @@ If you would like to delve into the details of the exact algorithm, you can revi
 - Consider your search use case for picking tokenization options. For example, use `word` for long text with partial matches, and `field` for short text with exact matches.
 - BM25F scoring, where 'F' stands for 'field', is used to score and rank the search results based on the fields that are searched.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const Bm25Question = [{

--- a/developers/academy/py/zero_to_mvp/104_queries_2/20_hybrid.mdx
+++ b/developers/academy/py/zero_to_mvp/104_queries_2/20_hybrid.mdx
@@ -118,9 +118,9 @@ Try varying the `alpha` parameter above. What happens to the results?
 - Hybrid search is helpful when a vector search or a keyword search alone is not producing desired results.
 - Hybrid search orders its search results by summing the inverse of the vector and `bm25` rankings.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const hybridRankingQuestion = [{

--- a/developers/academy/py/zero_to_mvp/104_queries_2/30_generative.mdx
+++ b/developers/academy/py/zero_to_mvp/104_queries_2/30_generative.mdx
@@ -236,6 +236,6 @@ As a starting point, we recommend that you try using the default options, includ
 - Object properties are used in generative searches; they form the model prompt in single prompt examples and can be specified in grouped tasks.
 - Generative modules use large language models (LLMs), and Weaviate exposes optional parameters for tuning their behavior.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/104_queries_2/40_qna.mdx
+++ b/developers/academy/py/zero_to_mvp/104_queries_2/40_qna.mdx
@@ -145,6 +145,6 @@ By setting the number of objects, you may increase the chance of retrieving the 
 - The QnA module will look for an answer in each retrieved object, returning the answer as an additional property.
 - If the QnA module does not identify an answer, it will indicate so in the response.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/104_queries_2/90_wrap_up.mdx
+++ b/developers/academy/py/zero_to_mvp/104_queries_2/90_wrap_up.mdx
@@ -18,6 +18,6 @@ Having finished this unit, you should be able to:
 - Transform data before delivery with generative searches.
 - Extract answers from data with QnA searches.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/104_queries_2/index.mdx
+++ b/developers/academy/py/zero_to_mvp/104_queries_2/index.mdx
@@ -39,6 +39,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 
 <LearningGoals unitName="queries_2"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/_000_template/_TEMPLATE_10_body.mdx
+++ b/developers/academy/py/zero_to_mvp/_000_template/_TEMPLATE_10_body.mdx
@@ -54,9 +54,9 @@ Try out ...
 Add summary
 :::
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const varName = [{

--- a/developers/academy/py/zero_to_mvp/_000_template/_TEMPLATE_90_wrap_up.mdx
+++ b/developers/academy/py/zero_to_mvp/_000_template/_TEMPLATE_90_wrap_up.mdx
@@ -10,6 +10,6 @@ In this unit, you have ...
 Now, you should be able to:
 ...
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/_000_template/_TEMPLATE_index.mdx
+++ b/developers/academy/py/zero_to_mvp/_000_template/_TEMPLATE_index.mdx
@@ -23,6 +23,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 <!-- Replace unitName with name from `unitData.js` - will pull in learning goals and outcomes -->
 <LearningGoals unitName="hello_weaviate"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/_104_vectorization_essentials/50_cross_references.mdx
+++ b/developers/academy/py/zero_to_mvp/_104_vectorization_essentials/50_cross_references.mdx
@@ -22,6 +22,6 @@ Add review exercises
 
 ### <i class="fa-solid fa-lightbulb-on"></i> Key takeaways
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/_104_vectorization_essentials/70_import_example_2.mdx
+++ b/developers/academy/py/zero_to_mvp/_104_vectorization_essentials/70_import_example_2.mdx
@@ -25,6 +25,6 @@ Add review exercises
 
 ### <i class="fa-solid fa-lightbulb-on"></i> Key takeaways
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/py/zero_to_mvp/setup.mdx
+++ b/developers/academy/py/zero_to_mvp/setup.mdx
@@ -180,6 +180,6 @@ In Python, you can run a GraphQL query directly with:
 - You know how to instantiate the Weaviate Python client, and run the shown example code.
 - The Academy units will show Python code, but also raw GraphQL or REST snippets where applicable.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/theory/101_hello_weaviate/10_intro_weaviate.mdx
+++ b/developers/academy/theory/101_hello_weaviate/10_intro_weaviate.mdx
@@ -142,9 +142,9 @@ Input box for user to put answer in and get back a similarity score & our defini
 
 <a name="1"></a>(1) Subject to terms of its license, of course.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const weaviateOpenSource = [

--- a/developers/academy/theory/101_hello_weaviate/15_overview_vectors.mdx
+++ b/developers/academy/theory/101_hello_weaviate/15_overview_vectors.mdx
@@ -75,9 +75,9 @@ Can you describe, in your own words, what vectors are?
 - Machine learning models help quantify similarity between different objects, which is essential for vector searches.
 - Weaviate uses a combination of approximate nearest neighbor (ANN) index and an inverted index to perform fast vector searches with filtering.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>
 
 import Quiz from '/src/components/Academy/quiz.js'
 const howWeaviateWorks = [{

--- a/developers/academy/theory/101_hello_weaviate/20_examples_1.mdx
+++ b/developers/academy/theory/101_hello_weaviate/20_examples_1.mdx
@@ -88,6 +88,6 @@ Input box for user to put answer in and get back a similarity score & our defini
 - Smaller distances indicate greater similarity.
 - Vector searches can be combined with keyword searches and filtering techniques for more refined search results.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/theory/101_hello_weaviate/25_examples_2.mdx
+++ b/developers/academy/theory/101_hello_weaviate/25_examples_2.mdx
@@ -101,6 +101,6 @@ Input box for user to put answer in and get back a similarity score & our defini
 - Generative search allows you to retrieve information and reshape or repurpose the content, such as generating a tweet based on a Wikipedia entry.
 - These advanced capabilities of Weaviate transform how you interact with and utilize information in your data.
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/theory/101_hello_weaviate/90_next_steps.mdx
+++ b/developers/academy/theory/101_hello_weaviate/90_next_steps.mdx
@@ -33,6 +33,6 @@ import CTASocials from '../../py/_snippets/cta_socials.mdx';
 
 See you soon! 👋
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>

--- a/developers/academy/theory/101_hello_weaviate/index.mdx
+++ b/developers/academy/theory/101_hello_weaviate/index.mdx
@@ -34,6 +34,6 @@ import LearningGoals from '/src/components/Academy/learningGoals.jsx';
 
 <LearningGoals unitName="hello_weaviate"/>
 
-import { GiscusDocComment } from '/src/components/GiscusComment';
+import DocsFeedback from '/_includes/docs-feedback.mdx';
 
-<GiscusDocComment />
+<DocsFeedback/>


### PR DESCRIPTION
### What's being changed:

Remove giscus widget on doc pages; replace with forum links.

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`