### PR TITLE
V1 27 deletion read repairs (do not merge)

### DIFF
--- a/_includes/code/howto/manage-data.collections.py
+++ b/_includes/code/howto/manage-data.collections.py
@@ -492,7 +492,7 @@ assert config.replication_config.async_enabled == True
 client.close()
 
 # ==============================================
-# ===== REPLICATION WITH ObjectDeletionConflictResolution
+# ===== REPLICATION WITH DeletionStrategy
 # ==============================================
 
 # Connect to a setting with 3 replicas
@@ -503,8 +503,8 @@ client = weaviate.connect_to_local(
 # Clean slate
 client.collections.delete("Article")
 
-# START ObjectDeletionConflictResolution
-from weaviate.classes.config import Configure, ObjectDeletionConflictResolution
+# START DeletionStrategy
+from weaviate.classes.config import Configure, DeletionStrategy
 
 client.collections.create(
     "Article",
@@ -512,16 +512,16 @@ client.collections.create(
         factor=3,
         async_enabled=True,
         # highlight-start
-        object_deletion_conflict_resolution=ObjectDeletionConflictResolution.PERMANENT_DELETION  # Or ObjectDeletionConflictResolution.NO_AUTOMATED_RESOLUTION
+        deletion_strategy=DeletionStrategy.DELETE_ON_CONFLICT  # Or DeletionStrategy.NO_AUTOMATED_RESOLUTION
         # highlight-end
     )
 )
-# END ObjectDeletionConflictResolution
+# END DeletionStrategy
 
 # Test
 collection = client.collections.get("Article")
 config = collection.config.get()
-# assert config.replication_config.object_deletion_conflict_resolution == ObjectDeletionConflictResolution.PERMANENT_DELETION  # Something like this for the test?
+# assert config.replication_config.deletion_strategy == DeletionStrategy.DELETE_ON_CONFLICT  # Something like this for the test?
 
 client.close()
 

--- a/_includes/code/howto/manage-data.collections.py
+++ b/_includes/code/howto/manage-data.collections.py
@@ -487,7 +487,41 @@ client.collections.create(
 # Test
 collection = client.collections.get("Article")
 config = collection.config.get()
-# assert config.replication_config.factor == 3   #ASYNC NEEDS TEST
+assert config.replication_config.async_enabled == True
+
+client.close()
+
+# ==============================================
+# ===== REPLICATION WITH ObjectDeletionConflictResolution
+# ==============================================
+
+# Connect to a setting with 3 replicas
+client = weaviate.connect_to_local(
+    port=8180  # Port for demo setup with 3 replicas
+)
+
+# Clean slate
+client.collections.delete("Article")
+
+# START ObjectDeletionConflictResolution
+from weaviate.classes.config import Configure, ObjectDeletionConflictResolution
+
+client.collections.create(
+    "Article",
+    replication_config=Configure.replication(
+        factor=3,
+        async_enabled=True,
+        # highlight-start
+        object_deletion_conflict_resolution=ObjectDeletionConflictResolution.PERMANENT_DELETION  # Or ObjectDeletionConflictResolution.NO_AUTOMATED_RESOLUTION
+        # highlight-end
+    )
+)
+# END ObjectDeletionConflictResolution
+
+# Test
+collection = client.collections.get("Article")
+config = collection.config.get()
+# assert config.replication_config.object_deletion_conflict_resolution == ObjectDeletionConflictResolution.PERMANENT_DELETION  # Something like this for the test?
 
 client.close()
 

--- a/_includes/code/howto/manage-data.collections.ts
+++ b/_includes/code/howto/manage-data.collections.ts
@@ -572,6 +572,30 @@ await client.collections.create({
 // Test
 // TODO NEEDS TEST assert.equal(result.replicationConfig.factor, 3);
 
+// =======================
+// ===== ObjectDeletionConflictResolution ====
+// =======================
+
+// /*
+// // START ObjectDeletionConflictResolution
+// import { configure } from 'weaviate-client';
+
+// // END ObjectDeletionConflictResolution
+// */
+
+// // START ObjectDeletionConflictResolution
+// await client.collections.create({
+//   name: 'Article',
+//   // highlight-start
+//   replication: configure.replication({
+//     factor: 3,
+//     asyncEnabled: true,
+//     objectDeletionConflictResolution: 'permanentDeletion'
+//   }),
+//   // highlight-end
+//  })
+//  // END ObjectDeletionConflictResolution
+
 // ====================
 // ===== SHARDING =====
 // ====================

--- a/_includes/code/howto/manage-data.collections.ts
+++ b/_includes/code/howto/manage-data.collections.ts
@@ -573,28 +573,28 @@ await client.collections.create({
 // TODO NEEDS TEST assert.equal(result.replicationConfig.factor, 3);
 
 // =======================
-// ===== ObjectDeletionConflictResolution ====
+// ===== DeletionStrategy ====
 // =======================
 
 // /*
-// // START ObjectDeletionConflictResolution
+// // START DeletionStrategy
 // import { configure } from 'weaviate-client';
 
-// // END ObjectDeletionConflictResolution
+// // END DeletionStrategy
 // */
 
-// // START ObjectDeletionConflictResolution
+// // START DeletionStrategy
 // await client.collections.create({
 //   name: 'Article',
 //   // highlight-start
 //   replication: configure.replication({
 //     factor: 3,
 //     asyncEnabled: true,
-//     objectDeletionConflictResolution: 'permanentDeletion'
+//     DeletionStrategy: 'permanentDeletion'
 //   }),
 //   // highlight-end
 //  })
-//  // END ObjectDeletionConflictResolution
+//  // END DeletionStrategy
 
 // ====================
 // ===== SHARDING =====

--- a/developers/weaviate/concepts/replication-architecture/consistency.md
+++ b/developers/weaviate/concepts/replication-architecture/consistency.md
@@ -191,6 +191,26 @@ Async replication supplements the repair-on-read mechanism. If a node becomes in
 
 To activate async replication, set `asyncEnabled` to true in the [`replicationConfig` section of your collection definition](../../manage-data/collections.mdx#replication-settings).
 
+### Object deletion conflict resolution
+
+:::info Added in `v1.27`
+:::
+
+If a consistency level other than `ALL` is used, an object deletion may only have been applied to a subset of replicas.
+
+This can lead to a conflict where the deleted object can still be read, or where the object is recreated after deletion.
+
+To resolve this, you can set an option in the replication config section of each collection.
+
+The available strategies are:
+
+- `PermanentlyDelete` - The object is deleted from all replicas.
+- `NoAutomatedResolution` - Conflicts in deletions are resolved in the same way as other conflicts.
+
+:::tip Related pages
+- See [this how-to page](../../configuration/replication.md#object-deletion-conflict-resolution) for an example of how to set the object deletion conflict resolution strategy.
+:::
+
 ## Related pages
 - [API References | GraphQL | Get | Consistency Levels](../../api/graphql/get.md#consistency-levels)
 - [API References | REST | Objects](/developers/weaviate/api/rest#tag/objects)

--- a/developers/weaviate/concepts/replication-architecture/consistency.md
+++ b/developers/weaviate/concepts/replication-architecture/consistency.md
@@ -191,7 +191,7 @@ Async replication supplements the repair-on-read mechanism. If a node becomes in
 
 To activate async replication, set `asyncEnabled` to true in the [`replicationConfig` section of your collection definition](../../manage-data/collections.mdx#replication-settings).
 
-### Object deletion conflict resolution
+### Deletion strategy
 
 :::info Added in `v1.27`
 :::
@@ -202,13 +202,13 @@ This can lead to a conflict where the deleted object can still be read, or where
 
 To resolve this, you can set an option in the replication config section of each collection.
 
-The available strategies are:
+The available deletion strategies are:
 
-- `PermanentlyDelete` - The object is deleted from all replicas.
+- `DeleteOnConflict` - The object is deleted from all replicas.
 - `NoAutomatedResolution` - Conflicts in deletions are resolved in the same way as other conflicts.
 
 :::tip Related pages
-- See [this how-to page](../../configuration/replication.md#object-deletion-conflict-resolution) for an example of how to set the object deletion conflict resolution strategy.
+- See [this how-to page](../../configuration/replication.md#deletion-strategy) for an example of how to set the object deletion conflict resolution strategy.
 :::
 
 ## Related pages

--- a/developers/weaviate/configuration/replication.md
+++ b/developers/weaviate/configuration/replication.md
@@ -5,6 +5,10 @@ image: og/docs/configuration.jpg
 # tags: ['configuration', 'operations', 'monitoring', 'observability']
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBlock';
+
 Weaviate instances can be replicated. Replication can improve read throughput, improve availability, and enable zero-downtime upgrades.
 
 For more details on how replication is designed and built in Weaviate, see [Replication Architecture](../concepts/replication-architecture/index.md).
@@ -62,7 +66,7 @@ import ReplicationConfigWithAsyncRepair from '/_includes/code/configuration/repl
 
 <ReplicationConfigWithAsyncRepair />
 
-### Object deletion conflict resolution
+### Deletion strategy
 
 import ManageDataPyCode from '!!raw-loader!/_includes/code/howto/manage-data.collections.py';
 import ManageDataTSCode from '!!raw-loader!/_includes/code/howto/manage-data.collections.ts';
@@ -76,8 +80,8 @@ You can optionally set a collection option on how to resolve object deletion con
   <TabItem value="py" label="Python Client v4">
     <FilteredTextBlock
       text={ManageDataPyCode}
-      startMarker="# START ObjectDeletionConflictResolution"
-      endMarker="# END ObjectDeletionConflictResolution"
+      startMarker="# START DeletionStrategy"
+      endMarker="# END DeletionStrategy"
       language="py"
     />
   </TabItem>
@@ -89,7 +93,6 @@ You can optionally set a collection option on how to resolve object deletion con
   ```
 
   </TabItem>
-
 </Tabs>
 
 ## How to use: Queries

--- a/developers/weaviate/configuration/replication.md
+++ b/developers/weaviate/configuration/replication.md
@@ -62,6 +62,36 @@ import ReplicationConfigWithAsyncRepair from '/_includes/code/configuration/repl
 
 <ReplicationConfigWithAsyncRepair />
 
+### Object deletion conflict resolution
+
+import ManageDataPyCode from '!!raw-loader!/_includes/code/howto/manage-data.collections.py';
+import ManageDataTSCode from '!!raw-loader!/_includes/code/howto/manage-data.collections.ts';
+
+:::info Added in `v1.27`
+:::
+
+You can optionally set a collection option on how to resolve object deletion conflicts in multi-node clusters.
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={ManageDataPyCode}
+      startMarker="# START ObjectDeletionConflictResolution"
+      endMarker="# END ObjectDeletionConflictResolution"
+      language="py"
+    />
+  </TabItem>
+
+  <TabItem value="js" label="JS/TS Client v3">
+
+  ```js
+  // Code example coming soon
+  ```
+
+  </TabItem>
+
+</Tabs>
+
 ## How to use: Queries
 
 When you add (write) or query (read) data, one or more replica nodes in the cluster will respond to the request. How many nodes need to send a successful response and acknowledgement to the coordinator node depends on the `consistency_level`. Available [consistency levels](../concepts/replication-architecture/consistency.md) are `ONE`, `QUORUM` (replication_factor / 2 + 1) and `ALL`.

--- a/developers/weaviate/configuration/replication.md
+++ b/developers/weaviate/configuration/replication.md
@@ -74,7 +74,7 @@ import ManageDataTSCode from '!!raw-loader!/_includes/code/howto/manage-data.col
 :::info Added in `v1.27`
 :::
 
-You can optionally set a collection option on how to resolve object deletion conflicts in multi-node clusters.
+You can optionally set a [deletion strategy](../concepts/replication-architecture/consistency.md#deletion-strategy) in multi-node clusters in case of conflicts.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python Client v4">

--- a/developers/weaviate/manage-data/collections.mdx
+++ b/developers/weaviate/manage-data/collections.mdx
@@ -762,6 +762,33 @@ For details on the configuration parameters, see the following:
 
 </details>
 
+## Object deletion resolution
+
+:::info Added in `v1.27`
+:::
+
+You can optionally set a collection option on how to resolve object deletion conflicts in multi-node clusters.
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={PyCode}
+      startMarker="# START ObjectDeletionConflictResolution"
+      endMarker="# END ObjectDeletionConflictResolution"
+      language="py"
+    />
+  </TabItem>
+
+  <TabItem value="js" label="JS/TS Client v3">
+
+  ```js
+  // Code example coming soon
+  ```
+
+  </TabItem>
+
+</Tabs>
+
 ## Sharding settings
 
 Configure sharding per collection.

--- a/developers/weaviate/manage-data/collections.mdx
+++ b/developers/weaviate/manage-data/collections.mdx
@@ -762,7 +762,7 @@ For details on the configuration parameters, see the following:
 
 </details>
 
-## Object deletion resolution
+### Object deletion conflict resolution
 
 :::info Added in `v1.27`
 :::

--- a/developers/weaviate/manage-data/collections.mdx
+++ b/developers/weaviate/manage-data/collections.mdx
@@ -767,7 +767,7 @@ For details on the configuration parameters, see the following:
 :::info Added in `v1.27`
 :::
 
-You can optionally set a collection option on how to resolve object deletion conflicts in multi-node clusters.
+You can optionally set a [deletion strategy](../concepts/replication-architecture/consistency.md#deletion-strategy) in multi-node clusters in case of conflicts.
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python Client v4">

--- a/developers/weaviate/manage-data/collections.mdx
+++ b/developers/weaviate/manage-data/collections.mdx
@@ -773,8 +773,8 @@ You can optionally set a collection option on how to resolve object deletion con
   <TabItem value="py" label="Python Client v4">
     <FilteredTextBlock
       text={PyCode}
-      startMarker="# START ObjectDeletionConflictResolution"
-      endMarker="# END ObjectDeletionConflictResolution"
+      startMarker="# START DeletionStrategy"
+      endMarker="# END DeletionStrategy"
       language="py"
     />
   </TabItem>


### PR DESCRIPTION
### What's being changed:

V1 27 deletion docs

- Code examples
    - In multiple places for discovery
- "Deletion strategy" descriptions in cluster architecture sections

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
