### PR TITLE
Add Vector Search snippets for Java Client docs

### DIFF
--- a/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/VectorSearchTest.java
+++ b/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/VectorSearchTest.java
@@ -1,0 +1,381 @@
+package io.weaviate.docs.search;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.filters.Operator;
+import io.weaviate.client.v1.filters.WhereFilter;
+import io.weaviate.client.v1.graphql.model.GraphQLResponse;
+import io.weaviate.client.v1.graphql.query.argument.GroupByArgument;
+import io.weaviate.client.v1.graphql.query.argument.NearImageArgument;
+import io.weaviate.client.v1.graphql.query.argument.NearObjectArgument;
+import io.weaviate.client.v1.graphql.query.argument.NearTextArgument;
+import io.weaviate.client.v1.graphql.query.argument.NearVectorArgument;
+import io.weaviate.client.v1.graphql.query.argument.WhereArgument;
+import io.weaviate.client.v1.graphql.query.builder.GetBuilder;
+import io.weaviate.client.v1.graphql.query.fields.Field;
+import io.weaviate.client.v1.graphql.query.fields.Fields;
+import io.weaviate.docs.helper.EnvHelper;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("crud")
+@Tag("vector-search")
+public class VectorSearchTest {
+
+  private static WeaviateClient client;
+
+  @BeforeAll
+  public static void beforeAll() {
+    String scheme = EnvHelper.scheme("http");
+    String host = EnvHelper.host("localhost");
+    String port = EnvHelper.port("8080");
+
+    Config config = new Config(scheme, host + ":" + port);
+    client = new WeaviateClient(config);
+
+    Result<Boolean> result = client.schema().allDeleter().run();
+    assertThat(result).isNotNull()
+      .withFailMessage(() -> result.getError().toString())
+      .returns(false, Result::hasErrors)
+      .withFailMessage(null)
+      .returns(true, Result::getResult);
+  }
+
+  @Test
+  public void shouldPerformVectorSearch() {
+    String className = "JeopardyQuestion";
+
+    searchWithNearText(className);
+    searchWithNearImage(className);
+    searchWithNearObject(className);
+    searchWithNearVector(className);
+    searchWithNamedVector(className);
+    searchWithSimilarityThreshold(className);
+    searchWithLimitOffset(className);
+    searchWithAutoCut(className);
+    searchWithGroupBy(className);
+    searchWithFilter(className);
+  }
+
+  private void searchWithNearText(String className) {
+    // START GetNearText
+    NearTextArgument nearText = NearTextArgument.builder()
+      .concepts(new String[]{ "animals in movies" })
+      .build();
+
+    Fields fields = Fields.builder()
+      .fields(new Field[]{
+        Field.builder().name("question").build(),
+        Field.builder().name("answer").build(),
+        Field.builder().name("_additional").fields(new Field[]{
+          Field.builder().name("distance").build()
+        }).build()
+      })
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .fields(fields)
+      .withNearTextFilter(nearText)
+      .limit(2)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END GetNearText
+  }
+
+  private void searchWithNearImage(String className) {
+    // START search with base64
+    String base64_string = "SOME_BASE_64_REPRESENTATION";
+
+    NearImageArgument nearImage = NearImageArgument.builder()
+      .image(base64_string)
+      .build();
+
+    Fields fields = Fields.builder()
+      .fields(new Field[]{
+        Field.builder().name("Breed").build()
+      })
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .fields(fields)
+      .withNearImageFilter(nearImage)
+      .limit(1)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END search with base64
+  }
+
+  private void searchWithNearObject(String className) {
+    // START GetNearObject
+    String id = "0b7235c5-86f1-48a9-baab-3b9571dca854";
+
+    NearObjectArgument nearObject = NearObjectArgument.builder()
+      .id(id)
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .withNearObjectFilter(nearObject)
+      .limit(2)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END GetNearObject
+  }
+
+  private void searchWithNearVector(String className) {
+    // START GetNearVector
+    Float[] vector = { -0.0125526935f, -0.021168863f, -0.01076519f, -0.02589537f, -0.0070362035f,
+      0.019870078f, -0.010001986f, -0.019120263f, 0.00090044655f, -0.017393013f };
+
+    NearVectorArgument nearVector = NearVectorArgument.builder()
+      .vector(vector)
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .withNearVectorFilter(nearVector)
+      .limit(2)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END GetNearVector
+    if (result.getError() != null) {
+      System.out.println("Error performing vector search: " + result.getError().getMessages());
+    } else {
+      System.out.println("Vector search result: " + result.getResult().getData());
+    }
+  }
+
+  private void searchWithNamedVector(String className) {
+    // START NamedVectorNearText
+    String[] target_vector = { "title_country" };
+
+    NearTextArgument nearText = NearTextArgument.builder()
+      .concepts(new String[]{ "a sweet German white wine" })
+      .targetVectors(target_vector)
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .withNearTextFilter(nearText)
+      .limit(1)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END NamedVectorNearText
+
+    if (result.getError() != null) {
+      System.out.println("Error performing vector search: " + result.getError().getMessages());
+    } else {
+      System.out.println("Vector search result: " + result.getResult().getData());
+    }
+
+  }
+
+  private void searchWithSimilarityThreshold(String className) {
+    // START GetWithDistance
+    NearTextArgument nearText = NearTextArgument.builder()
+      .concepts(new String[]{ "animals in movies" })
+      .distance(0.25f)
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .withNearTextFilter(nearText)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END GetWithDistance
+
+    if (result.getError() != null) {
+      System.out.println("Error performing vector search: " + result.getError().getMessages());
+    } else {
+      System.out.println("Vector search result: " + result.getResult().getData());
+    }
+
+  }
+
+  private void searchWithLimitOffset(String className) {
+    // START GetLimitOffset
+    NearTextArgument nearText = NearTextArgument.builder()
+      .concepts(new String[]{ "animals in movies" })
+      .build();
+
+    Fields fields = Fields.builder()
+      .fields(new Field[]{
+        Field.builder().name("question").build(),
+        Field.builder().name("answer").build(),
+        Field.builder().name("_additional").fields(new Field[]{
+          Field.builder().name("distance").build()
+        }).build()
+      })
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .withNearTextFilter(nearText)
+      .fields(fields)
+      .limit(3)
+      .offset(1)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END GetLimitOffset
+    if (result.getError() != null) {
+      System.out.println("Error performing vector search: " + result.getError().getMessages());
+    } else {
+      System.out.println("Vector search result: " + result.getResult().getData());
+    }
+  }
+
+  private void searchWithAutoCut(String className) {
+    // START Autocut
+    NearTextArgument nearText = NearTextArgument.builder()
+      .concepts(new String[]{ "animals in movies" })
+      .build();
+
+    Fields fields = Fields.builder()
+      .fields(new Field[]{
+        Field.builder().name("question").build(),
+        Field.builder().name("answer").build(),
+        Field.builder().name("_additional").fields(new Field[]{
+          Field.builder().name("distance").build()
+        }).build()
+      })
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .fields(fields)
+      .withNearTextFilter(nearText)
+      .autocut(1)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END Autocut
+    if (result.getError() != null) {
+      System.out.println("Error performing vector search: " + result.getError().getMessages());
+    } else {
+      System.out.println("Vector search result: " + result.getResult().getData());
+    }
+  }
+
+  private void searchWithGroupBy(String className) {
+    // START GetWithGroupBy
+    NearTextArgument nearText = NearTextArgument.builder()
+      .concepts(new String[]{ "animals in movies" })
+      .build();
+
+    // Define the group hits fields
+    Field[] hits = new Field[]{
+      Field.builder().name("answer").build(),
+      Field.builder().name("question").build(),
+    };
+
+    // Define the group field
+    Field group = Field.builder()
+      .name("group")
+      .fields(new Field[]{
+        Field.builder().name("id").build(),
+        Field.builder().name("groupedBy")
+          .fields(new Field[]{
+            Field.builder().name("path").build(),
+            Field.builder().name("value").build(),
+          }).build(),
+        Field.builder().name("count").build(),
+        Field.builder().name("minDistance").build(),
+        Field.builder().name("maxDistance").build(),
+        Field.builder().name("hits").fields(hits).build(),
+      }).build();
+
+    Field _additional = Field.builder().name("_additional").fields(new Field[]{ group }).build();
+
+    Fields fields = Fields.builder()
+      .fields(new Field[]{ _additional })
+      .build();
+
+    // Define the GroupBy argument
+    GroupByArgument groupBy = client.graphQL().arguments().groupByArgBuilder()
+      .path(new String[]{ "round" })  // Path to group by
+      .groups(2)  // Number of groups
+      .objectsPerGroup(2)  // Number of objects per group
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .fields(fields)
+      .withNearTextFilter(nearText)
+      .withGroupByArgument(groupBy)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END GetWithGroupBy
+    if (result.hasErrors()) {
+      System.out.println("Error performing vector search: " + result.getError().getMessages());
+    } else {
+      System.out.println("Vector search result: " + result.getResult().getData());
+    }
+  }
+
+  private void searchWithFilter(String className) {
+    // START GetWithFilter
+    NearTextArgument nearText = NearTextArgument.builder()
+      .concepts(new String[]{ "animals in movies" })  // Search concept
+      .build();
+
+    Fields fields = Fields.builder()
+      .fields(new Field[]{
+        Field.builder().name("question").build(),
+        Field.builder().name("answer").build(),
+        Field.builder().name("round").build(),
+        Field.builder().name("_additional").fields(new Field[]{
+          Field.builder().name("distance").build()
+        }).build()
+      })
+      .build();
+
+    WhereFilter whereFilter = WhereFilter.builder()
+      .path(new String[]{ "round" })  // Path to filter by
+      .operator(Operator.Equal)
+      .valueText("Double Jeopardy!")
+      .build();
+
+    WhereArgument whereArgument = WhereArgument.builder()
+      .filter(whereFilter)
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .fields(fields)
+      .withNearTextFilter(nearText)
+      .withWhereFilter(whereArgument)
+      .limit(2)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END GetWithFilter
+    if (result.getError() != null) {
+      System.out.println("Error performing vector search: " + result.getError().getMessages());
+    } else {
+      System.out.println("Vector search result: " + result.getResult().getData());
+    }
+  }
+}

--- a/developers/weaviate/search/similarity.md
+++ b/developers/weaviate/search/similarity.md
@@ -13,6 +13,7 @@ import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.similarity-v3.py
 import TSCode from '!!raw-loader!/_includes/code/howto/search.similarity.ts';
 import TSCodeLegacy from '!!raw-loader!/_includes/code/howto/search.similarity-v2.ts';
 import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/mainpkg/search-similarity_test.go';
+import JavaCode from '!!raw-loader!/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/VectorSearchTest.java';
 
 Vector search returns the objects with most similar vectors to that of the query.
 
@@ -63,6 +64,15 @@ Use the [`Near Text`](../api/graphql/search-operators.md#neartext) operator to f
       startMarker="// START GetNearText"
       endMarker="// END GetNearText"
       language="gonew"
+    />
+  </TabItem>
+
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetNearText"
+      endMarker="// END GetNearText"
+      language="java"
     />
   </TabItem>
 
@@ -137,6 +147,15 @@ This example uses a base64 representation of an image.
       language="ts"
     />
   </TabItem>
+
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START search with base64"
+      endMarker="// END search with base64"
+      language="java"
+    />
+  </TabItem>
 </Tabs>
 
 See [Image search](./image.md) for more information.
@@ -189,6 +208,15 @@ If you have an object ID, use the [`Near Object`](../api/graphql/search-operator
       startMarker="// START GetNearObject"
       endMarker="// END GetNearObject"
       language="gonew"
+    />
+  </TabItem>
+
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetNearObject"
+      endMarker="// END GetNearObject"
+      language="java"
     />
   </TabItem>
 
@@ -271,6 +299,15 @@ If you have an input vector, use the [`Near Vector`](../api/graphql/search-opera
 
   </TabItem>
 
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetNearVector"
+      endMarker="// END GetNearVector"
+      language="java"
+    />
+  </TabItem>
+
   <TabItem value="graphql" label="GraphQL">
     <FilteredTextBlock
       text={PyCodeV3}
@@ -331,6 +368,15 @@ To search a collection that has [named vectors](../config-refs/schema/multi-vect
       startMarker="// START NamedVectorNearText"
       endMarker="// END NamedVectorNearText"
       language="gonew"
+    />
+  </TabItem>
+
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START NamedVectorNearText"
+      endMarker="// END NamedVectorNearText"
+      language="java"
     />
   </TabItem>
 
@@ -408,6 +454,15 @@ To set a similarity threshold between the search and target vectors, define a ma
     />
   </TabItem>
 
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetWithDistance"
+      endMarker="// END GetWithDistance"
+      language="java"
+    />
+  </TabItem>
+
   <TabItem value="graphql" label="GraphQL">
     <FilteredTextBlock
       text={PyCodeV3}
@@ -479,6 +534,15 @@ Optionally, use `offset` to paginate the results.
     />
   </TabItem>
 
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetLimitOffset"
+      endMarker="// END GetLimitOffset"
+      language="java"
+    />
+  </TabItem>
+
   <TabItem value="graphql" label="GraphQL">
     <FilteredTextBlock
       text={PyCodeV3}
@@ -536,6 +600,15 @@ To limit results to groups of similar distances to the query, use the [`autocut`
       startMarker="// START Autocut"
       endMarker="// END Autocut"
       language="gonew"
+    />
+  </TabItem>
+
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START Autocut"
+      endMarker="// END Autocut"
+      language="java"
     />
   </TabItem>
 
@@ -613,6 +686,15 @@ Use a property or a cross-reference to group results. To group returned objects,
     />
   </TabItem>
 
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetWithGroupBy"
+      endMarker="// END GetWithGroupBy"
+      language="java"
+    />
+  </TabItem>
+
   <TabItem value="graphql" label="GraphQL">
     <FilteredTextBlock
       text={PyCodeV3}
@@ -684,6 +766,15 @@ For more specific results, use a [`filter`](../api/graphql/filters.md) to narrow
       startMarker="// START GetWithFilter"
       endMarker="// END GetWithFilter"
       language="gonew"
+    />
+  </TabItem>
+
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START GetWithFilter"
+      endMarker="// END GetWithFilter"
+      language="java"
     />
   </TabItem>
 


### PR DESCRIPTION
[staging](https://add-vector-search-snippets-java-c--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/search/similarity)

### What's being changed:

Add Vector Search snippets for Java client docs:

    searchWithNearText(className);
    searchWithNearImage(className);
    searchWithNearObject(className);
    searchWithNearVector(className);
    searchWithNamedVector(className);
    searchWithSimilarityThreshold(className);
    searchWithLimitOffset(className);
    searchWithAutoCut(className);
    searchWithGroupBy(className);
    searchWithFilter(className);

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
