### PR TITLE
Update k8s grpc doc

### DIFF
--- a/developers/academy/deployment/k8s/30_setup_weaviate.mdx
+++ b/developers/academy/deployment/k8s/30_setup_weaviate.mdx
@@ -55,7 +55,11 @@ Open the `values.yaml` file in a text editor, and update the following sections:
 
 #### Enable the gRPC service
 
-Set the `enabled` field to `true` and the `type` field to `LoadBalancer`. This will expose the gRPC service as a LoadBalancer service, which will allow you to access it from outside the Kubernetes cluster, which in turn enables use of the [fast gRPC API](/blog/grpc-performance-improvements).
+:::info Default settings
+From helm chart version `17.0.0`, the gRPC service is enabled by default. If using older versions, you must enable it to use gRPC.
+:::
+
+Check that the service's `enabled` field is set to `true` and the `type` field is set to `LoadBalancer`. This will expose the gRPC service, which will allow you to access it from outside the Kubernetes cluster so you can make of the [gRPC API](/blog/grpc-performance-improvements).
 
 ```yaml
 grpcService:

--- a/developers/weaviate/installation/kubernetes.md
+++ b/developers/weaviate/installation/kubernetes.md
@@ -73,12 +73,27 @@ Out of the box, the configuration file is setup for:
 - Local models, such as `text2vec-transformers`, `qna-transformers` or
   `img2vec-neural` are disabled by default. They can be enabled by setting the
   respective `enabled` flag to `true`.
-- `grpcService` is disabled by default. If you want to use the gRPC API, set the
-  `enabled` flag to `true` and the `type` to the required type, such as `LoadBalancer`. This decision to disable the gRPC service by default is made for backward compatibility, and as different setups might require different configurations.
 
 See the resource requests and limits in the example `values.yaml`. You can
 adjust them based on your expected load and the resources available on the
 cluster.
+
+#### gRPC service configuration
+
+The `grpcService` must be enabled to use the gRPC API. It is enabled by default from helm chart version `v17.0.0`.
+
+Check that the `enabled` field is set to `true` and the `type` field to `LoadBalancer`. This allow you to access it from outside the Kubernetes cluster, which in turn enables use of the [fast gRPC API](/blog/grpc-performance-improvements).
+
+```yaml
+grpcService:
+  enabled: true  # ⬅️ Make sure this is set to true
+  name: weaviate-grpc
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 50051
+  type: LoadBalancer  # ⬅️ Set this to LoadBalancer (from NodePort)
+```
 
 #### Authentication and authorization
 


### PR DESCRIPTION
### What's being changed:

- Update Academy reference to using grpc service with k8s
- Add verbose instructions on k8s install page re grpc

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`