### PR TITLE
fix replication example and async repair link

### DIFF
--- a/_includes/code/howto/manage-data.collections.py
+++ b/_includes/code/howto/manage-data.collections.py
@@ -402,6 +402,36 @@ assert config.vector_index_config.distance_metric.value == "cosine"
 client.close()
 
 # =======================
+# ===== REPLICATION =====
+# =======================
+
+client = weaviate.connect_to_local(
+    port=8180  # Port for demo setup with 3 replicas
+)
+
+# clean slate
+client.collections.delete("Article")
+# START ReplicationSettings
+from weaviate.classes.config import Configure
+
+client.collections.create(
+    "Article",
+    # highlight-start
+    replication_config=Configure.replication(
+        factor=3,
+    )
+    # highlight-end
+)
+# END ReplicationSettings
+
+# Test
+collection = client.collections.get("Article")
+config = collection.config.get()
+assert config.replication_config.factor == 3
+
+client.close()
+
+# =======================
 # ===== REPLICATION WITH ASYNC REPAIR ====
 # =======================
 

--- a/_includes/configuration/consistency-repair-intro.mdx
+++ b/_includes/configuration/consistency-repair-intro.mdx
@@ -1,3 +1,3 @@
 When Weaviate detects inconsistent data across nodes, it attempts to repair the out of sync nodes.
 
-Starting in v1.26, Weaviate adds [async replication](/developers/weaviate/concepts/replication-architecture/consistency#asynchronous-repair) to proactively detect inconsistencies. In earlier versions, Weaviate uses a [repair-on-read](/developers/weaviate/concepts/replication-architecture/consistency#repair-on-read) strategy to repair inconsistencies at read time.
+Starting in v1.26, Weaviate adds [async replication](/developers/weaviate/concepts/replication-architecture/consistency#async-replication) to proactively detect inconsistencies. In earlier versions, Weaviate uses a [repair-on-read](/developers/weaviate/concepts/replication-architecture/consistency#repair-on-read) strategy to repair inconsistencies at read time.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:
the replication factor for pyv4 was missing, and there was a wrong link to async repair due to anchor change.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
