### PR TITLE
Set vectorizers and default named vector

### DIFF
--- a/_includes/code/client-libraries/migrate-ts3.ts
+++ b/_includes/code/client-libraries/migrate-ts3.ts
@@ -1,5 +1,5 @@
 // CompleteScript // Imports
-import weaviate from 'weaviate-client'
+import weaviate from 'weaviate-client';
 import 'dotenv/config';
 // END CompleteScript // END Imports
 
@@ -26,7 +26,7 @@ async function main() {
   // create a new collection
   await client.collections.create({
     name: collectionName,
-    vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+    vectorizers: weaviate.configure.vectorizer.text2VecOpenAI("default"),
   })
 // END CompleteScript // END CreateCollection
 

--- a/_includes/code/howto/manage-data.collections.ts
+++ b/_includes/code/howto/manage-data.collections.ts
@@ -189,7 +189,7 @@ const newCollection = await client.collections.create({
       dataType: weaviate.configure.dataType.TEXT,
     },
   ],
-  vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+  vectorizers: weaviate.configure.vectorizer.text2VecOpenAI("default"),
   // highlight-start
   vectorIndex: weaviate.configure.vectorIndex.hnsw()
   // highlight-end
@@ -389,7 +389,7 @@ const newCollection = await client.collections.create({
     },
   ],
   // highlight-start
-  vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+  vectorizers: weaviate.configure.vectorizer.text2VecOpenAI("default"),
   // highlight-end
 })
 // The returned value is the full collection definition, showing all defaults

--- a/_includes/code/quickstart/endtoend.ts
+++ b/_includes/code/quickstart/endtoend.ts
@@ -40,7 +40,7 @@ const client: WeaviateClient = await weaviate.connectToWCS(
 // Add the schema
 const schema = {
   name: 'Question',
-  vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+  vectorizers: weaviate.configure.vectorizer.text2VecOpenAI("default"),
   generative: weaviate.configure.generative.openAI(),
 }
 

--- a/_includes/code/starter-guides/generative_local.ts
+++ b/_includes/code/starter-guides/generative_local.ts
@@ -64,7 +64,7 @@ const schemaDefinition = {
     }
   ],
     // highlight-start
-  vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+  vectorizers: weaviate.configure.vectorizer.text2VecOpenAI("default"),
   generative: weaviate.configure.generative.openAI()
     // highlight-end
 }

--- a/_includes/code/tutorial.schema.index-settings.mdx
+++ b/_includes/code/tutorial.schema.index-settings.mdx
@@ -109,7 +109,7 @@ const classObj = const schema = {
       vectorizePropertyName: false,
     }
   ],
-  vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+  vectorizers: weaviate.configure.vectorizer.text2VecOpenAI("default"),
   generative: weaviate.configure.generative.openAI(),
   invertedIndex: weaviate.configure.invertedIndex({
     indexNullState: true,

--- a/_includes/code/tutorial.schema.multi-tenancy.mdx
+++ b/_includes/code/tutorial.schema.multi-tenancy.mdx
@@ -97,7 +97,7 @@ const classObj = const schema = {
       vectorizePropertyName: false,
     }
   ],
-  vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+  vectorizers: weaviate.configure.vectorizer.text2VecOpenAI("default"),
   generative: weaviate.configure.generative.openAI(),
   multiTenancy: weaviate.configure.multiTenancy({enabled: true})
 }

--- a/_includes/code/tutorial.schema.properties.options.mdx
+++ b/_includes/code/tutorial.schema.properties.options.mdx
@@ -94,7 +94,7 @@ const classObj = const schema = {
       vectorizePropertyName: false,
     }
   ],
-  vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+  vectorizers: weaviate.configure.vectorizer.text2VecOpenAI("default"),
   generative: weaviate.configure.generative.openAI()
 }
 

--- a/blog/2024-03-28-hybrid-search-typescript/index.mdx
+++ b/blog/2024-03-28-hybrid-search-typescript/index.mdx
@@ -167,7 +167,7 @@ const quotesCollection = await client.collections.create({
       skipVectorisation: true,
     },
   ],
-  vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+  vectorizers: weaviate.configure.vectorizer.text2VecOpenAI("default"),
 });
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

We have old syntax in place for definition vectorizers for default colection:

instead of
```typescript
await client.collections.create({
  name: collectionName,
  vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
})
```
it should be
```typescript
await client.collections.create({
  name: collectionName,
  vectorizers: weaviate.configure.vectorizer.text2VecOpenAI("default"),
})
```


<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
