### PR TITLE
Propose moving to node v20.12.2 in docs due to errors when testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ nvm install node
 ```
 
 By default, `nvm` installs the most recent version of Node.js. Install Node.js
-19.9.0 as well. Version 19.9.0 is more compatible with the current
+20.12.2 as well. Version 20.12.2 is more compatible with the current
 `weaviate.io` project dependencies.
 
 ```
-nvm install node 19.9.0
-nvm use 19.9.0
+nvm install 20.12.2
+nvm use 20.12.2
 ```
 
 ### yarn Installation
@@ -131,7 +131,7 @@ second terminal, be sure to set the correct Node.js version before running
 additional `yarn` commands.
 
 ```
-nvm use node 19.9.0
+nvm use node 20.12.2
 ```
 
 ### Build the Web Site


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Propose moving to suggesting node `v20.12.2` because of a package error when running on `v19.9.0` just now (on an arm64 macbook).

Also removes `node` from `nvm install node 19.9.0` because `nvm` was ignoring the version when I ran this.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **README**

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

Ran `yarn build` locally
