### PR TITLE
Draft openapi spec

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,7 +89,7 @@ const config = {
               route: '/developers/weaviate/api/rest',
               configuration: {
                 spec: {
-                  url: 'https://raw.githubusercontent.com/weaviate/weaviate/openapi_docs_from_tag/openapi-specs/schema.json',
+                  url: 'https://raw.githubusercontent.com/weaviate/weaviate/openapi_docs_1_25/openapi-specs/schema.json',
                 },
                 // This feature currently broken - being fixed in: https://github.com/scalar/scalar/pull/1387
                 // hiddenClients: [...],


### PR DESCRIPTION
### What's being changed:

Staging openapi spec

Before merging to final:
- [ ] Merge changes in `weaviate/openapi_docs_1_25` into `weaviate/openapi_docs_from_tag` 
- [ ] Change the `docusaurus.config.js` location back to `openapi_docs_from_tag` from `openapi_docs_1_25`

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
