### PR TITLE
text2vec-contextionary is no longer enabled in helm by default

### DIFF
--- a/developers/weaviate/installation/kubernetes.md
+++ b/developers/weaviate/installation/kubernetes.md
@@ -70,9 +70,7 @@ configuration with your setup.
 Out of the box, the configuration file is setup for:
 
 - 1 Weaviate replica.
-- The `text2vec-contextionary` module is enabled and running with 1 replica.
-  (This can be adjusted based on the expected load).
-- Other modules, such as `text2vec-transformers`, `qna-transformers` or
+- Local models, such as `text2vec-transformers`, `qna-transformers` or
   `img2vec-neural` are disabled by default. They can be enabled by setting the
   respective `enabled` flag to `true`.
 - `grpcService` is disabled by default. If you want to use the gRPC API, set the


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
text2vec-contextionary is no longer enabled by default in helm chart
### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
