### PR TITLE
[docs] update roadmap to show 1.26 and 1.27

### DIFF
--- a/developers/weaviate/roadmap/index.md
+++ b/developers/weaviate/roadmap/index.md
@@ -14,13 +14,13 @@ Weaviate uses your feedback to plan future releases. If an issue is important to
 
 To join a discussion on GitHub, click on the issue title, and then add a comment in the discussion section. Alternatively, join our [forum](https://forum.weaviate.io/) to discuss the roadmap in more detail.
 
-## Planned for Weaviate 1.25
-
-<Roadmap label="planned-1.25"/>
-
 ## Planned for Weaviate 1.26
 
 <Roadmap label="planned-1.26"/>
+
+## Planned for Weaviate 1.27
+
+<Roadmap label="planned-1.27"/>
 
 ## Backlog
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
