### PR TITLE
1.25: Add RAFT_GRPC_MAX_SIZE to the environment variables

### DIFF
--- a/developers/weaviate/config-refs/env-vars.md
+++ b/developers/weaviate/config-refs/env-vars.md
@@ -81,7 +81,7 @@ To configure Weaviate in a [Docker](../installation/docker-compose.md) or a [Kub
 | `CLUSTER_GOSSIP_BIND_PORT` | Port for exchanging network state information. | `string - number` | `7102` |
 | `CLUSTER_DATA_BIND_PORT` | Port for exchanging data. | `string - number` | `7103` |
 | `CLUSTER_JOIN` | The service name of the "founding" member node in a cluster setup | `string` | `weaviate-node-1:7100` |
-| `RAFT_GRPC_MAX_SIZE` | The maximum internal raft gRPC message size in bytes, defaults to 1073741824 | `string - number` | `1073741824` |
+| `RAFT_GRPC_MESSAGE_MAX_SIZE` | The maximum internal raft gRPC message size in bytes, defaults to 1073741824 | `string - number` | `1073741824` |
 
 import DocsMoreResources from '/_includes/more-resources-docs.md';
 

--- a/developers/weaviate/config-refs/env-vars.md
+++ b/developers/weaviate/config-refs/env-vars.md
@@ -81,6 +81,7 @@ To configure Weaviate in a [Docker](../installation/docker-compose.md) or a [Kub
 | `CLUSTER_GOSSIP_BIND_PORT` | Port for exchanging network state information. | `string - number` | `7102` |
 | `CLUSTER_DATA_BIND_PORT` | Port for exchanging data. | `string - number` | `7103` |
 | `CLUSTER_JOIN` | The service name of the "founding" member node in a cluster setup | `string` | `weaviate-node-1:7100` |
+| `RAFT_GRPC_MAX_SIZE` | The maximum internal raft gRPC message size in bytes, defaults to 1073741824 | `string - number` | `1073741824` |
 
 import DocsMoreResources from '/_includes/more-resources-docs.md';
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Adds the `RAFT_GRPC_MAX_SIZE` environment variable to the Weaviate environment variables reference page. This environment variable will be made available in the `1.25.0` release (assuming no further changes), is there a branch for that release I should propose to merge this change into or something like that? If not, we can just close this PR and add this line when needed.

<img width="1041" alt="Screenshot 2024-04-29 at 10 41 50 PM" src="https://github.com/weaviate/weaviate-io/assets/10050520/ac8b15d0-af1c-489b-a783-2cc5e839586b">

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

Ran `yarn start` (see screenshot above).