### PR TITLE
20240604/add any all of examples

### DIFF
--- a/_includes/code/howto/search.filters.py
+++ b/_includes/code/howto/search.filters.py
@@ -170,8 +170,10 @@ response = jeopardy.query.fetch_objects(
     # highlight-start
     # Use & as AND
     #     | as OR
-    filters=Filter.by_property("round").equal("Double Jeopardy!") &
-            Filter.by_property("points").less_than(600),
+    filters=(
+        Filter.by_property("round").equal("Double Jeopardy!") &
+        Filter.by_property("points").less_than(600)
+    ),
     # highlight-end
     limit=3
 )
@@ -185,6 +187,76 @@ for o in response.objects:
 assert response.objects[0].collection == "JeopardyQuestion"
 assert response.objects[0].properties["round"] == "Double Jeopardy!"
 assert response.objects[0].properties["points"] < 600
+# End test
+
+
+# ==========================================
+# ===== Multiple Filters with Any of =====
+# ==========================================
+
+# MultipleFiltersAnyOfPython
+from weaviate.classes.query import Filter
+
+jeopardy = client.collections.get("JeopardyQuestion")
+response = jeopardy.query.fetch_objects(
+    # highlight-start
+    filters=(
+        Filter.any_of([  # Combines the below with `|`
+            Filter.by_property("points").greater_or_equal(700),
+            Filter.by_property("points").less_than(500),
+            Filter.by_property("round").equal("Double Jeopardy!"),
+        ])
+    ),
+    # highlight-end
+    limit=5
+)
+
+for o in response.objects:
+    print(o.properties)
+# END MultipleFiltersAnyOfPython
+
+
+# Test results
+assert (
+    response.objects[0].properties["points"] <= 700 |
+    response.objects[0].properties["points"] < 500 |
+    response.objects[0].properties["round"] == "Double Jeopardy!"
+)
+# End test
+
+
+# ==========================================
+# ===== Multiple Filters with All of =====
+# ==========================================
+
+# MultipleFiltersAllOfPython
+from weaviate.classes.query import Filter
+
+jeopardy = client.collections.get("JeopardyQuestion")
+response = jeopardy.query.fetch_objects(
+    # highlight-start
+    filters=(
+        Filter.all_of([  # Combines the below with `&`
+            Filter.by_property("points").greater_than(300),
+            Filter.by_property("points").less_than(700),
+            Filter.by_property("round").equal("Double Jeopardy!"),
+        ])
+    ),
+    # highlight-end
+    limit=5
+)
+
+for o in response.objects:
+    print(o.properties)
+# END MultipleFiltersAllOfPython
+
+
+# Test results
+assert (
+    response.objects[0].properties["points"] > 300 &
+    response.objects[0].properties["points"] < 700 &
+    response.objects[0].properties["round"] == "Double Jeopardy!"
+)
 # End test
 
 

--- a/developers/weaviate/search/filters.md
+++ b/developers/weaviate/search/filters.md
@@ -147,6 +147,39 @@ The output is like this:
 
 </details>
 
+## Filter by all/any of multiple conditions
+
+The `v4` Python client API supports filtering by `any`, or `all` of a set of provided filters.
+
+<!-- TODO: Could update to this ⬇️ when ready:  -->
+<!-- The `v4` Python client and the `v3` JS client APIs supports filtering by `any`, or `all` of a set of provided filters.  -->
+
+#### Filter with `any of`
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={PyCode}
+      startMarker="# MultipleFiltersAllOfPython"
+      endMarker="# END MultipleFiltersAllOfPython"
+      language="python"
+    />
+  </TabItem>
+</Tabs>
+
+#### Filter with `all of`
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={PyCode}
+      startMarker="# MultipleFiltersAllOfPython"
+      endMarker="# END MultipleFiltersAllOfPython"
+      language="python"
+    />
+  </TabItem>
+</Tabs>
+
 ## Nested filters
 
 You can group and nest filters.

--- a/developers/weaviate/search/filters.md
+++ b/developers/weaviate/search/filters.md
@@ -88,12 +88,44 @@ To filter with two or more conditions, use `And` or `Or` to define the relations
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python Client v4">
-    <FilteredTextBlock
-      text={PyCode}
-      startMarker="# MultipleFiltersAndPython"
-      endMarker="# END MultipleFiltersAndPython"
-      language="python"
-    />
+
+  The `v4` Python client API provides  filtering by `any_of`, or `all_of`, as well as using `&` or `|` operators.
+  <br/>
+
+  <ul>
+    <li>Use <code>any_of</code> or <code>all_of</code> for filtering by any, or all of a list of provided filters.</li>
+    <li>Use <code>&</code> or <code>|</code> for filtering by pairs of provided filters.</li>
+  </ul>
+
+  <br/>
+
+  #### Filter with `&` or `|`
+
+  <FilteredTextBlock
+    text={PyCode}
+    startMarker="# MultipleFiltersAndPython"
+    endMarker="# END MultipleFiltersAndPython"
+    language="python"
+  />
+
+  #### Filter with `any of`
+
+  <FilteredTextBlock
+    text={PyCode}
+    startMarker="# MultipleFiltersAllOfPython"
+    endMarker="# END MultipleFiltersAllOfPython"
+    language="python"
+  />
+
+  #### Filter with `all of`
+
+  <FilteredTextBlock
+    text={PyCode}
+    startMarker="# MultipleFiltersAllOfPython"
+    endMarker="# END MultipleFiltersAllOfPython"
+    language="python"
+  />
+
   </TabItem>
 
   <TabItem value="py3" label="Python Client v3">
@@ -106,12 +138,19 @@ To filter with two or more conditions, use `And` or `Or` to define the relations
   </TabItem>
 
   <TabItem value="js" label="JS/TS Client v3">
-    <FilteredTextBlock
-      text={JavaScriptCode}
-      startMarker="// searchMultipleFiltersAnd"
-      endMarker="// END searchMultipleFiltersAnd"
-      language="js"
-    />
+
+  Use `Filters.and` and `Filters.or` methods to combine filters in the JS/TS `v3` API.
+  <br/>
+
+  These methods take variadic arguments (e.g. `Filters.and(f1, f2, f3, ...)`). To pass an array (e.g. `fs`) as an argument, provide it like so: `Filters.and(...fs)` which will spread the array into its elements.
+  <br/>
+
+  <FilteredTextBlock
+    text={JavaScriptCode}
+    startMarker="// searchMultipleFiltersAnd"
+    endMarker="// END searchMultipleFiltersAnd"
+    language="js"
+  />
   </TabItem>
 
   <TabItem value="js2" label="JS/TS Client v2">
@@ -146,39 +185,6 @@ The output is like this:
 />
 
 </details>
-
-## Filter by all/any of multiple conditions
-
-The `v4` Python client API supports filtering by `any`, or `all` of a set of provided filters.
-
-<!-- TODO: Could update to this ⬇️ when ready:  -->
-<!-- The `v4` Python client and the `v3` JS client APIs supports filtering by `any`, or `all` of a set of provided filters.  -->
-
-#### Filter with `any of`
-
-<Tabs groupId="languages">
-  <TabItem value="py" label="Python Client v4">
-    <FilteredTextBlock
-      text={PyCode}
-      startMarker="# MultipleFiltersAllOfPython"
-      endMarker="# END MultipleFiltersAllOfPython"
-      language="python"
-    />
-  </TabItem>
-</Tabs>
-
-#### Filter with `all of`
-
-<Tabs groupId="languages">
-  <TabItem value="py" label="Python Client v4">
-    <FilteredTextBlock
-      text={PyCode}
-      startMarker="# MultipleFiltersAllOfPython"
-      endMarker="# END MultipleFiltersAllOfPython"
-      language="python"
-    />
-  </TabItem>
-</Tabs>
 
 ## Nested filters
 

--- a/developers/weaviate/search/filters.md
+++ b/developers/weaviate/search/filters.md
@@ -423,7 +423,7 @@ The output is like this:
 
 ## `ContainsAny` and `ContainsAll` with batch delete
 
-If you want to do a batch delete, see [Delete objects](../manage-data/delete.mdx#containsany--containsall). `ContainsAny` and `ContainsAll` have different behavior in batch deletion operations than they do in queries.
+If you want to do a batch delete, see [Delete objects](../manage-data/delete.mdx#use-containsany--containsall).
 
 ## Filter text on partial matches
 


### PR DESCRIPTION
### What's being changed:

- Add 'any_of' and 'all_of' examples to Py filters
- Add notes re usage for Py filters, as well as TS filters

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
