### PR TITLE
Correct typo in the "Import data" documentation page

### DIFF
--- a/developers/academy/py/starter_text_data/_snippets/102_collection.py
+++ b/developers/academy/py/starter_text_data/_snippets/102_collection.py
@@ -85,7 +85,7 @@ df = pd.DataFrame(resp.json())
 movies = client.collections.get("Movie")
 
 # Enter context manager
-with movies.batch.rate_limit(2400) as batch:
+with movies.batch.dynamic() as batch:
     # Loop through the data
     for i, movie in tqdm(df.iterrows()):
         # Convert data types


### PR DESCRIPTION
The documentation talks about the .dynamic() method to create a dynamic batcher but the code uses rate_limit batcher

Link of the webpage: https://weaviate.io/developers/academy/py/starter_text_data/text_collections/import_data#:~:text=This%20example%20uses,objects%20per%20minute.

### What's being changed:

![image](https://github.com/weaviate/weaviate-io/assets/43139889/88b4203e-47dd-4008-9401-2b7c20b1ffa6)

### Type of change:

- **Documentation** updates (non-breaking change to fix/update documentation)
