### PR TITLE
Fix – get the highest package version (not latest) to include in the docs

### DIFF
--- a/_build_scripts/update-config-versions.js
+++ b/_build_scripts/update-config-versions.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
 const getRepoVersion = async (repoName) => {
-    const response = await fetch(
-        `https://api.github.com/repos/weaviate/${repoName}/releases/latest`,
+    const response = await fetch( // fetch all release versions
+        `https://api.github.com/repos/weaviate/${repoName}/releases`,
         {
             method: 'GET',
             headers: {
@@ -14,12 +14,18 @@ const getRepoVersion = async (repoName) => {
         }
     );
 
-    const repoData = await response.json();
+    const releases = await response.json();
+    const highestVersion = releases
+        .filter(item => !item.prerelease) // remove pre-release items
+        .map(item => item.tag_name)       // keep only the tag_name
+        .sort()                           // sort items alphabetically – ascending
+        .pop()                            // the last item contains the highest version (what we need)
+        .replace('v', '')                 // remove the v from the name "v1.26.1" => "1.26.1"
 
-    const version = repoData.tag_name.match(/\d{1,2}\.\d{1,2}\.\d{1,2}/g)[0]
-    return version;
+    console.log(`${repoName} ${highestVersion}`)
+
+    return highestVersion;
 }
-
 
 // Build time versions replace values set in versions-config.json
 // versions-config.json values are used for yarn local yarn builds


### PR DESCRIPTION
### What's being changed:

Changing the script that gets the release version from GitHub to be the highest version, not the latest.
In some cases i.e. weaviate/weaviate 1.25.11 was released after 1.26.1, which caused the injected version in the docs to show as 1.25.1, instead of the preferred 1.26.1

### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [x] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
