### PR TITLE
Add Search Snippets for Java Client

### DIFF
--- a/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/BasicSearch.java
+++ b/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/BasicSearch.java
@@ -1,0 +1,96 @@
+package io.weaviate.docs.search;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.data.model.WeaviateObject;
+import io.weaviate.docs.helper.EnvHelper;
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("crud")
+@Tag("search")
+public class BasicSearch {
+
+  private static WeaviateClient client;
+
+  @BeforeAll
+  public static void beforeAll() {
+    String scheme = EnvHelper.scheme("http");
+    String host = EnvHelper.host("localhost");
+    String port = EnvHelper.port("8080");
+
+    Config config = new Config(scheme, host + ":" + port);
+    client = new WeaviateClient(config);
+
+    Result<Boolean> result = client.schema().allDeleter().run();
+    assertThat(result).isNotNull()
+      .withFailMessage(() -> result.getError().toString())
+      .returns(false, Result::hasErrors)
+      .withFailMessage(null)
+      .returns(true, Result::getResult);
+  }
+
+  @Test
+  public void shouldPerformBasicSearch() {
+    String className = "Article";
+    String tenantName = "TenantA";
+
+    listObjects(className);
+    limitReturnedObjects(className);
+    paginateObjects(className);
+    retrieveObjectVector(className);
+    retrieveTenant(className, tenantName);
+  }
+
+  private void listObjects(String className) {
+    // START BasicGet
+    Result<List<WeaviateObject>> resultObj = client.data().objectsGetter()
+      .withClassName(className)
+      .run();
+    // END BasicGet
+  }
+
+  //Metadata Returns as well
+  private void limitReturnedObjects(String className) {
+    // START GetWithLimit  // START GetObjectIdJS // START GetWithMetadata
+    Result<List<WeaviateObject>> resultObj = client.data().objectsGetter()
+      .withClassName(className)
+      .withLimit(1) // Metadata and Object IDs are included by default with the Java client
+      .run();
+    // END GetWithLimit  // END GetObjectIdJS // END GetWithMetadata
+  }
+
+  private void paginateObjects(String className) {
+    // START GetWithOffset
+    Result<List<WeaviateObject>> resultObj = client.data().objectsGetter()
+      .withClassName(className)
+      .withLimit(1)
+      .withOffset(1)
+      .run();
+    // END GetWithOffset
+  }
+
+  private void retrieveObjectVector(String className) {
+    // START GetObjectVector
+    Result<List<WeaviateObject>> resultObj = client.data().objectsGetter()
+      .withClassName(className)
+      .withLimit(1)
+      .withVector()
+      .run();
+    // END GetObjectVector
+  }
+
+  private void retrieveTenant(String className, String tenantName) {
+    // START MultiTenancy
+    Result<List<WeaviateObject>> resultObj = client.data().objectsGetter()
+      .withClassName(className)
+      .withTenant(tenantName)
+      .withVector()
+      .run();
+    // END MultiTenancy
+  }
+}

--- a/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/BasicSearchTest.java
+++ b/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/BasicSearchTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 @Tag("crud")
 @Tag("search")
-public class BasicSearch {
+public class BasicSearchTest {
 
   private static WeaviateClient client;
 
@@ -38,11 +38,14 @@ public class BasicSearch {
   public void shouldPerformBasicSearch() {
     String className = "Article";
     String tenantName = "TenantA";
+    String propertyName = "body";
 
     listObjects(className);
     limitReturnedObjects(className);
     paginateObjects(className);
+    specifyObjectProperties(className, propertyName);
     retrieveObjectVector(className);
+    retrieveMetadata(className);
     retrieveTenant(className, tenantName);
   }
 
@@ -54,14 +57,13 @@ public class BasicSearch {
     // END BasicGet
   }
 
-  //Metadata Returns as well
   private void limitReturnedObjects(String className) {
-    // START GetWithLimit  // START GetObjectIdJS // START GetWithMetadata
+    // START GetWithLimit  // START GetObjectIdJS
     Result<List<WeaviateObject>> resultObj = client.data().objectsGetter()
       .withClassName(className)
-      .withLimit(1) // Metadata and Object IDs are included by default with the Java client
+      .withLimit(1) // Object IDs are included by default with the Java client
       .run();
-    // END GetWithLimit  // END GetObjectIdJS // END GetWithMetadata
+    // END GetWithLimit  // END GetObjectIdJS
   }
 
   private void paginateObjects(String className) {
@@ -74,6 +76,16 @@ public class BasicSearch {
     // END GetWithOffset
   }
 
+  private void specifyObjectProperties(String className, String propertyName) {
+    // START GetProperties
+    Result<List<WeaviateObject>> resultObj = client.data().objectsGetter()
+      .withClassName(className)
+      .withLimit(1)
+      .run();
+    resultObj.getResult().get(0).getProperties().get(propertyName);
+    // END GetProperties
+  }
+
   private void retrieveObjectVector(String className) {
     // START GetObjectVector
     Result<List<WeaviateObject>> resultObj = client.data().objectsGetter()
@@ -82,6 +94,16 @@ public class BasicSearch {
       .withVector()
       .run();
     // END GetObjectVector
+  }
+
+  private void retrieveMetadata(String className) {
+    // START GetWithMetadata
+    Result<List<WeaviateObject>> resultObj = client.data().objectsGetter()
+      .withClassName(className)
+      .run();
+    resultObj.getResult().get(0).getLastUpdateTimeUnix();
+    resultObj.getResult().get(0).getCreationTimeUnix();
+    // END GetWithMetadata
   }
 
   private void retrieveTenant(String className, String tenantName) {

--- a/developers/weaviate/search/basics.md
+++ b/developers/weaviate/search/basics.md
@@ -13,7 +13,7 @@ import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.basics-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.basics.ts';
 import TSCodeLegacy from '!!raw-loader!/_includes/code/howto/search.basics-v2.ts';
 import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/mainpkg/search-basic_test.go';
-import JavaCode from '!!raw-loader!/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/BasicSearch.java';
+import JavaCode from '!!raw-loader!/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/BasicSearchTest.java';
 
 With Weaviate you can query your data using [vector similarity search](./similarity.md), [keyword search](./bm25.md), or a mix of both with [hybrid search](./hybrid.md). You can control what object [properties](#specify-object-properties) and [metadata](#retrieve-metadata-values) to return.
 
@@ -334,6 +334,15 @@ You can specify which object properties to return.
     endMarker="// END GetProperties"
     language="go"
   />
+</TabItem>
+
+<TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetProperties"
+      endMarker="// END GetProperties"
+      language="java"
+    />
 </TabItem>
 
 <TabItem value="graphql" label="GraphQL">

--- a/developers/weaviate/search/basics.md
+++ b/developers/weaviate/search/basics.md
@@ -12,8 +12,8 @@ import PyCode from '!!raw-loader!/_includes/code/howto/search.basics.py';
 import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.basics-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.basics.ts';
 import TSCodeLegacy from '!!raw-loader!/_includes/code/howto/search.basics-v2.ts';
-import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/mainpkg/search-basic_test.go';
 import JavaCode from '!!raw-loader!/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/BasicSearchTest.java';
+import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/mainpkg/search-basic_test.go';
 
 With Weaviate you can query your data using [vector similarity search](./similarity.md), [keyword search](./bm25.md), or a mix of both with [hybrid search](./hybrid.md). You can control what object [properties](#specify-object-properties) and [metadata](#retrieve-metadata-values) to return.
 
@@ -335,6 +335,7 @@ You can specify which object properties to return.
     language="go"
   />
 </TabItem>
+
 
 <TabItem value="java" label="Java">
     <FilteredTextBlock
@@ -671,6 +672,7 @@ You can specify metadata fields to be returned.
     language="go"
   />
 </TabItem>
+
 
 <TabItem value="java" label="Java">
     <FilteredTextBlock

--- a/developers/weaviate/search/basics.md
+++ b/developers/weaviate/search/basics.md
@@ -13,7 +13,7 @@ import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.basics-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.basics.ts';
 import TSCodeLegacy from '!!raw-loader!/_includes/code/howto/search.basics-v2.ts';
 import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/mainpkg/search-basic_test.go';
-
+import JavaCode from '!!raw-loader!/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/BasicSearch.java';
 
 With Weaviate you can query your data using [vector similarity search](./similarity.md), [keyword search](./bm25.md), or a mix of both with [hybrid search](./hybrid.md). You can control what object [properties](#specify-object-properties) and [metadata](#retrieve-metadata-values) to return.
 
@@ -35,35 +35,30 @@ You can get objects without specifying any parameters. This returns objects in a
   </TabItem>
 
 <TabItem value="py3" label="Python Client v3">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# BasicGetPython"
   endMarker="# END BasicGetPython"
   language="py"
 />
-
 </TabItem>
-<TabItem value="js" label="JS/TS Client v3">
 
+<TabItem value="js" label="JS/TS Client v3">
 <FilteredTextBlock
   text={TSCode}
   startMarker="// BasicGetJS"
   endMarker="// END BasicGetJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="js2" label="JS/TS Client v2">
-
 <FilteredTextBlock
   text={TSCodeLegacy}
   startMarker="// BasicGetJS"
   endMarker="// END BasicGetJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="go" label="Go">
@@ -75,16 +70,24 @@ You can get objects without specifying any parameters. This returns objects in a
   />
 </TabItem>
 
-<TabItem value="graphql" label="GraphQL">
+<TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START BasicGet"
+      endMarker="// END BasicGet"
+      language="java"
+    />
+</TabItem>
 
+<TabItem value="graphql" label="GraphQL">
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# BasicGetGraphQL"
   endMarker="# END BasicGetGraphQL"
   language="graphql"
 />
-
 </TabItem>
+
 </Tabs>
 
 <details>
@@ -113,6 +116,7 @@ The output is like this:
 Use `limit` to set a fixed maximum number of objects to return.
 
 <Tabs groupId="languages">
+
 <TabItem value="py" label="Python Client v4">
 <FilteredTextBlock
   text={PyCode}
@@ -123,28 +127,24 @@ Use `limit` to set a fixed maximum number of objects to return.
 </TabItem>
 
 <TabItem value="py3" label="Python Client v3">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetWithLimitPython"
   endMarker="# END GetWithLimitPython"
   language="py"
 />
-
 </TabItem>
-<TabItem value="js" label="JS/TS Client v3">
 
+<TabItem value="js" label="JS/TS Client v3">
 <FilteredTextBlock
   text={TSCode}
   startMarker="// GetWithLimitJS"
   endMarker="// END GetWithLimitJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="js2" label="JS/TS Client v2">
-
 <FilteredTextBlock
   text={TSCodeLegacy}
   startMarker="// GetWithLimitJS"
@@ -161,17 +161,25 @@ Use `limit` to set a fixed maximum number of objects to return.
     language="go"
   />
 </TabItem>
+ 
+<TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetWithLimit"
+      endMarker="// END GetWithLimit"
+      language="java"
+    />
+</TabItem>
 
 <TabItem value="graphql" label="GraphQL">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetWithLimitGraphQL"
   endMarker="# END GetWithLimitGraphQL"
   language="graphql"
 />
-
 </TabItem>
+
 </Tabs>
 
 <details>
@@ -193,6 +201,7 @@ The output is like this:
 To start in the middle of your result set, define an `offset`. Set a `limit` to return objects starting at the offset.
 
 <Tabs groupId="languages">
+
 <TabItem value="py" label="Python Client v4">
 <FilteredTextBlock
   text={PyCode}
@@ -203,28 +212,24 @@ To start in the middle of your result set, define an `offset`. Set a `limit` to 
 </TabItem>
 
 <TabItem value="py3" label="Python Client v3">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetWithLimitOffsetPython"
   endMarker="# END GetWithLimitOffsetPython"
   language="py"
 />
-
 </TabItem>
-<TabItem value="js" label="JS/TS Client v3">
 
+<TabItem value="js" label="JS/TS Client v3">
 <FilteredTextBlock
   text={TSCode}
   startMarker="// GetWithLimitOffsetJS"
   endMarker="// END GetWithLimitOffsetJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="js2" label="JS/TS Client v2">
-
 <FilteredTextBlock
   text={TSCodeLegacy}
   startMarker="// GetWithLimitOffsetJS"
@@ -242,17 +247,24 @@ To start in the middle of your result set, define an `offset`. Set a `limit` to 
   />
 </TabItem>
 
+<TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetWithOffset"
+      endMarker="// END GetWithOffset"
+      language="java"
+    />
+</TabItem>
 
 <TabItem value="graphql" label="GraphQL">
-
-<FilteredTextBlock
-  text={PyCodeV3}
-  startMarker="# GetWithLimitOffsetGraphQL"
-  endMarker="# END GetWithLimitOffsetGraphQL"
-  language="graphql"
-/>
-
+  <FilteredTextBlock
+    text={PyCodeV3}
+    startMarker="# GetWithLimitOffsetGraphQL"
+    endMarker="# END GetWithLimitOffsetGraphQL"
+    language="graphql"
+  />
 </TabItem>
+
 </Tabs>
 
 <details>
@@ -277,6 +289,7 @@ To paginate through the entire database, use a [cursor](../manage-data/read-all-
 You can specify which object properties to return.
 
 <Tabs groupId="languages">
+
 <TabItem value="py" label="Python Client v4">
 <FilteredTextBlock
   text={PyCode}
@@ -288,35 +301,30 @@ You can specify which object properties to return.
 
 
 <TabItem value="py3" label="Python Client v3">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetPropertiesPython"
   endMarker="# END GetPropertiesPython"
   language="py"
 />
-
 </TabItem>
-<TabItem value="js" label="JS/TS Client v3">
 
+<TabItem value="js" label="JS/TS Client v3">
 <FilteredTextBlock
   text={TSCode}
   startMarker="// GetPropertiesJS"
   endMarker="// END GetPropertiesJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="js2" label="JS/TS Client v2">
-
 <FilteredTextBlock
   text={TSCodeLegacy}
   startMarker="// GetPropertiesJS"
   endMarker="// END GetPropertiesJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="go" label="Go">
@@ -329,15 +337,14 @@ You can specify which object properties to return.
 </TabItem>
 
 <TabItem value="graphql" label="GraphQL">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetPropertiesGraphQL"
   endMarker="# END GetPropertiesGraphQL"
   language="graphql"
 />
-
 </TabItem>
+
 </Tabs>
 
 <details>
@@ -359,6 +366,7 @@ The output is like this:
 You can retrieve the object vector. (Also applicable where [named vectors](../config-refs/schema/multi-vector.md) are used.)
 
 <Tabs groupId="languages">
+
 <TabItem value="py" label="Python Client v4">
 <FilteredTextBlock
   text={PyCode}
@@ -377,26 +385,23 @@ You can retrieve the object vector. (Also applicable where [named vectors](../co
 />
 
 </TabItem>
-<TabItem value="js" label="JS/TS Client v3">
 
+<TabItem value="js" label="JS/TS Client v3">
 <FilteredTextBlock
   text={TSCode}
   startMarker="// GetObjectVectorJS"
   endMarker="// END GetObjectVectorJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="js2" label="JS/TS Client v2">
-
 <FilteredTextBlock
   text={TSCodeLegacy}
   startMarker="// GetObjectVectorJS"
   endMarker="// END GetObjectVectorJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="go" label="Go">
@@ -408,16 +413,24 @@ You can retrieve the object vector. (Also applicable where [named vectors](../co
   />
 </TabItem>
 
-<TabItem value="graphql" label="GraphQL">
+<TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetObjectVector"
+      endMarker="// END GetObjectVector"
+      language="java"
+    />
+</TabItem>
 
+<TabItem value="graphql" label="GraphQL">
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetObjectVectorGraphQL"
   endMarker="# END GetObjectVectorGraphQL"
   language="graphql"
 />
-
 </TabItem>
+
 </Tabs>
 
 <details>
@@ -439,8 +452,8 @@ The output is like this:
 You can retrieve the object `id` (uuid).
 
 <Tabs groupId="languages">
-<TabItem value="py" label="Python Client v4">
 
+<TabItem value="py" label="Python Client v4">
 <FilteredTextBlock
   text={PyCode}
   startMarker="# GetObjectIdPython"
@@ -450,35 +463,39 @@ You can retrieve the object `id` (uuid).
 </TabItem>
 
 <TabItem value="py3" label="Python Client v3">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetObjectIdPython"
   endMarker="# END GetObjectIdPython"
   language="py"
 />
-
 </TabItem>
-<TabItem value="js" label="JS/TS Client v3">
 
+<TabItem value="js" label="JS/TS Client v3">
 <FilteredTextBlock
   text={TSCode}
   startMarker="// GetObjectIdJS"
   endMarker="// END GetObjectIdJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="js2" label="JS/TS Client v2">
-
 <FilteredTextBlock
   text={TSCodeLegacy}
   startMarker="// GetObjectIdJS"
   endMarker="// END GetObjectIdJS"
   language="js"
 />
+</TabItem>
 
+<TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetObjectIdJS"
+      endMarker="// END GetObjectIdJS"
+      language="java"
+    />
 </TabItem>
 
 <TabItem value="go" label="Go">
@@ -491,15 +508,14 @@ You can retrieve the object `id` (uuid).
 </TabItem>
 
 <TabItem value="graphql" label="GraphQL">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetObjectIdGraphQL"
   endMarker="# END GetObjectIdGraphQL"
   language="graphql"
 />
-
 </TabItem>
+
 </Tabs>
 
 <details>
@@ -525,6 +541,7 @@ To retrieve properties from cross-referenced objects, specify:
 - The properties to retrieve
 
 <Tabs groupId="languages">
+
 <TabItem value="py" label="Python Client v4">
 <FilteredTextBlock
   text={PyCode}
@@ -535,35 +552,30 @@ To retrieve properties from cross-referenced objects, specify:
 </TabItem>
 
 <TabItem value="py3" label="Python Client v3">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetWithCrossRefsPython"
   endMarker="# END GetWithCrossRefsPython"
   language="py"
 />
-
 </TabItem>
-<TabItem value="js" label="JS/TS Client v3">
 
+<TabItem value="js" label="JS/TS Client v3">
 <FilteredTextBlock
   text={TSCode}
   startMarker="// GetWithCrossRefs"
   endMarker="// END GetWithCrossRefs"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="js2" label="JS/TS Client v2">
-
 <FilteredTextBlock
   text={TSCodeLegacy}
   startMarker="// GetWithCrossRefs"
   endMarker="// END GetWithCrossRefs"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="go" label="Go">
@@ -576,15 +588,14 @@ To retrieve properties from cross-referenced objects, specify:
 </TabItem>
 
 <TabItem value="graphql" label="GraphQL">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetWithCrossRefsGraphQL"
   endMarker="# END GetWithCrossRefsGraphQL"
   language="graphql"
 />
-
 </TabItem>
+
 </Tabs>
 
 <details>
@@ -606,6 +617,7 @@ The output is like this:
 You can specify metadata fields to be returned.
 
 <Tabs groupId="languages">
+
 <TabItem value="py" label="Python Client v4">
 <FilteredTextBlock
   text={PyCode}
@@ -616,35 +628,30 @@ You can specify metadata fields to be returned.
 </TabItem>
 
 <TabItem value="py3" label="Python Client v3">
-
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetWithMetadataPython"
   endMarker="# END GetWithMetadataPython"
   language="py"
 />
-
 </TabItem>
-<TabItem value="js" label="JS/TS Client v3">
 
+<TabItem value="js" label="JS/TS Client v3">
 <FilteredTextBlock
   text={TSCode}
   startMarker="// GetWithMetadataJS"
   endMarker="// END GetWithMetadataJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="js2" label="JS/TS Client v2">
-
 <FilteredTextBlock
   text={TSCodeLegacy}
   startMarker="// GetWithMetadataJS"
   endMarker="// END GetWithMetadataJS"
   language="js"
 />
-
 </TabItem>
 
 <TabItem value="go" label="Go">
@@ -656,16 +663,24 @@ You can specify metadata fields to be returned.
   />
 </TabItem>
 
-<TabItem value="graphql" label="GraphQL">
+<TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetWithMetadata"
+      endMarker="// END GetWithMetadata"
+      language="java"
+    />
+</TabItem>
 
+<TabItem value="graphql" label="GraphQL">
 <FilteredTextBlock
   text={PyCodeV3}
   startMarker="# GetWithMetadataGraphQL"
   endMarker="# END GetWithMetadataGraphQL"
   language="graphql"
 />
-
 </TabItem>
+
 </Tabs>
 
 For a comprehensive list of metadata fields, see [GraphQL: Additional properties](../api/graphql/additional-properties.md).
@@ -721,6 +736,14 @@ If [multi-tenancy](../concepts/data.md#multi-tenancy) is enabled, specify the te
   />
 </TabItem>
 
+<TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START MultiTenancy"
+      endMarker="// END MultiTenancy"
+      language="java"
+    />
+</TabItem>
 
 </Tabs>
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

Adding Search Patterns snippets for Java Client:

- List Objects
- Limit Returned Objects
- Retrieve Object ID & Metadata
- Paginate Objects
- Retrieve Object Vectors
- Retrieve Tenant

Example:
![image](https://github.com/user-attachments/assets/dc0e996c-c61e-48dd-800b-f05b64122a3c)


### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
