### PR TITLE
counts should correspond

### DIFF
--- a/developers/weaviate/concepts/vector-index.md
+++ b/developers/weaviate/concepts/vector-index.md
@@ -9,7 +9,7 @@ Vector indexing is a key component of vector databases. It can help to [signific
 
 Weaviate's vector-first storage system takes care of all storage operations with a vector index. Storing data in a vector-first manner not only allows for semantic or context-based search, but also makes it possible to store *very* large amounts of data without decreasing performance (assuming scaled well horizontally or having sufficient shards for the indexes).
 
-Weaviate supports two types of vector indexing:
+Weaviate supports these vector index types:
 * [flat index](#flat-index): a simple, lightweight index that is designed for small datasets.
 * [HNSW index](#hnsw-index): a more complex index that is slower to build, but it scales well to large datasets as queries have a logarithmic time complexity.
 * [dynamic index](#dynamic-index): allows you to automatically switch from a flat index to an HNSW index as object count scales


### PR DESCRIPTION
Text says two types and lists three things.

Make the text correspond to the quantity

[staging](https://index-type-count--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/concepts/vector-index)