### PR TITLE
Fix import errors in existing Go examples

### DIFF
--- a/_includes/code/howto/go/docs/manage-data.classes_test.go
+++ b/_includes/code/howto/go/docs/manage-data.classes_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/entities/vectorindex/common"
 	"weaviate.io/docs/docs/helper"
 )
 
@@ -94,7 +94,7 @@ func Test_ManageDataClasses(t *testing.T) {
 		originalClass := &models.Class{
 			Class: className,
 			VectorIndexConfig: map[string]interface{}{
-				"distance": hnsw.DistanceCosine, // Note the distance metric
+				"distance": common.DistanceCosine, // Note the distance metric
 			},
 		}
 
@@ -112,7 +112,7 @@ func Test_ManageDataClasses(t *testing.T) {
 		updatedClass := &models.Class{
 			Class: className,
 			VectorIndexConfig: map[string]interface{}{
-				"distance": hnsw.DistanceDot, // Note the distance metric
+				"distance": common.DistanceDot, // Note the distance metric
 			},
 		}
 

--- a/_includes/code/howto/go/docs/manage-data.create_auto-multitenancy.go
+++ b/_includes/code/howto/go/docs/manage-data.create_auto-multitenancy.go
@@ -1,4 +1,4 @@
-package main
+package docs
 
 import (
 	"context"

--- a/_includes/code/howto/go/docs/manage-data.read-all-objects_test.go
+++ b/_includes/code/howto/go/docs/manage-data.read-all-objects_test.go
@@ -24,7 +24,7 @@ func Test_ManageDataReadAllObjects(t *testing.T) {
 
 		sourceClient, err := weaviate.NewClient(weaviate.Config{
 			Scheme: "https",
-			Host:   "WEAVIATE_INSTANCE_URL" // Replace WEAVIATE_INSTANCE_URL with your instance URL
+			Host:   "WEAVIATE_INSTANCE_URL", // Replace WEAVIATE_INSTANCE_URL with your instance URL
 			AuthConfig: auth.ApiKey{
 				Value: "YOUR-WEAVIATE-API-KEY", // If auth enabled. Replace with your Weaviate instance API key.
 			},

--- a/_includes/code/howto/go/go.mod
+++ b/_includes/code/howto/go/go.mod
@@ -2,24 +2,20 @@ module weaviate.io/docs
 
 go 1.21
 
-toolchain go1.21.6
-
 require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/stretchr/testify v1.9.0
-	github.com/weaviate/weaviate v1.26.0-rc.1
+	github.com/weaviate/weaviate v1.26.4
 	github.com/weaviate/weaviate-go-client/v4 v4.15.1
 )
 
 require (
-	github.com/PuerkitoBio/purell v1.1.1 // indirect
-	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-openapi/analysis v0.21.2 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
-	github.com/go-openapi/jsonreference v0.19.6 // indirect
+	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/loads v0.21.1 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/_includes/code/howto/go/go.sum
+++ b/_includes/code/howto/go/go.sum
@@ -1,7 +1,5 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
-github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
@@ -19,8 +17,9 @@ github.com/go-openapi/errors v0.22.0/go.mod h1:J3DmZScxCDufmIMsdOuDHxJbdOGC0xtUy
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
-github.com/go-openapi/jsonreference v0.19.6 h1:UBIxjkht+AWIgYzCDSv2GN+E/togfwXUJFRTWhl2Jjs=
 github.com/go-openapi/jsonreference v0.19.6/go.mod h1:diGHMEHg2IqXZGKxqyvWdfWU/aim5Dprw5bqpKkTvns=
+github.com/go-openapi/jsonreference v0.20.0 h1:MYlu0sBgChmCfJxxUKZ8g1cPWFOB37YSZqewK7OKeyA=
+github.com/go-openapi/jsonreference v0.20.0/go.mod h1:Ag74Ico3lPc+zR+qjn4XBUmXymS4zJbYVCZmcgkasdo=
 github.com/go-openapi/loads v0.21.1 h1:Wb3nVZpdEzDTcly8S4HMkey6fjARRzb7iEaySimlDW0=
 github.com/go-openapi/loads v0.21.1/go.mod h1:/DtAMXXneXFjbQMGEtbamCZb+4x7eGwkvZCvBmwUG+g=
 github.com/go-openapi/spec v0.20.4 h1:O8hJrt0UMnhHcluhIdUgCLRWyM2x7QkBXRvOs7m+O1M=
@@ -129,8 +128,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/weaviate/weaviate v1.26.0-rc.1 h1:p+8Cw4VfAbevtf90/sEN+43IHMBtdUc5ZH3r4NZKVR8=
-github.com/weaviate/weaviate v1.26.0-rc.1/go.mod h1:o6nFEB4UozA+B2fnAWyF0HZqB2ab44pRhJHYwvxVyyA=
+github.com/weaviate/weaviate v1.26.4 h1:Z5y/OnSltWhBT4zLopTyebprnWlgxwrfByW74wdDWPI=
+github.com/weaviate/weaviate v1.26.4/go.mod h1:kx97B+cHQrnUYteo9pkTlDwWbcgbhMvnfHTzuMb2cLU=
 github.com/weaviate/weaviate-go-client/v4 v4.15.1 h1:zw+aw8DsZZkSiFyZOkuKKK49y0jnNr+4nKXCUKsyR/Q=
 github.com/weaviate/weaviate-go-client/v4 v4.15.1/go.mod h1:0aUsHXNfsdRfbO46t4Us5KUHqkhY+hlHevK6fBu72J4=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=


### PR DESCRIPTION
### What's being changed:

Fix import errors in existing Go examples.

### Type of change:

Go examples.

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
