### PR TITLE
remove tokenization place holder

### DIFF
--- a/developers/weaviate/search/bm25.md
+++ b/developers/weaviate/search/bm25.md
@@ -361,15 +361,6 @@ import TknTsCodeLegacy from '!!raw-loader!/_includes/code/howto/manage-data.coll
     />
   </TabItem>
 
-  <TabItem value="go" label="Go">
-    <FilteredTextBlock
-      text={GoCode}
-      startMarker="// START PropModuleSettings"
-      endMarker="// END PropModuleSettings"
-      language="go"
-    />
-  </TabItem>
-
   <TabItem value="js2" label="JS/TS Client v2">
     <FilteredTextBlock
       text={TknTsCodeLegacy}


### PR DESCRIPTION
Remove placeholder so it doesn't leave an empty tab

[staging](https://tokenization-placeholder--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/search/bm25#set-tokenization)