### PR TITLE
Fix version include

### DIFF
--- a/developers/weaviate/concepts/modules.md
+++ b/developers/weaviate/concepts/modules.md
@@ -24,7 +24,7 @@ This page explains what modules are, and what purpose they serve in Weaviate.
 
 ## Available module types
 
-This graphic displays the available modules for the latest Weaviate version (v||site.weaviate_version|). Modules are grouped into these categories:
+This graphic displays the available modules for the latest Weaviate version (||site.weaviate_version||) . Modules are grouped into these categories:
 
 - Vectorization modules
 - Vectorization and additional functionality modules


### PR DESCRIPTION
typo on modules page
[slack](https://weaviate-org.slack.com/archives/C04LB3DLSSG/p1720434358468299)
[staging](https://docs-typos-021--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/concepts/modules#available-module-types)