### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Thanks again!
 
 <!-- Please select all options that apply -->
 
-- [ ] **Github action** – automated build completed without errors
+- [ ] **GitHub action** – automated build completed without errors
 - [ ] **Local build** - the site works as expected when running `yarn start`
 
 > note, you can run `yarn verify-links` to test site links locally

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm install --global yarn
 To contribute to this web site, first fork this repository and create a local
 copy to work on.
 
-1. Log into your Github account.
+1. Log into your GitHub account.
 2. Fork the upstream repository, https://github.com/weaviate/weaviate-io.
 3. Clone the repository to your local system.
 

--- a/blog/2023-04-04-weaviate-retrieval-plugin/index.mdx
+++ b/blog/2023-04-04-weaviate-retrieval-plugin/index.mdx
@@ -26,7 +26,7 @@ In short, plugins give ChatGPT the ability to leverage third-party resources to 
 
 What we’re most excited about is **the Retrieval Plugin**, which allows you to use ChatGPT with a [Vector Database](https://weaviate.io/blog/what-is-a-vector-database) like Weaviate to overcome one of the biggest challenges that ChatGPT has struggled with: its lack of long-term memory, as well as its inability to provide responses based on internal documents and data. 🧠🔌
 
-This has the potential to be the most widely used plugin as it will allow users to create customized versions of ChatGPT catered to their own data. Don’t just take it from me, take it [from Greg](https://twitter.com/gdb/status/1640006228930867200), the Co-founder of OpenAI and the fact that the plugin was trending on Github!
+This has the potential to be the most widely used plugin as it will allow users to create customized versions of ChatGPT catered to their own data. Don’t just take it from me, take it [from Greg](https://twitter.com/gdb/status/1640006228930867200), the Co-founder of OpenAI and the fact that the plugin was trending on GitHub!
 
 ![gdbtweet](./img/gdbtweet.png)
 

--- a/blog/2023-05-05-generative-feedback-loops/index.mdx
+++ b/blog/2023-05-05-generative-feedback-loops/index.mdx
@@ -32,7 +32,7 @@ Here is a quick overview of the code snippets before diving in:
 ## Part 1: AirBnB Listing Example
 
 :::note
-The Github repo with notebooks (using Weaviate embedded) can be found [here](https://github.com/weaviate/Generative-Feedback-Loops/).
+The GitHub repo with notebooks (using Weaviate embedded) can be found [here](https://github.com/weaviate/Generative-Feedback-Loops/).
 :::
 
 In this example we will be using the OpenAI `text-davinci-003` and the Cohere `command-xlarge-nightly` LLMs to generate content, but this is also possible with other providers such as HuggingFace, Anthropic, and more. Set your OpenAI or Cohere key to use with Weaviate’s generate module using the following block of code:

--- a/blog/2024-01-23-typescript-multimodal-search/index.mdx
+++ b/blog/2024-01-23-typescript-multimodal-search/index.mdx
@@ -60,7 +60,7 @@ You need the following to go through with this tutorial.
 - [Docker](https://www.docker.com/)
 - [Git](https://git-scm.com/)
 
-> The project that this tutorial is based on is [available on Github](https://github.com/malgamves/next-multimodal-search-demo) if you’d like to give it a try before going through with the tutorial.
+> The project that this tutorial is based on is [available on GitHub](https://github.com/malgamves/next-multimodal-search-demo) if you’d like to give it a try before going through with the tutorial.
 
 
 Create your Next.js application that comes with TypeScript, Tailwind CSS and the App Router with the following command.

--- a/blog/2024-03-13-weaviate-champions/index.mdx
+++ b/blog/2024-03-13-weaviate-champions/index.mdx
@@ -24,7 +24,7 @@ Today, we have more than 25K members in our Community, and we are still growing 
 
 ![25000 user world mapWhat is RAG? Animation](./img/community_map.gif)
 
-Our Community is active across the web and in real life. We see engagement in channels like LinkedIn, Twitter, Github, Slack, Discourse, and StackOverflow, as well as at conferences, meetups, and hackathons. In all places community members:
+Our Community is active across the web and in real life. We see engagement in channels like LinkedIn, Twitter, GitHub, Slack, Discourse, and StackOverflow, as well as at conferences, meetups, and hackathons. In all places community members:
 
 - discuss the most recent developments in Open Source and AI
 - share their knowledge on how to build amazing AI-native applications with Weaviate
@@ -78,7 +78,7 @@ To make this program transparent and coherent across all areas of our Community,
 
 ### Contributions & Engagement
 
-Weaviate Heroes are passionate about Weaviate. They build AI-native applications and contribute back to our community and product roadmap in a true open-source manner. Members of the Weaviate Hero program share their ideas, thoughts, and feedback to improve Weaviate through GitHub, Slack, or direct conversations with our engineers. 
+Weaviate Heroes are passionate about Weaviate. They build AI-native applications and contribute back to our community and product roadmap in a true open-source manner. Members of the Weaviate Hero program share their ideas, thoughts, and feedback to improve Weaviate through GitHub, Slack, or direct conversations with our engineers.
 
 They engage in early access initiatives and share their knowledge and experience in various ways, like answering Questions in our Open Slack Community, the Weaviate Forum, or Stack Overflow, joining our Podcasts or live streams, publishing blog posts, or attending community and in-person events.
 
@@ -110,7 +110,7 @@ This is only a small excerpt of possibilities - our primary goal is to reward ac
 
 ### Education & Elevation
 
-Celebrating and rewarding contributions of all kinds is only the first step to appreciating and valuing the time and effort community members invest into enabling and helping others be successful. The second step is to enable, educate, and elevate Weaviate Heroes themselves. 
+Celebrating and rewarding contributions of all kinds is only the first step to appreciating and valuing the time and effort community members invest into enabling and helping others be successful. The second step is to enable, educate, and elevate Weaviate Heroes themselves.
 
 Dedicated content and materials that can help better understand core - and advanced - concepts around various interesting topics.
 
@@ -131,17 +131,17 @@ Our Weaviate Hero Program only exists because we already have many great people 
   style={{ maxWidth: "30%" , paddingRight:"20px"}}
 />
 
-Ron is an exceptional, humble, and supportive person, and his journey through tech is quite fascinating. Ron grew up as a child of the 1960s with a love of science fiction and fantasy. 
+Ron is an exceptional, humble, and supportive person, and his journey through tech is quite fascinating. Ron grew up as a child of the 1960s with a love of science fiction and fantasy.
 It was his fascination with Star Trek that led him into the world of computer technology. In 1980, Ron started his own business, Software Creations, and began developing and marketing his first software packages (still distributed by postal mail on floppy disks).
 
-Needless to say, Ron has been witness to the entire modern Information Revolution: From the bulletin board services to the Internet, from MS DOS to MS Windows, from command line interfaces to GUI point and click, from shoebox-sized cellular telephones to smartphones. 
+Needless to say, Ron has been witness to the entire modern Information Revolution: From the bulletin board services to the Internet, from MS DOS to MS Windows, from command line interfaces to GUI point and click, from shoebox-sized cellular telephones to smartphones.
 
 Ron says:
 
 > *“I’ve seen it all. But, I’ve always been a passenger, in the back seat, along for the ride.
 If you can’t tell already, I’m an old man. However, when OpenAI announced their Artificial Intelligence models in late 2022, I was filled once again with the fascination and passion of my youth. I had to be a part of this new revolution, but this time I wanted to be in the front seat. I did it once, I could do it again.”*
 
-Ron is very passionate about supporting community members, as this is precisely how he grows stronger in his knowledge and learns new things. Remembering how difficult it was when he had questions that he couldn’t get answered, he hopes he can inspire others to both grow and lend a hand to their fellow developer when they can. 
+Ron is very passionate about supporting community members, as this is precisely how he grows stronger in his knowledge and learns new things. Remembering how difficult it was when he had questions that he couldn’t get answered, he hopes he can inspire others to both grow and lend a hand to their fellow developer when they can.
 Reach out to Ron in our [Slack Community](https://weaviate.slack.com/team/U04TUKD2RK7) or on [LinkedIn](https://www.linkedin.com/in/ron-parker-scbbs/)
 
 ### Patrice Bourgougnon
@@ -180,7 +180,7 @@ You find Patrice in our [Weaviate Community Slack](https://weaviate.slack.com/te
 
 Travis is a technologist and product leader at [Innovative Solutions](https://innovativesol.com/), who has worked with AWS for over 10 years. As an entrepreneur who has built, grown, and sold cloud-first companies, Travis sees how developing in the cloud impacts the business and competitiveness of customers. Leading the Product and Services team at Innovative, Travis is an advocate for GenAI-enabled solutions and speaks on industry trends and challenges in this space.
 
-When we asked Travis what inspires him the most, his answer was, 
+When we asked Travis what inspires him the most, his answer was,
 
 > *“Trying new things when everyone rolls their eyes or says it's not possible. The challenge of the unknown can be incredibly alluring and its what drives me to get out of my comfort zone.”*
 
@@ -194,7 +194,7 @@ Take a look, and follow along on our [Weaviate Hero Website](/community).
 
 Are you as excited about the Weaviate Hero Program as we are? Did our heroes inspire you, and would you like to become a Weaviate Hero yourself?
 
-As a first step, start engaging in our open source community by collaborating with other community members in our [forum.weaviate.io](http://forum.weaviate.io), inside our [open Weaviate Slack Community](http://weaviate.io/slack), with content on our  [blog](https://weaviate.io/blog) (or your own) or via social media. **EVERYONE** can become a hero!  
+As a first step, start engaging in our open source community by collaborating with other community members in our [forum.weaviate.io](http://forum.weaviate.io), inside our [open Weaviate Slack Community](http://weaviate.io/slack), with content on our  [blog](https://weaviate.io/blog) (or your own) or via social media. **EVERYONE** can become a hero!
 
 If you are already highly engaged with the Weaviate Community, share our core values, and like the idea of the Weaviate Hero program, you can [apply here to become a Weaviate Hero.](https://forms.gle/ENEGVmGQF2Tjvnze8)
 

--- a/blog/2024-03-28-hybrid-search-typescript/index.mdx
+++ b/blog/2024-03-28-hybrid-search-typescript/index.mdx
@@ -320,7 +320,7 @@ To view your application, run `npm run dev` in the root directory of your projec
 
 We've got a deployed version of this project that you can find at [quotefinder.weaviate.io](https://quotefinder.weaviate.io). If you'd like to dive into the code, you can take a look at the projects [GitHub repository](https://github.com/weaviate/quote-finder).
 
-The project on Github should look like this once cloned and started.
+The project on GitHub should look like this once cloned and started.
 
 ![A screenshot of the QuoteFinder](./img/quote-finder-screenshot.png)
 

--- a/developers/weaviate/client-libraries/typescript/typescript-v3.mdx
+++ b/developers/weaviate/client-libraries/typescript/typescript-v3.mdx
@@ -288,7 +288,7 @@ Here are some resources to help you get started using the client.
 
 ### Recipes
 
-The [recipes repository](https://github.com/weaviate/recipes-ts) on Github has sample code for common use cases.
+The [recipes repository](https://github.com/weaviate/recipes-ts) on GitHub has sample code for common use cases.
 
 ### Demo applications
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-require('dotenv').config(); 
+require('dotenv').config();
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const remarkReplace = require('./src/remark/remark-replace');
@@ -253,7 +253,7 @@ const config = {
         ],
     ],
 
-    
+
 
     themeConfig:
         /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
@@ -265,7 +265,7 @@ const config = {
                 backgroundColor: '#1C1468',
                 textColor: '#F5F5F5',
                 isCloseable: true,
-            }, 
+            },
             docs: {
                 sidebar: {
                     hideable: true,
@@ -291,7 +291,7 @@ const config = {
                                className: 'dropDownContainer2',
                             },
                         ]
-                        
+
                     },
                     {  type: 'dropdown',
                     label: 'Solutions',
@@ -302,7 +302,7 @@ const config = {
                             value : '<div class="holder"><ul class="holdRightnoBorder"><li class="dropDownLabel">Use Cases</li><li><a class="dropdown__link" href="/rag">RAG</a></li><li><a class="dropdown__link" href="/hybrid-search">Hybrid Search</a></li><li><a class="dropdown__link" href="/gen-feedback-loops">Generative Feedback Loops</a></li><li><a class="dropdown__link" href="/cost-performance-optimization">Cost-Performance Optimization</a></li></ul><div class="divider"></div><ul class="holdRightnoBorder"><li class="dropDownLabel" >Examples</li><li><a class="dropdown__link" href="/community/build-with-weaviate">Showcases</a></li><li><a class="dropdown__link" href="/community/demos">Demos</a></li></ul></div><ul class="menu__list mobileNav"><li class="menu__list-item"><a class="menu__link" href="/rag">RAG</a></li><li class="menu__list-item"><a class="menu__link" href="/hybrid-search">Hybrid Search</a></li><li class="menu__list-item"><a class="menu__link" href="/gen-feedback-loops">Generative Feedback Loops </a></li><li class="menu__list-item"><a class="menu__link" href="/deployment/enterprise-cloud">Infrastructure Optimization</a></li><li class="menu__list-item"><a class="menu__link" href="/community/build-with-weaviate">Showcases</a></li><li class="menu__list-item"><a class="menu__link" href="/community/demos">Demos</a></li></ul>',
                             className: 'dropDownContainer2',
                         },
-                        
+
                        /*  {
                             label: 'Serverless',
                             href: '/services/serverless',
@@ -330,7 +330,7 @@ const config = {
                         }, */
                     ]
                 },
-                
+
                 {
                         type: 'dropdown',
                         label: 'Developers',
@@ -338,7 +338,7 @@ const config = {
                         items: [
                             {
                                 type: 'html',
-                                value : '<div class="holder"><ul class="holdRightnoBorder"><li class="dropDownLabel">Build</li><li><a class="dropdown__link" href="/developers/weaviate">Documentation</a></li><li><a class="dropdown__link" href="/developers/wcs">Weaviate Cloud Docs</a></li><li><a class="dropdown__link" href="https://github.com/weaviate/weaviate">Github</a></li></ul><div class="divider"></div><ul class="holdRightnoBorder"><li class="dropDownLabel" >Learn</li><li><a class="dropdown__link" href="/blog">Blog</a></li><li><a class="dropdown__link" href="/developers/academy">Academy</a></li><li><a class="dropdown__link" href="/community/events">Workshops</a></li><li><a class="dropdown__link" href="/learn/knowledgecards">Knowledge Cards</a></li><li><a class="dropdown__link" href="/papers">Paper Reviews</a></li><li><a class="dropdown__link" href="/podcast">Podcasts</a></li></ul><div class="divider"></div><ul class="holdRightnoBorder"><li class="dropDownLabel" >Engage</li><li><a class="dropdown__link" href="/community/events">Events & Webinars</a></li><li><a class="dropdown__link" href="/community">Weaviate Hero Program</a></li><li><a class="dropdown__link" href="https://forum.weaviate.io/">Forum</a></li><li><a class="dropdown__link" href="https://weaviate.io/slack">Slack</a></li></ul></div><ul class="menu__list mobileNav"><li class="menu__list-item"><a class="menu__link" href="/developers/weaviate">Documentation</a></li><li class="menu__list-item"><a class="menu__link" href="/developers/wcs">Weaviate Cloud Docs</a></li><li class="menu__list-item"><a class="menu__link" href="https://github.com/weaviate/weaviate">Github</a></li><li class="menu__list-item"><a class="menu__link" href="/blog">Blog</a></li><li class="menu__list-item"><a class="menu__link" href="/developers/academy">Academy</a></li><li class="menu__list-item"><a class="menu__link" href="/community/events">Workshops</a></li><li class="menu__list-item"><a class="menu__link" href="/learn/knowledgecards">Knowledge Cards</a></li><li class="menu__list-item"><a class="menu__link" href="/papers">Paper Reviews</a></li><li class="menu__list-item"><a class="menu__link" href="/podcast">Podcasts</a></li><li class="menu__list-item"><a class="menu__link" href="/community/events">Events & Webinars</a></li><li class="menu__list-item"><a class="menu__link" href="/community">Weaviate Hero Program</a></li><li class="menu__list-item"><a class="menu__link" href="https://forum.weaviate.io/">Forum</a></li><li class="menu__list-item"><a class="menu__link" href="https://weaviate.io/slack">Slack</a></li></ul>',
+                                value : '<div class="holder"><ul class="holdRightnoBorder"><li class="dropDownLabel">Build</li><li><a class="dropdown__link" href="/developers/weaviate">Documentation</a></li><li><a class="dropdown__link" href="/developers/wcs">Weaviate Cloud Docs</a></li><li><a class="dropdown__link" href="https://github.com/weaviate/weaviate">GitHub</a></li></ul><div class="divider"></div><ul class="holdRightnoBorder"><li class="dropDownLabel" >Learn</li><li><a class="dropdown__link" href="/blog">Blog</a></li><li><a class="dropdown__link" href="/developers/academy">Academy</a></li><li><a class="dropdown__link" href="/community/events">Workshops</a></li><li><a class="dropdown__link" href="/learn/knowledgecards">Knowledge Cards</a></li><li><a class="dropdown__link" href="/papers">Paper Reviews</a></li><li><a class="dropdown__link" href="/podcast">Podcasts</a></li></ul><div class="divider"></div><ul class="holdRightnoBorder"><li class="dropDownLabel" >Engage</li><li><a class="dropdown__link" href="/community/events">Events & Webinars</a></li><li><a class="dropdown__link" href="/community">Weaviate Hero Program</a></li><li><a class="dropdown__link" href="https://forum.weaviate.io/">Forum</a></li><li><a class="dropdown__link" href="https://weaviate.io/slack">Slack</a></li></ul></div><ul class="menu__list mobileNav"><li class="menu__list-item"><a class="menu__link" href="/developers/weaviate">Documentation</a></li><li class="menu__list-item"><a class="menu__link" href="/developers/wcs">Weaviate Cloud Docs</a></li><li class="menu__list-item"><a class="menu__link" href="https://github.com/weaviate/weaviate">GitHub</a></li><li class="menu__list-item"><a class="menu__link" href="/blog">Blog</a></li><li class="menu__list-item"><a class="menu__link" href="/developers/academy">Academy</a></li><li class="menu__list-item"><a class="menu__link" href="/community/events">Workshops</a></li><li class="menu__list-item"><a class="menu__link" href="/learn/knowledgecards">Knowledge Cards</a></li><li class="menu__list-item"><a class="menu__link" href="/papers">Paper Reviews</a></li><li class="menu__list-item"><a class="menu__link" href="/podcast">Podcasts</a></li><li class="menu__list-item"><a class="menu__link" href="/community/events">Events & Webinars</a></li><li class="menu__list-item"><a class="menu__link" href="/community">Weaviate Hero Program</a></li><li class="menu__list-item"><a class="menu__link" href="https://forum.weaviate.io/">Forum</a></li><li class="menu__list-item"><a class="menu__link" href="https://weaviate.io/slack">Slack</a></li></ul>',
                                 className: 'dropDownContainer2',
                             },
                          /*    {
@@ -456,11 +456,11 @@ const config = {
                         ], */
                     },
                     {
-                       
+
                         label: 'Pricing',
                         position: 'right',
                         href: '/pricing',
-                        
+
                     },
                     {
                         html: `<svg class="githubStars" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>`,

--- a/src/components/ContactUsForm/index.jsx
+++ b/src/components/ContactUsForm/index.jsx
@@ -16,7 +16,7 @@ export default function ContactUsForm({ theme = 'light' }) {
       value: 'searchEngine',
       text: 'Search engine (e.g., Google or DuckDuckGo)',
     },
-    { value: 'githubList', text: 'Github List' },
+    { value: 'githubList', text: 'GitHub List' },
     { value: 'reddit', text: 'Reddit' },
     { value: 'twitter', text: 'Twitter' },
     { value: 'friend', text: 'A friend' },

--- a/src/components/Documentation/Home/index.jsx
+++ b/src/components/Documentation/Home/index.jsx
@@ -318,7 +318,7 @@ const DocHomePage = () => {
         <div className={styles.secondaryContent}>
           <h3>Can we help?</h3>
           <div className={`${styles.secondaryTabs} ${styles.github}`}>
-            <a href="https://github.com/weaviate/weaviate">Github</a>
+            <a href="https://github.com/weaviate/weaviate">GitHub</a>
           </div>
           <div className={`${styles.secondaryTabs} ${styles.forum}`}>
             <a href="https://forum.weaviate.io/">Community forum</a>

--- a/src/pages/privacy/index.md
+++ b/src/pages/privacy/index.md
@@ -219,7 +219,7 @@ Kindly note that our websites may contain links to websites of third parties. Th
 <br></br>
 
 - [YouTube](https://www.youtube.com/t/terms);
-- [Github](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement);
+- [GitHub](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement);
 - [Slack](https://slack.com/trust/privacy/privacy-policy);
 - [Discourse](https://www.discourse.org/privacy);
 - [AWS](https://aws.amazon.com/privacy/);

--- a/static/data/resources.json
+++ b/static/data/resources.json
@@ -120,7 +120,7 @@
     "title": "BigGraph Wikidata dataset",
     "date": "2021-12-01T00:00:00.000Z",
     "cover_image": "https://opengraph.githubassets.com/8a137d82f4edc11c85cacfe69a16fd29936215d59a1d993569af8f89ed15c384/semi-technologies/biggraph-wikidata-search-with-weaviate",
-    "description": "In this repository on Github, you'll find a guide on how you can import the complete Wikidata PBG model into a Weaviate.",
+    "description": "In this repository on GitHub, you'll find a guide on how you can import the complete Wikidata PBG model into a Weaviate.",
     "source": "github",
     "link": "https://github.com/weaviate/biggraph-wikidata-search-with-weaviate",
     "tags": [


### PR DESCRIPTION
GitHub was written as Github in the site dropdown. Turned out to be that way in a few places.

[staging](https://docs-typos-023--tangerine-buttercream-20c32f.netlify.app/)  


