### PR TITLE
Change references to "generative search" to "retrieval augmented generation"

### DIFF
--- a/_includes/code/howto/search.generative-v2.ts
+++ b/_includes/code/howto/search.generative-v2.ts
@@ -1,4 +1,4 @@
-// Howto: Search -> Generative search - TypeScript examples
+// Howto: Search -> Retreval augmented generation - TypeScript examples
 // Run with: node --loader=ts-node/esm search.generative.ts
 import assert from 'assert';
 

--- a/_includes/code/howto/search.generative.ts
+++ b/_includes/code/howto/search.generative.ts
@@ -1,4 +1,4 @@
-// Howto: Search -> Generative search - TypeScript examples
+// Howto: Search -> Retreval augmented generation - TypeScript examples
 // Run with: node --loader=ts-node/esm search.generative.ts
 import assert from 'assert';
 

--- a/_includes/code/starter-guides/generative_edudemo-v2.ts
+++ b/_includes/code/starter-guides/generative_edudemo-v2.ts
@@ -1,4 +1,4 @@
-// Starter-guides: Generative search (RAG)
+// Starter-guides: Retreval augmented generation (RAG)
 
 import assert from 'assert';
 

--- a/_includes/code/starter-guides/generative_edudemo.ts
+++ b/_includes/code/starter-guides/generative_edudemo.ts
@@ -1,4 +1,4 @@
-// Starter-guides: Generative search (RAG)
+// Starter-guides: Retreval augmented generation (RAG)
 
 import assert from 'assert';
 
@@ -16,7 +16,7 @@ const client: WeaviateClient = await weaviate.connectToWeaviateCloud(
    headers: {
      'X-OpenAI-Api-Key': process.env.OPENAI_API_KEY || '',  // Replace with your inference API key
    }
- } 
+ }
 )
 // END Instantiation
 

--- a/_includes/code/starter-guides/generative_local-v2.ts
+++ b/_includes/code/starter-guides/generative_local-v2.ts
@@ -1,4 +1,4 @@
-// Starter-guides: Generative search (RAG)
+// Starter-guides: Retreval augmented generation (RAG)
 
 import assert from 'assert';
 

--- a/_includes/code/starter-guides/generative_local.ts
+++ b/_includes/code/starter-guides/generative_local.ts
@@ -1,4 +1,4 @@
-// Starter-guides: Generative search (RAG)
+// Starter-guides: Retreval augmented generation (RAG)
 
 import assert from 'assert';
 
@@ -77,7 +77,7 @@ if (collectionExists) {
 }
 // CreateClass
 
-const newCollection = await client.collections.create(schemaDefinition) 
+const newCollection = await client.collections.create(schemaDefinition)
 console.log('We have a new class!', newCollection['name']);
 
 // END CreateClass

--- a/blog/2024-07-31-weaviate-1-26-release/_core-1-26-include.mdx
+++ b/blog/2024-07-31-weaviate-1-26-release/_core-1-26-include.mdx
@@ -49,7 +49,7 @@ For details, see [async replication](/developers/weaviate/concepts/replication-a
 
 ## Anthropic integration
 
-An Anthropic generative AI integration is available in Weaviate. This integration allows you to use the `Claude` family of models from Anthropic to perform generative search on your data. The integration includes support for the latest models, such as `Claude 3.5 Sonnet`.
+An Anthropic generative AI integration is available in Weaviate. This integration allows you to use the `Claude` family of models from Anthropic to perform retreval augmented generation on your data. The integration includes support for the latest models, such as `Claude 3.5 Sonnet`.
 
 The Anthropic integration is enabled by default on Weaviate Cloud [WCD](https://console.weaviate.cloud/) instances.
 

--- a/developers/academy/py/standalone/chunking/_snippets/30_example.py
+++ b/developers/academy/py/standalone/chunking/_snippets/30_example.py
@@ -434,7 +434,7 @@ In this section, we'll cover some of these remote-management skills.
 
 
 # ===================================
-# ======= GENERATIVE SEARCH =========
+# ======= Retreval augmented generation =========
 # ===================================
 
 # START generative_search
@@ -447,7 +447,7 @@ n_chunks_by_strat['para_chunks'] = 8
 n_chunks_by_strat['fixed_size_100'] = 2
 n_chunks_by_strat['para_chunks_min_25'] = 2
 
-# Perform generative search
+# Perform Retreval augmented generation
 # highlight-start
 search_string = "history of git"  # Or "available git remote commands"
 # highlight-end

--- a/developers/weaviate/api/graphql/additional-properties.md
+++ b/developers/weaviate/api/graphql/additional-properties.md
@@ -82,7 +82,7 @@ Use the `vector` field to fetch the vector representation of the data object
 :::info Requires a [generative model integration](../../model-providers/index.md)
 :::
 
-The `generate` field can be used to perform a [generative search](../../search/generative.md).
+The `generate` field can be used to perform [retrieval augmented generation](../../search/generative.md).
 
 A `generate` query will cause corresponding additional result fields to be available, such as `singleResult`, `groupedResult` and `error`.
 

--- a/developers/weaviate/client-libraries/python/index.md
+++ b/developers/weaviate/client-libraries/python/index.md
@@ -208,7 +208,7 @@ You can set timeout values, in seconds, for the client. Use the `Timeout` class 
   language="py"
 />
 
-:::tip Timeouts on `generate` (RAG) queries
+:::tip Timeouts on `generate` queries
 
 If you see errors while using the `generate` submodule, try increasing the query timeout values (`Timeout(query=60)`). <br/><br/>The `generate` submodule uses a large language model to generate text. The submodule is dependent on the speed of the language model and any API that serves the language model. <br/><br/>Increase the timeout values to allow the client to wait longer for the language model to respond.
 :::
@@ -637,7 +637,7 @@ The results are organized by both their individual objects as well as the group.
 
 ### `generate`
 
-The RAG / generative search functionality is a two-step process involving a search followed by prompting a large language model. Therefore, function names are shared across the `query` and `generate` submodules, with additional parameters available in the `generate` submodule.
+The `generate` methods perform [retrieval augmented generation (RAG)](../../starter-guides/generative.md). This is a two-step process involving a search followed by prompting a large language model. Therefore, function names are shared across the `query` and `generate` submodules, with additional parameters available in the `generate` submodule.
 
 <Tabs groupId="languages">
 <TabItem value="generate" label="Generate">

--- a/developers/weaviate/client-libraries/typescript/typescript-v3.mdx
+++ b/developers/weaviate/client-libraries/typescript/typescript-v3.mdx
@@ -307,7 +307,7 @@ There are demo applications written in TypeScript and JavaScript here:
 - [Next Vector Search](https://github.com/weaviate-tutorials/next-vector-search): A vector search and RAG application to search through Wikipedia pages with React (Next.js), OpenAI and Weaviate.
 - [Next Multimodal Search](https://github.com/weaviate-tutorials/next-multimodal-search-demo): A multimodal search application to search through images with React (Next.js), Google Vertex AI and Weaviate.
 - [Nuxt Multimodal Search](https://github.com/weaviate-tutorials/nuxt-multimodal-search): A multimodal search application to search through images with Vue (Nuxt.js), Google Vertex AI and Weaviate.
-- [FlickPicker](https://github.com/weaviate-tutorials/flick-picker):  A multimodal search application with generative search (RAG) functionality to search through images with Vue (Nuxt.js), Google Vertex AI and Weaviate.
+- [FlickPicker](https://github.com/weaviate-tutorials/flick-picker):  A multimodal search application with retrieval augmented generation (RAG) functionality to search through images with Vue (Nuxt.js), Google Vertex AI and Weaviate.
 - [Nuxt eCommerce RAG](https://github.com/weaviate-tutorials/nuxt-ecommerce-rag): An eCommerce site with vector search and RAG to search through outdoor product listing and help you plan hikes built with Vue (Nuxt.js), OpenAI and Weaviate.
 
 ## Client releases

--- a/developers/weaviate/concepts/search/_best-practices.md
+++ b/developers/weaviate/concepts/search/_best-practices.md
@@ -170,9 +170,9 @@ Identify fields that contribute most to semantic understanding. Consider combini
 - Quantization and queries
 - Best practices for optimizing search in large datasets
 
-## Generative Search (RAG)
+## Retrieval Augmented Generation (RAG)
 
-Generative search, also known as Retrieval Augmented Generation (RAG), combines traditional search mechanisms with generative AI models to produce new content based on retrieved information.
+Retrieval Augmented Generation (RAG), also known as generative search, combines traditional search mechanisms with generative AI models to produce new content based on retrieved information.
 
 ### RAG Architecture
 

--- a/developers/weaviate/concepts/search/index.md
+++ b/developers/weaviate/concepts/search/index.md
@@ -19,7 +19,7 @@ The following table illustrates the search process in Weaviate. Around the core 
 |------|-------------|----------|
 | 1. [Retrieval](#retrieval-filter) | <strong>[Filter](#retrieval-filter):</strong> Narrow result sets based on criteria<br/><strong>[Search](#retrieval-search):</strong> Find the most relevant entries, using one of [keyword](#keyword-search), [vector](#vector-search) or [hybrid](#hybrid-search) search types<br/> | Required |
 | 2. [Reranking](#rerank) | Reorder results using a different (e.g. more complex) model | Optional |
-| 3. [Generative](#generative-search--rag) | Send retrieved data and a prompt to a generative AI model. Also called retrieval augmented generation, or RAG. | Optional |
+| 3. [Generative](#retrieval-augmented-generation-rag) | Send retrieved data and a prompt to a generative AI model. Also called retrieval augmented generation, or RAG. | Optional |
 
 Here is a brief overview of each step:
 
@@ -264,22 +264,22 @@ Reranking is useful when you want to improve the quality of search results by ap
 For example, searches in legal, medical, or scientific literature may require a more nuanced understanding of the text. Reranking can help to ensure that the most relevant results are surfaced.
 </details>
 
-### Generative search / RAG
+### Retrieval augmented generation (RAG)
 
 :::info In one sentence
-<i class="fa-solid fa-robot"></i> Generative search combines search with a generative AI model to produce new content based on the search results.
+<i class="fa-solid fa-robot"></i> Retrieval Augmented Generation combines search with a generative AI model to produce new content based on the search results.
 :::
 
-Generative search, also called retrieval augmented generation or RAG, combines search with a generative AI model to produce new content based on the search results. It is a powerful technique that can leverage the generative capabilities of AI models and the search capabilities of Weaviate.
+Retrieval augmented generation (RAG), also called generative search, combines search with a generative AI model to produce new content based on the search results. It is a powerful technique that can leverage the generative capabilities of AI models and the search capabilities of Weaviate.
 
 Weaviate integrates with many popular [generative model providers](../../model-providers/index.md) such as [AWS](../../model-providers/aws/generative.md), [Cohere](../../model-providers/cohere/generative.md), [Google](../../model-providers/google/generative.md), [OpenAI](../../model-providers/openai/generative.md) and [Ollama](../../model-providers/ollama/generative.md).
 
-As a result, generative searches in Weaviate are [easy to set up](../../manage-data/collections.mdx#specify-a-generative-module), and can be conveniently executed as [an integrated, single query](../../search/generative.md#grouped-task-search).
+As a result, Weaviate makes RAG easy to [set up](../../manage-data/collections.mdx#specify-a-generative-module), and easy to [execute as an integrated, single query](../../search/generative.md#grouped-task-search).
 
 <details>
-  <summary>Generative Search: Example</summary>
+  <summary>RAG: Example</summary>
 
-In a dataset such as `animal_objs` below, you could combine generative search with any other search method to find relevant objects and then transform it.
+In a dataset such as `animal_objs` below, you could combine retrieval augmented generation with any other search method to find relevant objects and then transform it.
 <br/>
 
 ```json
@@ -293,7 +293,7 @@ In a dataset such as `animal_objs` below, you could combine generative search wi
 ]
 ```
 
-Take an example of a keyword search for `"black"`, and a generative search request `"What do these animal descriptions have in common?"`.
+Take an example of a keyword search for `"black"`, and a RAG request `"What do these animal descriptions have in common?"`.
 <br/>
 
 The search results consist of `{"description": "black bear"}` and `{"description": "small domestic black cat"}` as you saw before. Then, the generative model would produce an output based on our query. In one example, it produced:

--- a/developers/weaviate/concepts/search/index.md
+++ b/developers/weaviate/concepts/search/index.md
@@ -19,7 +19,7 @@ The following table illustrates the search process in Weaviate. Around the core 
 |------|-------------|----------|
 | 1. [Retrieval](#retrieval-filter) | <strong>[Filter](#retrieval-filter):</strong> Narrow result sets based on criteria<br/><strong>[Search](#retrieval-search):</strong> Find the most relevant entries, using one of [keyword](#keyword-search), [vector](#vector-search) or [hybrid](#hybrid-search) search types<br/> | Required |
 | 2. [Reranking](#rerank) | Reorder results using a different (e.g. more complex) model | Optional |
-| 3. [Generative](#retrieval-augmented-generation-rag) | Send retrieved data and a prompt to a generative AI model. Also called retrieval augmented generation, or RAG. | Optional |
+| 3. [Retrieval augmented generation](#retrieval-augmented-generation-rag) | Send retrieved data and a prompt to a generative AI model. Also called retrieval augmented generation, or RAG. | Optional |
 
 Here is a brief overview of each step:
 

--- a/developers/weaviate/configuration/modules.md
+++ b/developers/weaviate/configuration/modules.md
@@ -114,7 +114,7 @@ services:
 
 ## Generative model integrations
 
-The [generative model integrations](../model-providers/index.md) enable [generative search](../search/generative.md) functions.
+The [generative model integrations](../model-providers/index.md) enable [retrieval augmented generation](../search/generative.md) functions.
 
 ### Enable a generative module
 

--- a/developers/weaviate/manage-data/collections.mdx
+++ b/developers/weaviate/manage-data/collections.mdx
@@ -999,7 +999,7 @@ This configuration for nested objects defines the following:
 <details>
   <summary>Sample configuration: Generative search</summary>
 
-This configuration for [generative search](../search/generative.md) defines the following:
+This configuration for [retrieval augmented generation](../search/generative.md) defines the following:
 
 - The collection name (`Article`)
 - The default vectorizer module (`text2vec-openai`)

--- a/developers/weaviate/quickstart/index.md
+++ b/developers/weaviate/quickstart/index.md
@@ -17,7 +17,7 @@ This Quickstart takes about 20 minutes to complete. It introduces some common ta
 - Build a Weaviate vector database.
 - Make a *semantic search* query.
 - Add a *filter* to your query.
-- Use *generative searches* and a large language model (LLM) to transform your search results.
+- Use *retrieval augmented generation* and a large language model (LLM) to transform your search results.
 
 #### Object vectors
 
@@ -212,9 +212,9 @@ The results are limited to objects from the `ANIMALS` category.
 Using a Boolean filter allows you to combine the flexibility of vector search with the precision of `where` filters.
 :::
 
-### Generative search (single prompt)
+### Retrieval augmented generation (single prompt)
 
-Next, let's try a generative search. A generative search, also called retrieval augmented generation, prompts a large language model (LLM) with a combination of a user query as well as data retrieved from a database.
+Next, let's try a retrieval augmented generation (RAG). RAG, also called generative search, prompts a large language model (LLM) with a combination of a user query as well as data retrieved from a database.
 
 To see what happens when an LLM uses query results to perform a task that is based on our prompt, run the code below.
 
@@ -232,7 +232,7 @@ import BiologyGenerativeSearchJson from '/_includes/code/quickstart/response.bio
 
 We see that Weaviate has retrieved the same results as before. But now it includes an additional, generated text with a plain-language explanation of each answer.
 
-### Generative search (grouped task)
+### Retrieval augmented generation (grouped task)
 
 The next example uses a `grouped task` prompt instead to combine all search results and send them to the LLM with a prompt.
 
@@ -249,7 +249,7 @@ import BiologyGenerativeSearchGroupedJson from '/_includes/code/quickstart/respo
 <BiologyGenerativeSearchGroupedJson />
 
 :::tip Why is this useful?
-Generative search sends retrieved data from Weaviate to a large language model, or LLM. This allows you to go beyond simple data retrieval, but transform the data into a more useful form, without ever leaving Weaviate.
+RAG sends retrieved data from Weaviate to a large language model, or LLM. This allows you to go beyond simple data retrieval, but transform the data into a more useful form, without ever leaving Weaviate.
 :::
 
 <hr/>
@@ -262,7 +262,7 @@ Well done! You have:
 - Performed searches, including:
     - Semantic search
     - Semantic search with a filter
-    - Generative search
+    - Retrieval augmented generation
 
 Where next is up to you. We include a few links below - or you can check out the sidebar.
 

--- a/developers/weaviate/search/generative.md
+++ b/developers/weaviate/search/generative.md
@@ -1,5 +1,5 @@
 ---
-title: Generative search
+title: Retrieval Augmented Generation (RAG)
 sidebar_position: 70
 image: og/docs/howto.jpg
 # tags: ['how to', 'generative']
@@ -14,7 +14,8 @@ import TSCode from '!!raw-loader!/_includes/code/howto/search.generative.ts';
 import TSCodeLegacy from '!!raw-loader!/_includes/code/howto/search.generative-v2.ts';
 import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/mainpkg/search-generative_test.go';
 
-`Generative` search, also known as "Retrieval Augmented Generation" (RAG), is a multi-stage process.<br/>
+"Retrieval Augmented Generation" (RAG), also called generative search, is a multi-stage process.
+
 First Weaviate performs a query, then it passes the retrieved results and a prompt to a large language model (LLM), to generate a new output.
 
 <details>
@@ -22,7 +23,7 @@ First Weaviate performs a query, then it passes the retrieved results and a prom
     Additional information
   </summary>
 
-### Configure generative search
+### Configure RAG
 
 1. Configure Weaviate to enable a [generative model integration](../model-providers/index.md).
  2. Configure the target collection to use the generator module. For details, see schema configuration on the module reference page.

--- a/developers/weaviate/search/index.md
+++ b/developers/weaviate/search/index.md
@@ -15,7 +15,7 @@ These guides cover additional search topics:
 - [Image search](./image.md): Use images as input for a similarity search.
 - [Keyword search](./bm25.md): A keyword search that uses the BM25F algorithm to rank results.
 - [Hybrid search](./hybrid.md): Combines BM25 and similarity search to rank results.
-- [Generative search](./generative.md): Use search results as a prompt for an LLM.
+- [Retrieval augmented generation](./generative.md): Use search results as a prompt for an LLM.
 - [Reranking](./rerank.md): Rerank retrieved search results using a `reranker` module.
 - [Aggregation](./aggregate.md): Aggregate data from a results set.
 - [Filters](./filters.md): Apply conditional filters to the search.

--- a/developers/weaviate/starter-guides/generative.md
+++ b/developers/weaviate/starter-guides/generative.md
@@ -23,7 +23,7 @@ import TSCodeLocalLegacy from '!!raw-loader!/_includes/code/starter-guides/gener
 - [How-to: Retrieval augmented generation](../search/generative.md)
 :::
 
-This pages introduces you to retrieval augmented generation (RAG) with Weaviate. It covers:
+This pages introduces you to retrieval augmented generation (RAG) using Weaviate. It covers:
 
 - What RAG is.
 - How to configure Weaviate for RAG.
@@ -320,7 +320,7 @@ Now, let's go through an end-to-end example for using Weaviate for RAG.
 
 For this example, you will need access to a Weaviate instance that you can write to. You can use any Weaviate instance, such as a local Docker instance, or a WCD instance.
 
-### Configure RAG
+### Configure Weaviate for RAG
 
 :::caution Generative module cannot be changed
 Currently, a generative module cannot be changed in the Weaviate collection definition once it has been set. We are looking to change this going forward.

--- a/developers/weaviate/starter-guides/generative.md
+++ b/developers/weaviate/starter-guides/generative.md
@@ -1,5 +1,5 @@
 ---
-title: Generative search (RAG)
+title: Retrieval augmented generation (RAG)
 sidebar_position: 50
 image: og/docs/tutorials.jpg
 # tags: ['getting started']
@@ -20,15 +20,15 @@ import TSCodeLocalLegacy from '!!raw-loader!/_includes/code/starter-guides/gener
 
 :::info Related pages
 - [Which Weaviate is right for me?](./which-weaviate.md)
-- [How-to: Generative search](../search/generative.md)
+- [How-to: Retrieval augmented generation](../search/generative.md)
 :::
 
-This pages introduces you to generative search with Weaviate. It covers:
+This pages introduces you to retrieval augmented generation (RAG) with Weaviate. It covers:
 
-- What generative search, or RAG, is.
-- How to configure Weaviate for generative search.
-- How to perform generative searches.
-- Importing data with generative search in mind.
+- What RAG is.
+- How to configure Weaviate for RAG.
+- How to perform RAG.
+- Importing data with RAG in mind.
 
 ### Prerequisites
 
@@ -36,35 +36,35 @@ This guide assumes some familiarity with Weaviate, but it is not required. If yo
 
 ## Background
 
-### What is generative search?
+### What is retrieval augmented generation?
 
-Generative search is a powerful technique that retrieves relevant data to provide to large language models (LLMs) as context, along with the task prompt. It is also called retrieval augmented generation (RAG), or in-context learning in some cases.
+Retrieval augmented generation is a powerful technique that retrieves relevant data to provide to large language models (LLMs) as context, along with the task prompt. It is also called RAG, generative search, or in-context learning in some cases.
 
-### Why generative search?
+### Why use RAG?
 
 LLM are incredibly powerful, but can suffer from two important limitations. These limitation are that:
 - They can confidently produce incorrect, or outdated, information (also called 'hallucination'); and
 - They might simply not be trained on the information you need.
 
-Generative search remedies this problem with a two-step process.
+RAG remedies this problem with a two-step process.
 
 The first step is to retrieve relevant data through a query. Then, in the second step, the LLM is prompted with a combination of the retrieve data with a user-provided query.
 
 This provides in-context learning for the LLM, which causes it to use the relevant and up-to-date data rather than rely on recall from its training, or even worse, hallucinated outputs.
 
-### Weaviate and generative search
+### Weaviate and retrieval augmented generation
 
-Weaviate incorporates key functionalities to make generative search easier and faster.
+Weaviate incorporates key functionalities to make RAG easier and faster.
 
 For one, Weaviate's search capabilities make it easier to find relevant information. You can use any of similarity, keyword and hybrid searches, along with filtering capabilities to find the information you need.
 
-Additionally, Weaviate has integrated generative search capabilities, so that the retrieval and generation steps are combined into a single query. This means that you can use Weaviate's search capabilities to retrieve the data you need, and then in the same query, prompt the LLM with the same data.
+Additionally, Weaviate has integrated RAG capabilities, so that the retrieval and generation steps are combined into a single query. This means that you can use Weaviate's search capabilities to retrieve the data you need, and then in the same query, prompt the LLM with the same data.
 
-This makes it easier, faster and more efficient to implement generative search workflows in your application.
+This makes it easier, faster and more efficient to implement RAG workflows in your application.
 
-## Examples of generative search
+## Examples of RAG
 
-Let's begin by viewing examples of generative search in action. We will then explore how to configure Weaviate for generative search.
+Let's begin by viewing examples of RAG in action. We will then explore how to configure Weaviate for RAG.
 
 We have run this demo with an OpenAI language model and a cloud instance of Weaviate. But you can run it with any [deployment method](./which-weaviate.md) and with any generative AI [model integration](../model-providers/index.md).
 
@@ -179,7 +179,7 @@ This should return a set of results like the following (truncated for brevity):
 
 ### Transform result sets
 
-We can transform this result set into new text using generative search with just a minor modification of the code. First, let's use a `grouped task` prompt to summarize this information.
+We can transform this result set into new text using RAG with just a minor modification of the code. First, let's use a `grouped task` prompt to summarize this information.
 
 Run the following code snippet, and inspect the results:
 
@@ -230,7 +230,7 @@ Here is our generated text:
 - This book was written using Git version 2, but most commands should work in older versions as well.
 ```
 
-In a `grouped task` generative search, Weaviate:
+In a `grouped task` RAG query, Weaviate:
 - Retrieves the three most similar passages to the meaning of `history of git`.
 - Then prompts the LLM with a combination of:
     - Text from all of the search results, and
@@ -238,7 +238,7 @@ In a `grouped task` generative search, Weaviate:
 
 Note that the user-provided prompt did not contain any information about the subject matter. But because Weaviate retrieve the relevant data about the history of git, it was able to summarize the information relating to this subject matter using verifiable data.
 
-That's how easy it is to use generative search in Weaviate.
+That's how easy it is to perform RAG queries in Weaviate.
 
 :::note Your results may vary
 There will be variability in the actual text that has been generated. This due to the randomness in LLMs' behaviors, and variability across models. This is perfectly normal.
@@ -310,17 +310,17 @@ Here, Weaviate has:
 - For each result, prompted the LLM with:
     - The user-provided prompt, replacing `{country}`, `{title}`, and `{review_body}` with the corresponding text.
 
-In both examples, you saw Weaviate return new text that is original, but grounded in the retrieved data. This is what makes generative search powerful, by combining the best of data retrieval and language generation.
+In both examples, you saw Weaviate return new text that is original, but grounded in the retrieved data. This is what makes RAG powerful, by combining the best of data retrieval and language generation.
 
-## Generative search, end-to-end
+## RAG, end-to-end
 
-Now, let's go through an end-to-end example for using Weaviate for generative search.
+Now, let's go through an end-to-end example for using Weaviate for RAG.
 
 ### Your own Weaviate instance
 
 For this example, you will need access to a Weaviate instance that you can write to. You can use any Weaviate instance, such as a local Docker instance, or a WCD instance.
 
-### Configure generative search
+### Configure RAG
 
 :::caution Generative module cannot be changed
 Currently, a generative module cannot be changed in the Weaviate collection definition once it has been set. We are looking to change this going forward.
@@ -329,7 +329,7 @@ Currently, a generative module cannot be changed in the Weaviate collection defi
 If you would like us to prioritize this issue, upvote it on [GitHub](https://github.com/weaviate/weaviate/issues/3364).
 :::
 
-To use generative search, the appropriate `generative-xxx` module must be:
+To use RAG, the appropriate `generative-xxx` module must be:
 - Enabled in Weaviate, and
 - Specified in the collection definition.
 
@@ -438,7 +438,7 @@ See the [documentation](../model-providers/index.md) for various model provider 
 
 ### Populate database
 
-Adding data to Weaviate for generative search is similar to adding data for other purposes. However, there are some important considerations to keep in mind, such as chunking and data structure.
+Adding data to Weaviate for RAG is similar to adding data for other purposes. However, there are some important considerations to keep in mind, such as chunking and data structure.
 
 You can read further discussions in the [Best practices & tips](#best-practices--tips) section. Here, we will use a chunk length of 150 words and a 25-word overlap. We will also include the title of the book, the chapter it is from, and the chunk number. This will allow us to search through the chunks, as well as filter it.
 
@@ -485,7 +485,7 @@ This will download the text from the chapter, and return a list/array of strings
 
 #### Create collection definitions
 
-We can now create a collection definition for the chunks. To use generative search, your desired generative module must be specified at the collection level as shown below.
+We can now create a collection definition for the chunks. To use RAG, your desired generative module must be specified at the collection level as shown below.
 
 The below collection definition for the `GitBookChunk` collection specifies `text2vec-openai` as the vectorizer and `generative-openai` as the generative module. Note that the `generative-openai` parameter can have an empty dictionary/object as its value, which will use the default parameters.
 
@@ -710,7 +710,7 @@ Did you know? 🤔 Git thinks of its data as snapshots, not just changes to file
 
 #### Pairing with search
 
-Generative search in Weaviate is a two-step process under the hood, involving retrieval of objects and then generation of text. This means that you can use the full power of Weaviate's search capabilities to retrieve the objects you want to use for generation.
+RAG in Weaviate is a two-step process under the hood, involving retrieval of objects and then generation of text. This means that you can use the full power of Weaviate's search capabilities to retrieve the objects you want to use for generation.
 
 In this example, we search the chapter for passages that relate to the states of git before generating a tweet as before.
 
@@ -813,7 +813,7 @@ As you can see, Weaviate allows you to use the full power of search to retrieve 
 
 In the context of language processing, "chunking" refers to the process of splitting texts into smaller pieces of texts, i.e. "chunks".
 
-For generative search, chunking affects both the information retrieval and the amount of contextual information provided.
+For RAG, chunking affects both the information retrieval and the amount of contextual information provided.
 
 While there is no one-size-fits all chunking strategy that we can recommend, we can provide some general guidelines. Chunking by semantic markers, or text length may both be viable strategies.
 
@@ -853,7 +853,7 @@ Our own [Connor Shorten's podcast](https://weaviate.io/podcast) is a great resou
 
 ## Wrap-up
 
-We've explored the dynamic capabilities of generative search in Weaviate, showcasing how it enhances large language models through retrieval-augmented generation.
+We've explored the dynamic capabilities of RAG in Weaviate, showcasing how it enhances large language models through retrieval-augmented generation.
 
 To learn more about specific search capabilities, check out the [How-to: search guide](../search/index.md). And to learn more about individual modules, check out the [Modules section](../modules/index.md).
 

--- a/developers/weaviate/starter-guides/index.md
+++ b/developers/weaviate/starter-guides/index.md
@@ -12,6 +12,6 @@ This section helps you to get started with Weaviate.
 - [Which Weaviate setup to use?](./which-weaviate.md): Find the right Weaviate setup for your needs.
 - [Collection definitions and schema](./schema.md): How to define your collection settings and schema.
 - [Bring your own vectors](./custom-vectors.mdx): How to use your own vectors with Weaviate.
-- [Generative search (RAG)](./generative.md): Guide to performing generative search (also called retrieval augmented generation, or RAG).
+- [Retrieval augmented generation (RAG)](./generative.md): Guide to performing retrieval augmented generation (RAG), or generative search.
 - [Indexing](./managing-resources/indexing.mdx): How does Weaviate index data for fast search and filtering? What index types and settings are right for me?
 - [Managing resources](./managing-resources/index.md): How to balance search speeds, accuracy/recall, and costs with Weaviate's flexible resource management features.


### PR DESCRIPTION


### What's being changed:

Change references to "generative search" to "retrieval augmented generation"

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
