### PR TITLE
Fix internal links to /text2vec-transformers

### DIFF
--- a/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers.md
@@ -17,10 +17,10 @@ Key notes:
 - This module is not available on Weaviate Cloud Services (WCS).
 - Enabling this module will enable the [`nearText` search operator](/developers/weaviate/api/graphql/search-operators.md#neartext).
 - This module is only compatible with models encapsulated in a Docker container.
-- [Pre-built images](#option-1-pre-built-images) are available with popular models.
+- [Pre-built images](#use-a-pre-built-image) are available with popular models.
 - You can also use other models, such as:
-    - By [building an image](#option-2-a-hugging-face-model) for any publicly available model from the [Hugging Face model hub](https://huggingface.co/models).
-    - By [building an image](#option-3-a-private-or-local-model) for any model compatible with Hugging Face's `AutoModel` and `AutoTokenizer`.
+    - By [building an image](#build-a-model) for any publicly available model from the [Hugging Face model hub](https://huggingface.co/models).
+    - By [building an image](#use-a-private-or-local-model) for any model compatible with Hugging Face's `AutoModel` and `AutoTokenizer`.
 
 :::tip Do you have GPU acceleration?
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

same page links on how to use pre built or build your own images were broken

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
