### PR TITLE
new versions of docker image require PERSISTENCE_DATA_PATH to be

### DIFF
--- a/developers/weaviate/configuration/persistence.md
+++ b/developers/weaviate/configuration/persistence.md
@@ -22,11 +22,12 @@ services:
       - /var/weaviate:/var/lib/weaviate
     environment:
       CLUSTER_HOSTNAME: 'node1'
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
 ```
 
 * About the volumes
   * `/var/weaviate` is the location where you want to store the data on the local machine
-  * `/var/lib/weaviate` (after the colon) is the location inside the container, don't change this
+  * `/var/lib/weaviate` (after the colon) is the location inside the container, don't change this as it needs to match whatever is in `PERSISTENCE_DATA_PATH` variable.
 * About the hostname
   * The `CLUSTER_HOSTNAME` can be any arbitrarily chosen name
 

--- a/developers/weaviate/configuration/persistence.md
+++ b/developers/weaviate/configuration/persistence.md
@@ -27,7 +27,7 @@ services:
 
 * About the volumes
   * `/var/weaviate` is the location where you want to store the data on the local machine
-  * `/var/lib/weaviate` (after the colon) is the location inside the container, don't change this as it needs to match whatever is in `PERSISTENCE_DATA_PATH` variable.
+  * `/var/lib/weaviate` The value after the colon (:) is the storage location inside the container. This value must match the PERSISTENCE_DATA_PATH variable.
 * About the hostname
   * The `CLUSTER_HOSTNAME` can be any arbitrarily chosen name
 

--- a/developers/weaviate/configuration/persistence.md
+++ b/developers/weaviate/configuration/persistence.md
@@ -29,7 +29,7 @@ services:
   * `/var/weaviate` is the location where you want to store the data on the local machine
   * `/var/lib/weaviate` The value after the colon (:) is the storage location inside the container. This value must match the PERSISTENCE_DATA_PATH variable.
 * About the hostname
-  * The `CLUSTER_HOSTNAME` can be any arbitrarily chosen name
+  * `CLUSTER_HOSTNAME` can be any name
 
 In the case you want a more verbose output, you can change the environment variable for the `LOG_LEVEL`
 


### PR DESCRIPTION
new versions of docker image require PERSISTENCE_DATA_PATH to be set as it is now defaulting to ./data

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
