### PR TITLE
Remove duplicated imports

### DIFF
--- a/developers/academy/py/vector_index/_snippets/100_config.py
+++ b/developers/academy/py/vector_index/_snippets/100_config.py
@@ -1,8 +1,4 @@
 import weaviate
-# START ConfigHNSW  # START CustomConfigHNSW
-from weaviate.classes.config import Configure, VectorDistances
-
-# END ConfigHNSW  # END CustomConfigHNSW
 
 client = weaviate.connect_to_local()
 


### PR DESCRIPTION
Examples have duplicated imports

[staging](https://remove-duplicated-imports--tangerine-buttercream-20c32f.netlify.app/developers/academy/py/vector_index/hnsw#-specify-hnsw-as-the-index-type)