### PR TITLE
fix(docs): property 'insert' does not exist on type Collection

### DIFF
--- a/developers/weaviate/client-libraries/typescript/typescript-v3.mdx
+++ b/developers/weaviate/client-libraries/typescript/typescript-v3.mdx
@@ -254,7 +254,7 @@ type Article = {
 }
 
 const collection = client.collections.get<Article>('Article');
-await collection.insert({ // compiler error since 'body' field is missing in '.insert'
+await collection.data.insert({ // compiler error since 'body' field is missing in '.insert'
   title: 'TS is awesome!',
   wordcount: 9001
 })


### PR DESCRIPTION
### What's being changed:

Example of the code snippet in the generics of the ts-client

### Type of change:
- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?
- [ ] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
