### PR TITLE
[build] Upgrade GitHub Actions to node 20

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -17,8 +17,8 @@ jobs:
       GOOGLE_CONTAINER_ID: ${{ secrets.GOOGLE_CONTAINER_ID }}
       GOOGLE_TRACKING_ID: ${{ secrets.GOOGLE_TRACKING_ID }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -8,8 +8,8 @@ jobs:
     name: Validate links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'yarn'


### PR DESCRIPTION
### What's being changed:

Change GH Actions to run with Node 20

### Type of change:

- [x] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **Github action** – automated build completed without errors
