### PR TITLE
Match docs to code using Cohere in 25_generate_vectors.mdx

### DIFF
--- a/developers/academy/py/starter_custom_vectors/102_object_collections/25_generate_vectors.mdx
+++ b/developers/academy/py/starter_custom_vectors/102_object_collections/25_generate_vectors.mdx
@@ -28,7 +28,7 @@ This will generate a vector for each movie in the dataset, which we can use when
 
 ### <i class="fa-solid fa-chalkboard"></i> Model
 
-We use the `sentence-transformers/all-MiniLM-L6-v2` model to generate the vectors. We access it here through the Hugging Face API for convenience. You could also use the `transformers` library, if you would like to perform the generation locally.
+We use the `embed-multilingual-v3.0` Cohere model to generate the vector embeddings. You could also use the `transformers` library, if you would like to perform the generation locally.
 
 ### <i class="fa-solid fa-code"></i> Source text
 


### PR DESCRIPTION
### What's being changed:

[<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->](https://weaviate.io/developers/academy/py/starter_custom_vectors/object_collections/generate_vectors#-model)

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### Bonus

Would help to explain in the [Source text](https://weaviate.io/developers/academy/py/starter_custom_vectors/object_collections/generate_vectors#-source-text) section why use one vector and concatenate properties, vs. use a separate (named) vector for each.