### PR TITLE
Specify Missing Property in the Basic Schema Creation Python Example

### DIFF
--- a/_includes/code/starter-guides/schema.py
+++ b/_includes/code/starter-guides/schema.py
@@ -29,6 +29,10 @@ try:
                 name="answer",
                 data_type=wvc.config.DataType.TEXT,
             ),
+            wvc.config.Property(
+                name="category",
+                data_type=wvc.config.DataType.TEXT,
+            )
         ]
     )
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

The starter guide titled "Schema (collection definitions)" has a section titled "Basic schema creation", which includes an example on how to create a simple collection with some properties. It says that **three** properties called _answer, question, and category_ will be created. However, the script only contains **two** properties, while its returned schema output contains **three**.

**Page:** https://weaviate.io/developers/weaviate/starter-guides/schema#basic-schema-creation
### Type of change:

<!--Please delete options that are not relevant.-->

- [ x ] **Documentation** updates (non-breaking change to fix/update documentation)
- [ x ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ x ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally

I agree to the CLA.
