### PR TITLE
Learning Centre - JPH proposed edits

### DIFF
--- a/src/components/Learn/Documentation/index.jsx
+++ b/src/components/Learn/Documentation/index.jsx
@@ -11,8 +11,7 @@ export default function Documentation() {
         <div className={styles.header}>
           <h2>Documentation</h2>
           <p>
-            Training courses, resources, and support options for builders of all
-            levels.<br></br> We’re with you on your AI journey.
+            How-tos, concepts, guides, and technical references
           </p>
         </div>
         <div className={styles.boxContainer}>
@@ -23,7 +22,7 @@ export default function Documentation() {
                 <h2>Docs: Integration guides</h2>
               </div>
               <div className={styles.typeText}>
-                <p>How Weaviate integrates with various Al model providers</p>
+                <p>How to use Weaviate with various Al model providers</p>
                 <div className={styles.integrations}>
                   <p>AWS</p>
                   <p>Cohere</p>
@@ -38,35 +37,39 @@ export default function Documentation() {
                   to="/developers/weaviate/model-providers"
                   className={styles.button}
                 >
-                  Learn More
+                  Model provider integrations pages
                 </Link>
               </div>
             </div>
             <div className={styles.typeBox}>
               <div className={styles.typeIcon}>
                 <div className={`${styles.homeIcon} ${styles.starter}`}></div>
-                <h2>Docs: Starter guides</h2>
+                <h2>Docs: Concepts</h2>
               </div>
               <div className={styles.typeText}>
                 <p>
-                  Intermediate level workshops, or webinars with industry users
+                  In-depth explanations of key features and ideas that power Weaviate
                 </p>
                 <ul>
                   <li>
-                    <strong>Connect to Weaviate:</strong> Different ways to
-                    connect to Weaviate
+                    <strong>Data structures</strong> explained for
+                    collections and tenants
                   </li>
                   <li>
-                    <strong>Generative search (RAG):</strong> A basic guide to
-                    retrieval augmented generation
+                    <strong>Vector indexing</strong> helps perform
+                    fast and effective searches
+                  </li>
+                  <li>
+                    <strong>Compression</strong> reduces resource usage with
+                    minimal loss of search quality
                   </li>
                 </ul>
 
                 <Link
-                  to="/developers/weaviate/starter-guides"
+                  to="/developers/weaviate/concepts"
                   className={styles.button}
                 >
-                  Learn More
+                  All concepts pages
                 </Link>
               </div>
             </div>
@@ -77,25 +80,25 @@ export default function Documentation() {
               </div>
               <div className={styles.typeText}>
                 <p>
-                  Intermediate level workshops, or webinars with industry users
+                  Concise snippets to help you perform specific tasks
                 </p>
                 <ul>
                   <li>
-                    <strong>Manage data:</strong> Manage collections, create
-                    objects, read objects, migrate data, ...
+                    <strong>Install:</strong> with Docker, Kubernetes, ...
                   </li>
                   <li>
-                    <strong>Search:</strong> Basics, similarity, hybrid, image,
-                    generative, reranking, filters, ...
+                    <strong>Connect:</strong> to Weaviate
+                  </li>
+                  <li>
+                    <strong>Manage data:</strong> Manage collections & data
+                  </li>
+                  <li>
+                    <strong>Search:</strong> find the data you want
+                  </li>
+                  <li>
+                    <strong>Configure:</strong> Weaviate and its features
                   </li>
                 </ul>
-
-                <Link
-                  to="developers/weaviate/installation"
-                  className={styles.button}
-                >
-                  Learn More
-                </Link>
               </div>
             </div>
             <div className={styles.typeBox}>
@@ -107,21 +110,19 @@ export default function Documentation() {
               </div>
               <div className={styles.typeText}>
                 <p>
-                  Intermediate level workshops, or webinars with industry users
+                  Detailed feature and API information
                 </p>
                 <ul>
                   <li>
-                    <strong> API references:</strong> Manage collections, create
-                    objects, read objects, migrate data, ...
+                    <strong> API references:</strong> REST, GraphQL, gRPC
                   </li>
                   <li>
-                    <strong>Configuration:</strong> ..
+                    <strong>Configuration:</strong> Collection definitions, data types, environment variables, ...
+                  </li>
+                  <li>
+                    <strong> Client libraries:</strong> Python, TypeScript / JavaScript, Go, Java
                   </li>
                 </ul>
-
-                <Link to="/developers/weaviate/api" className={styles.button}>
-                  Learn More
-                </Link>
               </div>
             </div>
           </div>

--- a/src/components/Learn/Examples/index.jsx
+++ b/src/components/Learn/Examples/index.jsx
@@ -11,8 +11,7 @@ export default function Examples() {
         <div className={styles.header}>
           <h2>Code Examples</h2>
           <p>
-            Training courses, resources, and support options for builders of all
-            levels.<br></br> We’re with you on your AI journey.
+            Go straight to the <i>source</i> and view these examples
           </p>
         </div>
         <div className={styles.boxContainer}>
@@ -24,8 +23,7 @@ export default function Examples() {
               </div>
               <div className={styles.typeText}>
                 <p>
-                  Self-contained, end-to-end code examples for builders (PY & JS
-                  only)
+                  End-to-end code examples for builders
                 </p>
                 <ul>
                   <li>
@@ -39,10 +37,10 @@ export default function Examples() {
                 </ul>
 
                 <Link
-                  to="/docs/getting-started/quickstart"
+                  to="https://github.com/weaviate/recipes"
                   className={styles.button}
                 >
-                  Learn More
+                  Weaviate recipes on GitHub
                 </Link>
               </div>
             </div>
@@ -58,12 +56,6 @@ export default function Examples() {
                   <li>Project A:</li>
                   <li>Project B:</li>
                 </ul>
-                <Link
-                  to="/docs/getting-started/quickstart"
-                  className={styles.button}
-                >
-                  Learn More
-                </Link>
               </div>
             </div>
           </div>
@@ -74,23 +66,23 @@ export default function Examples() {
               <h2>Weaviate repositories</h2>
             </div>
             <div className={`${styles.typeText} ${styles.large}`}>
-              <p>We are proudly open source! Here are our key repositories</p>
+              <p>We are proudly open source! Here are some of our main repositories</p>
               <div className={styles.intergrations}>
                 <ul>
-                  <li>weaviate: The "core" database & web server</li>
-                  <li>weaviate-python-client: Python SDK</li>
-                  <li>typescript-client: TS/JS SDK</li>
+                  <li><code>weaviate</code>: The "core" database & web server</li>
+                  <li><code>weaviate-python-client</code>: Python SDK</li>
+                  <li><code>typescript-client</code>: TS/JS SDK</li>
                 </ul>
                 <ul>
-                  <li>weaviate-go-client: Go(lang) SDK</li>
-                  <li>java-client: Java SDK</li>
+                  <li><code>weaviate-go-client</code>: Go(lang) SDK</li>
+                  <li><code>java-client</code>: Java SDK</li>
                 </ul>
               </div>
               <Link
-                to="/docs/getting-started/quickstart"
+                to="https://github.com/weaviate"
                 className={styles.button}
               >
-                Learn More
+                Weaviate repositories on GitHub
               </Link>
             </div>
           </div>

--- a/src/components/Learn/Further/index.jsx
+++ b/src/components/Learn/Further/index.jsx
@@ -11,8 +11,8 @@ export default function GoFurther() {
         <div className={styles.header}>
           <h2>Go Further</h2>
           <p>
-            Training courses, resources, and support options for builders of all
-            levels.<br></br> We’re with you on your AI journey.
+            There's much more to explore. Ask questions, learn about the<br/>
+            latest in AI & data science and dive into big topics from the experts
           </p>
         </div>
         <div className={styles.boxContainer}>

--- a/src/components/Learn/GetStarted/index.jsx
+++ b/src/components/Learn/GetStarted/index.jsx
@@ -11,8 +11,7 @@ export default function GetStarted() {
         <div className={styles.header}>
           <h2>Get Started</h2>
           <p>
-            Training courses, resources, and support options for builders of all
-            levels.<br></br> We’re with you on your AI journey.
+            See what you can do with Weaviate through demos and hands-on guides
           </p>
         </div>
         <div className={styles.boxContainer}>
@@ -23,12 +22,12 @@ export default function GetStarted() {
                 <h2>Quickstart guide</h2>
               </div>
               <div className={styles.typeText}>
-                <p>See what you can do with Weaviate, in 20-30 minutes</p>
+                <p>Essential Weaviate concepts demonstrated (20-30 minutes).</p>
                 <Link
                   to="/docs/getting-started/quickstart"
                   className={styles.button}
                 >
-                  Learn More
+                  Weaviate quickstart
                 </Link>
               </div>
             </div>
@@ -39,11 +38,10 @@ export default function GetStarted() {
               </div>
               <div className={styles.typeText}>
                 <p>
-                  Live, <strong>introductory</strong> workshops for Weaviate
-                  with code & key concepts
+                  <strong>Introductory</strong> workshops for Weaviate with an instructor (60 minutes).
                 </p>
                 <Link to="/community/events" className={styles.button}>
-                  Learn More
+                  Weaviate workshops
                 </Link>
               </div>
             </div>
@@ -55,18 +53,19 @@ export default function GetStarted() {
               <h2>Docs: Starter guides</h2>
             </div>
             <div className={`${styles.typeText} ${styles.large}`}>
-              <p>Short guides for common task types</p>
+              <p>Roadmaps for important topics</p>
               <ul>
                 <li>Connect to Weaviate</li>
                 <li>Generative search (RAG)</li>
                 <li>Which Weaviate is right for me?</li>
-                <li>Schema (collection definitions)</li>
+                <li>Collection definitions & data schema</li>
+                <li>Managing resources (hot, warm & cold)</li>
               </ul>
               <Link
                 to="/developers/weaviate/starter-guides"
                 className={styles.button}
               >
-                Learn More
+                Starter guides
               </Link>
             </div>
           </div>

--- a/src/components/Learn/Guides/index.jsx
+++ b/src/components/Learn/Guides/index.jsx
@@ -11,8 +11,7 @@ export default function Guides() {
         <div className={styles.header}>
           <h2>Guided Courses</h2>
           <p>
-            Training courses, resources, and support options for builders of all
-            levels.<br></br> We’re with you on your AI journey.
+            Structured learning paths for Weaviate mastery.
           </p>
         </div>
         <div className={styles.boxContainer}>
@@ -24,8 +23,7 @@ export default function Guides() {
 
             <div className={`${styles.typeText} ${styles.large}`}>
               <p>
-                End-to-end courses designed to accelerate your<br></br> Weaviate
-                learning journey
+                End-to-end courses designed by the Weaviate team
               </p>
 
               <ul>
@@ -41,6 +39,9 @@ export default function Guides() {
                 </li>
                 <li>
                   <strong>PY_250</strong>: Vector compression
+                </li>
+                <li>
+                  <strong>PY_280</strong>: Multi-tenancy
                 </li>
               </ul>
 
@@ -61,7 +62,7 @@ export default function Guides() {
               </ul>
 
               <Link to="/developers/academy" className={styles.button}>
-                Learn More
+                Weaviate Academy
               </Link>
             </div>
           </div>
@@ -78,12 +79,6 @@ export default function Guides() {
                   <li>DeepLearning.ai: Course 1, Course 2</li>
                   <li>Linkedin Learning: Course 1, Course 2</li>
                 </ul>
-                <Link
-                  to="/developers/weaviate/tutorials"
-                  className={styles.button}
-                >
-                  Learn More
-                </Link>
               </div>
             </div>
             <div className={styles.typeBox}>
@@ -110,7 +105,7 @@ export default function Guides() {
                   to="/community/events#on-demand-webinar"
                   className={styles.button}
                 >
-                  Learn More
+                  Workshops and Webinars
                 </Link>
               </div>
             </div>

--- a/src/components/Learn/Header/index.jsx
+++ b/src/components/Learn/Header/index.jsx
@@ -12,9 +12,19 @@ export default function Header() {
           <div className={styles.box}>
             <h1>Weaviate Learning Centre</h1>
             <p>
-              Training courses, resources, and support options for<br></br>{' '}
-              builders of all levels. We’re with you on your AI journey.
+              A learning resources hub for builders of all levels.
             </p>
+            <div className={styles.boxContainer}>
+              <Link to="#get-started">Get started</Link>
+              &nbsp;|&nbsp;
+              <Link to="#guided-courses">Guided courses</Link>
+              &nbsp;|&nbsp;
+              <Link to="#documentation">Documentation</Link>
+              &nbsp;|&nbsp;
+              <Link to="#code-examples">Code examples</Link>
+              &nbsp;|&nbsp;
+              <Link to="#go-further">Go further</Link>
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/learn/index.jsx
+++ b/src/pages/learn/index.jsx
@@ -9,7 +9,6 @@ import Documentation from '/src/components/Learn/Documentation';
 import Examples from '/src/components/Learn/Examples';
 import Guides from '/src/components/Learn/Guides';
 import GoFurther from '/src/components/Learn/Further';
-import Resources from '/src/components/Learn/Resources';
 import ThemeSwitch from '/src/components/ThemeSwitch';
 
 export default function Home() {
@@ -22,7 +21,6 @@ export default function Home() {
         <MetaSEO img="og/website/home.jpg" />
         <Header />
         <main>
-          <Resources />
           <GetStarted />
           <Guides />
           <Documentation />


### PR DESCRIPTION
### What's being changed:

Proposed edits to the draft "Learning Centre" section

- Remove the "Resources" section and move the section links to the Header element. 
    - Have not deleted the React component; should delete if we decide to go with this
- Formatting for repo names to use `<code>`
- Removed links on the bottom on cards where there isn't one appropriate link. 
    - With the idea that each `<li>` item would become a link
    - If agreed, we (JP/docs) can add links
- Copyedits

- Outstanding:
    - Example repos need to be added (unsure what)
    - The "Go Further" cards need padding underneath when browser width very narrow. They stack on top of each other as a 2x2 without any spacing


### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
