### PR TITLE
Fix header in local connection External API Key docs example

### DIFF
--- a/_includes/code/client-libraries/python_v4.py
+++ b/_includes/code/client-libraries/python_v4.py
@@ -153,7 +153,7 @@ import weaviate
 import os
 
 client = weaviate.connect_to_local(
-    headers={"X-OpenAI-Api": os.getenv("OPENAI_APIKEY")}
+    headers={"X-OpenAI-Api-key": os.getenv("OPENAI_APIKEY")}
 )
 # END LocalInstantiationWithHeaders
 


### PR DESCRIPTION
### What's being changed:

Just a one line change in the External API keys example, changing the headers key from `X-OpenAI-Api` to `X-OpenAI-Api-key`.

With the current header key I get the following error:

```
WeaviateQueryError: Query call with protocol GRPC search failed with message explorer: get class: vectorize params:
 vectorize params: vectorize params: vectorize keywords: remote client vectorize: API Key: no api key found neither in
  request header: X-Openai-Api-Key nor in environment variable under OPENAI_APIKEY.
```

My connection works with the changed header :)

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] not tested
