### PR TITLE
Fix multi2vec-clip curl example

### DIFF
--- a/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip.md
+++ b/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip.md
@@ -297,7 +297,7 @@ to your `multi2vec-clip`.
 Then you can send REST requests to it directly, e.g.:
 
 ```shell
-localhost:9090/vectorize -d '{"texts": ["foo bar"], "images":[]}'
+curl localhost:9090/vectorize -d '{"texts": ["foo bar"], "images":[]}' --header 'Content-Type: application/json'
 ```
 
 and it will print the created vector(s) directly.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:
fixing curl example, from discussion:
https://forum.weaviate.io/t/curl-localhost-8080-vectorize-doesnt-work/2707

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **Github action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
