### PR TITLE
Add max vector distance to the (Py) docs

### DIFF
--- a/_includes/code/howto/search.hybrid-v3.py
+++ b/_includes/code/howto/search.hybrid-v3.py
@@ -907,6 +907,7 @@ gql_query = """
              nearText: {
                 concepts: [ "large animal" ]
              }
+             maxVectorDistance: 0.5
            # highlight-end
            }
            alpha: 0.75,

--- a/_includes/code/howto/search.hybrid.py
+++ b/_includes/code/howto/search.hybrid.py
@@ -312,6 +312,7 @@ jeopardy = client.collections.get("JeopardyQuestion")
 response = jeopardy.query.hybrid(
     query="California",
     # highlight-start
+    max_vector_distance=0.4,  # Maximum threshold for the vector search component
     vector=HybridVector.near_text(
         query="large animal",
         move_away=Move(force=0.5, concepts=["mammal", "terrestrial"]),

--- a/_includes/code/howto/search.hybrid.ts
+++ b/_includes/code/howto/search.hybrid.ts
@@ -15,7 +15,7 @@ const client = await weaviate.connectToWeaviateCloud(
    headers: {
      'X-OpenAI-Api-Key': process.env.OPENAI_APIKEY,  // Replace with your inference API key
    }
- } 
+ }
 )
 
 // searchHybridBasic  // searchHybridWithScore  // searchHybridWithAlpha  // searchHybridWithFusionType  // searchHybridWithProperties  // searchHybridWithVector // VectorSimilarity // searchHybridWithFilter  // START limit  // START autocut // searchHybridWithPropertyWeighting
@@ -230,9 +230,10 @@ for (let object of result.objects) {
 
 const result = await jeopardy.query.hybrid('California', {
   vector: {
-    text: 'large animal',
+    query: 'large animal',
     moveAway: { force: 0.5, concepts:['mamal', 'terrestrial'] }
   },
+  // maxVectorDistance support coming soon
   alpha: 0.75,
   limit: 5
 })

--- a/developers/weaviate/search/hybrid.md
+++ b/developers/weaviate/search/hybrid.md
@@ -623,7 +623,7 @@ The output is like this:
 :::info Added in `v1.25`
 :::
 
-You can specify [vector similarity search](/developers/weaviate/search/similarity) parameters similar to [near text](/developers/weaviate/search/similarity.md#search-with-text) or [near vector](/developers/weaviate/search/similarity.md#search-with-a-vector) searches, such as `group by` and `move to` / `move away`.
+You can specify [vector similarity search](/developers/weaviate/search/similarity) parameters similar to [near text](/developers/weaviate/search/similarity.md#search-with-text) or [near vector](/developers/weaviate/search/similarity.md#search-with-a-vector) searches, such as `group by` and `move to` / `move away`. An equvalent `distance` [threshold for vector search](./similarity.md#set-a-similarity-threshold) can be specified with the `max vector distance` parameter.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python Client v4">


### PR DESCRIPTION


### What's being changed:

Add max vector distance to the (Py) docs

TS tbc when client support added

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`