### PR TITLE
fix the payload to be vectorized as numbers are not removed

### DIFF
--- a/developers/weaviate/config-refs/schema/index.md
+++ b/developers/weaviate/config-refs/schema/index.md
@@ -601,7 +601,7 @@ Article = {
 will be vectorized as:
 
 ```md
-article cows lose their jobs as milk prices drop as his diary cows lumbered over for their monday...
+article cows lose their jobs as milk prices drop as his 100 diary cows lumbered over for their monday...
 ```
 
 By default, the calculation includes the  `collection name` and all property `values`, but the property `names` *are not* indexed.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

instead of 

> article cows lose their jobs as milk prices drop as his diary cows lumbered over for their monday...

the correct payload is 

> article cows lose their jobs as milk prices drop as his 100 diary cows lumbered over for their monday...

as numbers are not removed from vectorization

Forum thread with further discussion:
https://forum.weaviate.io/t/numbers-in-text-to-be-vectorized/2174/2

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
