### PR TITLE
[Docs] Fix a typo in the cluster types description

### DIFF
--- a/_includes/wcs/two-cluster-types.mdx
+++ b/_includes/wcs/two-cluster-types.mdx
@@ -1,4 +1,4 @@
 [Weaviate Cloud (WCD)](https://console.weaviate.cloud/) provides two instance types.
 
- - Sandbox clusters. Sandbox clusters are small, free clusters designed for learning and experimentation. Sandbox clusters not scalable and expire after 14 days.
+ - Sandbox clusters. Sandbox clusters are small, free clusters designed for learning and experimentation. Sandbox clusters are not scalable and expire after 14 days.
  - Serverless clusters. Serverless clusters are robust, paid clusters designed for production use. Manage clusters scale to meet your needs and don't expire.


### PR DESCRIPTION
### What's being changed:

Fix a typo in the cluster types template. `Sandbox clusters not scalable` -> `Sandbox clusters are not scalable`

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

Tested with oculus sinister and oculus dexter 🙂, no need to (re)build the entire project.