### PR TITLE
Rearrange GraphQL example for maxVectorDistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
 After you install `nvm`, use `nvm` to install Node.js.
 
 ```
-nvm install node
+nvm install
 ```
 
 By default, `nvm` installs the most recent version of Node.js. Install Node.js
@@ -29,7 +29,7 @@ By default, `nvm` installs the most recent version of Node.js. Install Node.js
 `weaviate.io` project dependencies.
 
 ```
-nvm install node 19.9.0
+nvm install 19.9.0
 nvm use 19.9.0
 ```
 

--- a/_includes/code/howto/search.hybrid-v3.py
+++ b/_includes/code/howto/search.hybrid-v3.py
@@ -907,10 +907,10 @@ gql_query = """
              nearText: {
                 concepts: [ "large animal" ]
              }
-             maxVectorDistance: 0.5
-           # highlight-end
            }
-           alpha: 0.75,
+           maxVectorDistance: 0.5
+           # highlight-end
+           alpha: 0.75
            query: "California"
          }
        )


### PR DESCRIPTION
### What's being changed:

maxVectorDistance is a higher-level parameter and should be placed under `hybrid: { maxVectorDistance: 3 }`

Source: https://github.com/weaviate/weaviate/blob/b053ca564c0ade810dfe660743b1b8011bc8ef42/adapters/handlers/graphql/local/aggregate/hybrid_search.go#L57-L60

---
Misc: updated `nvm` commands in README -- those do not require specifying `node` as an argument. In fact, adding it seems to break the command in that it ignores other parameters, e.g. custom version number, and just runs with the default (latest version).

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
