### PR TITLE
Add FQDN env vars & descriptions to the docs

### DIFF
--- a/_includes/wcs/wcs.update-to-125-downtime.mdx
+++ b/_includes/wcs/wcs.update-to-125-downtime.mdx
@@ -1,4 +1,4 @@
 :::note Cluster downtime
 
-Weaviate introduces [Raft](/developers/weaviate/concepts/replication-architecture/cluster-architecture#schema-replication-raft), an improved cluster synchronization mechanism, in v1.25. There is some downtime when you upgrade an HA cluster to 1.25 while the cluster switches to the new mechanism.
+Weaviate introduces [Raft](/developers/weaviate/concepts/replication-architecture/cluster-architecture#metadata-replication-raft), an improved cluster synchronization mechanism, in v1.25. There is some downtime when you upgrade an HA cluster to 1.25 while the cluster switches to the new mechanism.
 :::

--- a/developers/weaviate/concepts/cluster.md
+++ b/developers/weaviate/concepts/cluster.md
@@ -80,17 +80,20 @@ Weaviate - especially when running as a cluster - is optimized to run on Kuberne
 
 ### FQDN for node discovery
 
+:::info Added in `v1.25.15`
+:::
+
 There can be a situation where IP-address based node discovery is not optimal. In such cases, you can set `RAFT_ENABLE_FQDN_RESOLVER` and `RAFT_FQDN_RESOLVER_TLD` [environment variables](../config-refs/env-vars.md#multi-node-instances) to enable fully qualified domain name (FQDN) based node discovery.
 
 If this feature is enabled, Weaviate uses the FQDN resolver to resolve the node name to the node IP address for metadata (e.g., Raft) communication.
 
 :::info FQDN: For metadata changes only
-This feature is only used for metadata changes which [use Raft as the consensus mechanism](./replication-architecture/cluster-architecture.md#schema-replication-raft). It does not affect data read/write operations.
+This feature is only used for metadata changes which [use Raft as the consensus mechanism](./replication-architecture/cluster-architecture.md#metadata-replication-raft). It does not affect data read/write operations.
 :::
 
 #### Examples of when to use FQDN for node discovery
 
-For example, this can resolve a situation where if IP addresses are re-used across different clusters, the nodes in one cluster could mistakenly discover nodes in another cluster.
+The use of FQDN can resolve a situation where if IP addresses are re-used across different clusters, the nodes in one cluster could mistakenly discover nodes in another cluster.
 
 It can also be useful when using services (for example, Kubernetes) where the IP of the services is different from the actual node IP, but it proxies the connection to the node.
 

--- a/developers/weaviate/concepts/cluster.md
+++ b/developers/weaviate/concepts/cluster.md
@@ -74,9 +74,27 @@ The groundwork to be able to re-shard has been laid by using Weaviate's Virtual 
 
 ## Node Discovery
 
-Nodes in a cluster use a gossip-like protocol through [Hashicorp's Memberlist](https://github.com/hashicorp/memberlist) to communicate node state and failure scenarios.
+By default, Weaviate nodes in a cluster use a gossip-like protocol through [Hashicorp's Memberlist](https://github.com/hashicorp/memberlist) to communicate node state and failure scenarios.
 
 Weaviate - especially when running as a cluster - is optimized to run on Kubernetes. The [Weaviate Helm chart](/developers/weaviate/installation/kubernetes.md#weaviate-helm-chart) makes use of a `StatefulSet` and a headless `Service` that automatically configures node discovery. All you have to do is specify the desired node count.
+
+### FQDN for node discovery
+
+There can be a situation where IP-address based node discovery is not optimal. In such cases, you can set `RAFT_ENABLE_FQDN_RESOLVER` and `RAFT_FQDN_RESOLVER_TLD` [environment variables](../config-refs/env-vars.md#multi-node-instances) to enable fully qualified domain name (FQDN) based node discovery.
+
+#### Examples of when to use FQDN for node discovery
+
+For example, this can resolve a situation where if IP addresses are re-used across different clusters, the nodes in one cluster could mistakenly discover nodes in another cluster.
+
+It can also be useful when using services (for example, Kubernetes) where the IP of the services is different from the actual node IP, but it proxies the connection to the node.
+
+#### Environment variables for FQDN node discovery
+
+`RAFT_ENABLE_FQDN_RESOLVER` is a Boolean flag. This flag enables the FQDN resolver. If set to `true`, Weaviate uses the FQDN resolver to resolve the node name to the node IP address. If set to `false`, Weaviate uses the memberlist lookup to resolve the node name to the node IP address. The default value is `false`.
+
+`RAFT_FQDN_RESOLVER_TLD` is a string that is appended in the format `[node-id].[tld]` when resolving a node-id to an IP address, where `[tld]` is the top-level domain.
+
+To use this feature, set `RAFT_ENABLE_FQDN_RESOLVER` to `true`.
 
 ## Node affinity of shards and/or replication shards
 

--- a/developers/weaviate/concepts/cluster.md
+++ b/developers/weaviate/concepts/cluster.md
@@ -82,6 +82,12 @@ Weaviate - especially when running as a cluster - is optimized to run on Kuberne
 
 There can be a situation where IP-address based node discovery is not optimal. In such cases, you can set `RAFT_ENABLE_FQDN_RESOLVER` and `RAFT_FQDN_RESOLVER_TLD` [environment variables](../config-refs/env-vars.md#multi-node-instances) to enable fully qualified domain name (FQDN) based node discovery.
 
+If this feature is enabled, Weaviate uses the FQDN resolver to resolve the node name to the node IP address for metadata (e.g., Raft) communication.
+
+:::info FQDN: For metadata changes only
+This feature is only used for metadata changes which [use Raft as the consensus mechanism](./replication-architecture/cluster-architecture.md#schema-replication-raft). It does not affect data read/write operations.
+:::
+
 #### Examples of when to use FQDN for node discovery
 
 For example, this can resolve a situation where if IP addresses are re-used across different clusters, the nodes in one cluster could mistakenly discover nodes in another cluster.

--- a/developers/weaviate/config-refs/env-vars.md
+++ b/developers/weaviate/config-refs/env-vars.md
@@ -97,7 +97,7 @@ All other values are interpreted as `false`.
 | `CLUSTER_JOIN` | The service name of the "founding" member node in a cluster setup | `string` | `weaviate-node-1:7100` |
 | `HNSW_STARTUP_WAIT_FOR_VECTOR_CACHE` | If `true`, vector cache prefill is synchronous when a node starts. The node reports ready to serve when the cache is hot. Defaults to `false`. Added in 1.24.20 and 1.25.5. | `boolean` | `false` |
 | `RAFT_ENABLE_FQDN_RESOLVER` | If `true`, use DNS lookup instead of memberlist lookup for Raft. Added in `v1.25.15`. ([Read more](../concepts/cluster.md#fqdn-for-node-discovery)) | `boolean` | `true` |
-| `RAFT_FQDN_RESOLVER_TLD` | The top-level domain to use for DNS lookup, in `[node-id].[tld]` format. Added in `v1.25.15`. ([Read more](../concepts/cluster.md#fqdn-for-node-discovery)) | `string` | `weaviate-0.example.com` |
+| `RAFT_FQDN_RESOLVER_TLD` | The top-level domain to use for DNS lookup, in `[node-id].[tld]` format. Added in `v1.25.15`. ([Read more](../concepts/cluster.md#fqdn-for-node-discovery)) | `string` | `example.com` |
 | `RAFT_BOOTSTRAP_EXPECT` | The number of voter notes at bootstrapping time | `string - number` | `1` |
 | `RAFT_BOOTSTRAP_TIMEOUT` | The time in seconds to wait for the cluster to bootstrap | `string - number` | `90` |
 | `RAFT_GRPC_MESSAGE_MAX_SIZE` | The maximum internal raft gRPC message size in bytes. Defaults to 1073741824 | `string - number` | `1073741824` |

--- a/developers/weaviate/config-refs/env-vars.md
+++ b/developers/weaviate/config-refs/env-vars.md
@@ -96,6 +96,8 @@ All other values are interpreted as `false`.
 | `CLUSTER_HOSTNAME` | Hostname of a node | `string` | `node1` |
 | `CLUSTER_JOIN` | The service name of the "founding" member node in a cluster setup | `string` | `weaviate-node-1:7100` |
 | `HNSW_STARTUP_WAIT_FOR_VECTOR_CACHE` | If `true`, vector cache prefill is synchronous when a node starts. The node reports ready to serve when the cache is hot. Defaults to `false`. Added in 1.24.20 and 1.25.5. | `boolean` | `false` |
+| `RAFT_ENABLE_FQDN_RESOLVER` | If `true`, use DNS lookup instead of memberlist lookup for Raft. ([Read more](../concepts/cluster.md#fqdn-for-node-discovery)) | `boolean` | `true` |
+| `RAFT_FQDN_RESOLVER_TLD` | The top-level domain to use for DNS lookup, in `[node-id].[tld]` format. ([Read more](../concepts/cluster.md#fqdn-for-node-discovery)) | `string` | `weaviate-0.example.com` |
 | `RAFT_BOOTSTRAP_EXPECT` | The number of voter notes at bootstrapping time | `string - number` | `1` |
 | `RAFT_BOOTSTRAP_TIMEOUT` | The time in seconds to wait for the cluster to bootstrap | `string - number` | `90` |
 | `RAFT_GRPC_MESSAGE_MAX_SIZE` | The maximum internal raft gRPC message size in bytes. Defaults to 1073741824 | `string - number` | `1073741824` |

--- a/developers/weaviate/config-refs/env-vars.md
+++ b/developers/weaviate/config-refs/env-vars.md
@@ -96,8 +96,8 @@ All other values are interpreted as `false`.
 | `CLUSTER_HOSTNAME` | Hostname of a node | `string` | `node1` |
 | `CLUSTER_JOIN` | The service name of the "founding" member node in a cluster setup | `string` | `weaviate-node-1:7100` |
 | `HNSW_STARTUP_WAIT_FOR_VECTOR_CACHE` | If `true`, vector cache prefill is synchronous when a node starts. The node reports ready to serve when the cache is hot. Defaults to `false`. Added in 1.24.20 and 1.25.5. | `boolean` | `false` |
-| `RAFT_ENABLE_FQDN_RESOLVER` | If `true`, use DNS lookup instead of memberlist lookup for Raft. ([Read more](../concepts/cluster.md#fqdn-for-node-discovery)) | `boolean` | `true` |
-| `RAFT_FQDN_RESOLVER_TLD` | The top-level domain to use for DNS lookup, in `[node-id].[tld]` format. ([Read more](../concepts/cluster.md#fqdn-for-node-discovery)) | `string` | `weaviate-0.example.com` |
+| `RAFT_ENABLE_FQDN_RESOLVER` | If `true`, use DNS lookup instead of memberlist lookup for Raft. Added in `v1.25.15`. ([Read more](../concepts/cluster.md#fqdn-for-node-discovery)) | `boolean` | `true` |
+| `RAFT_FQDN_RESOLVER_TLD` | The top-level domain to use for DNS lookup, in `[node-id].[tld]` format. Added in `v1.25.15`. ([Read more](../concepts/cluster.md#fqdn-for-node-discovery)) | `string` | `weaviate-0.example.com` |
 | `RAFT_BOOTSTRAP_EXPECT` | The number of voter notes at bootstrapping time | `string - number` | `1` |
 | `RAFT_BOOTSTRAP_TIMEOUT` | The time in seconds to wait for the cluster to bootstrap | `string - number` | `90` |
 | `RAFT_GRPC_MESSAGE_MAX_SIZE` | The maximum internal raft gRPC message size in bytes. Defaults to 1073741824 | `string - number` | `1073741824` |


### PR DESCRIPTION
### What's being changed:

Add FQDN env vars & descriptions to the docs

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
