### PR TITLE
Update OpenAPI spec path

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,7 +89,7 @@ const config = {
               route: '/developers/weaviate/api/rest',
               configuration: {
                 spec: {
-                  url: 'https://raw.githubusercontent.com/weaviate/weaviate/openapi_docs_1_25/openapi-specs/schema.json',
+                  url: 'https://raw.githubusercontent.com/weaviate/weaviate/openapi_docs/openapi-specs/schema.json',
                 },
                 // This feature currently broken - being fixed in: https://github.com/scalar/scalar/pull/1387
                 // hiddenClients: [...],


### PR DESCRIPTION
### What's being changed:

Update OpenAPI spec path to https://github.com/weaviate/weaviate/tree/openapi_docs

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
