### PR TITLE
Pull helm chart

### DIFF
--- a/developers/weaviate/installation/kubernetes.md
+++ b/developers/weaviate/installation/kubernetes.md
@@ -42,6 +42,7 @@ Add the Weaviate helm repo that contains the Weaviate helm chart.
 
 ```bash
 helm repo add weaviate https://weaviate.github.io/weaviate-helm
+helm repo update
 ```
 
 Get the default `values.yaml` configuration file from the Weaviate helm chart:


### PR DESCRIPTION
Add step to get latest helm chart (from `https://weaviate.github.io/weaviate-helm/`)

[staging](https://update-helm-chart--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/installation/kubernetes#get-the-helm-chart)