### PR TITLE
Data types page: Update text, add Python & TS examples for collection config & data insertion

### DIFF
--- a/_includes/code/python/config-refs.datatypes.blob.py
+++ b/_includes/code/python/config-refs.datatypes.blob.py
@@ -1,0 +1,42 @@
+import weaviate
+
+# START ConfigureDataType
+from weaviate.classes.config import Property, DataType
+
+# END ConfigureDataType
+
+client = weaviate.connect_to_local()
+
+# Delete collection if it exists
+client.collections.delete(name="Poster")
+
+# START ConfigureDataType
+# Create collection
+my_collection = client.collections.create(
+    name="Poster",
+    properties=[
+        Property(name="title", data_type=DataType.TEXT),
+        Property(name="image", data_type=DataType.BLOB),
+    ],
+    # Other properties are omitted for brevity
+)
+# END ConfigureDataType
+
+blob_string = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+# START AddObject
+# Create an object
+example_object = {
+    "title": "The Matrix",
+    "image": blob_string
+}
+
+obj_uuid = my_collection.data.insert(example_object)
+# END AddObject
+
+returned_obj = my_collection.query.fetch_object_by_id(obj_uuid, return_properties=["title", "image"])
+
+assert obj_uuid is not None
+assert returned_obj.properties == example_object
+
+client.close()

--- a/_includes/code/python/config-refs.datatypes.date.py
+++ b/_includes/code/python/config-refs.datatypes.date.py
@@ -1,0 +1,55 @@
+import weaviate
+
+# START ConfigureDataType
+from weaviate.classes.config import Property, DataType
+from datetime import datetime, timezone
+
+# END ConfigureDataType
+
+client = weaviate.connect_to_local()
+
+# Delete collection if it exists
+client.collections.delete(name="ConcertTour")
+
+# START ConfigureDataType
+# Create collection
+my_collection = client.collections.create(
+    name="ConcertTour",
+    properties=[
+        Property(name="artist", data_type=DataType.TEXT),
+        Property(name="tour_name", data_type=DataType.TEXT),
+        Property(name="tour_start", data_type=DataType.DATE),
+        Property(name="tour_dates", data_type=DataType.DATE_ARRAY),
+    ],
+    # Other properties are omitted for brevity
+)
+# END ConfigureDataType
+
+# START AddObject
+# Create an object
+# In Python, you can use the RFC 3339 format or a datetime object (preferably with a timezone)
+example_object = {
+    "artist": "Taylor Swift",
+    "tour_name": "Eras Tour",
+    "tour_start": datetime(2023, 3, 17).replace(tzinfo=timezone.utc),
+    "tour_dates": [
+        # Use `datetime` objects with a timezone
+        datetime(2023, 3, 17).replace(tzinfo=timezone.utc),
+        datetime(2023, 3, 18).replace(tzinfo=timezone.utc),
+        # .. more dates
+        # Or use RFC 3339 format
+        "2024-12-07T00:00:00Z",
+        "2024-12-08T00:00:00Z",
+    ],
+}
+
+obj_uuid = my_collection.data.insert(example_object)
+# END AddObject
+
+returned_obj = my_collection.query.fetch_object_by_id(obj_uuid)
+
+assert obj_uuid is not None
+assert returned_obj.properties["tour_start"] == example_object["tour_start"]
+# Only testing the `tour_start` date for simplicity (the `tour_dates` array has mixed date formats)
+
+client.close()

--- a/_includes/code/python/config-refs.datatypes.geocoordinates.py
+++ b/_includes/code/python/config-refs.datatypes.geocoordinates.py
@@ -1,0 +1,41 @@
+import weaviate
+
+# START ConfigureDataType
+from weaviate.classes.config import Property, DataType
+from weaviate.classes.data import GeoCoordinate
+
+# END ConfigureDataType
+
+client = weaviate.connect_to_local()
+
+# Delete collection if it exists
+client.collections.delete(name="City")
+
+# START ConfigureDataType
+# Create collection
+my_collection = client.collections.create(
+    name="City",
+    properties=[
+        Property(name="name", data_type=DataType.TEXT),
+        Property(name="location", data_type=DataType.GEO_COORDINATES),
+    ],
+    # Other properties are omitted for brevity
+)
+# END ConfigureDataType
+
+# START AddObject
+# Create an object
+example_object = {
+    "name": "Sydney",
+    "location": GeoCoordinate(latitude=-33.8688, longitude=151.2093),
+}
+
+obj_uuid = my_collection.data.insert(example_object)
+# END AddObject
+
+returned_obj = my_collection.query.fetch_object_by_id(obj_uuid)
+
+assert obj_uuid is not None
+assert [str(i) for i in returned_obj.properties["related_movie_uuids"]] == example_object["related_movie_uuids"]
+
+client.close()

--- a/_includes/code/python/config-refs.datatypes.numerical.py
+++ b/_includes/code/python/config-refs.datatypes.numerical.py
@@ -1,7 +1,7 @@
 import weaviate
 
 # START ConfigureDataType
-from weaviate.classes.config import Property, DataType, Configure, Tokenization
+from weaviate.classes.config import Property, DataType
 
 # END ConfigureDataType
 

--- a/_includes/code/python/config-refs.datatypes.numerical.py
+++ b/_includes/code/python/config-refs.datatypes.numerical.py
@@ -1,0 +1,46 @@
+import weaviate
+
+# START ConfigureDataType
+from weaviate.classes.config import Property, DataType, Configure, Tokenization
+
+# END ConfigureDataType
+
+client = weaviate.connect_to_local()
+
+# Delete collection if it exists
+client.collections.delete(name="Product")
+
+# START ConfigureDataType
+# Create collection
+my_collection = client.collections.create(
+    name="Product",
+    properties=[
+        Property(name="name", data_type=DataType.TEXT),
+        Property(name="price", data_type=DataType.NUMBER),
+        Property(name="stock_quantity", data_type=DataType.INT),
+        Property(name="is_on_sale", data_type=DataType.BOOL),
+        Property(name="customer_ratings", data_type=DataType.NUMBER_ARRAY),
+    ],
+    # Other properties are omitted for brevity
+)
+# END ConfigureDataType
+
+# START AddObject
+# Create an object
+example_object = {
+    "name": "Wireless Headphones",
+    "price": 95.50,
+    "stock_quantity": 100,
+    "is_on_sale": True,
+    "customer_ratings": [4.5, 4.8, 4.2],
+}
+
+obj_uuid = my_collection.data.insert(example_object)
+# END AddObject
+
+returned_obj = my_collection.query.fetch_object_by_id(obj_uuid)
+
+assert obj_uuid is not None
+assert returned_obj.properties == example_object
+
+client.close()

--- a/_includes/code/python/config-refs.datatypes.object.py
+++ b/_includes/code/python/config-refs.datatypes.object.py
@@ -1,7 +1,7 @@
 import weaviate
 
 # START ConfigureDataType
-from weaviate.classes.config import Property, DataType, Configure, Tokenization
+from weaviate.classes.config import Property, DataType
 
 # END ConfigureDataType
 

--- a/_includes/code/python/config-refs.datatypes.object.py
+++ b/_includes/code/python/config-refs.datatypes.object.py
@@ -1,0 +1,85 @@
+import weaviate
+
+# START ConfigureDataType
+from weaviate.classes.config import Property, DataType, Configure, Tokenization
+
+# END ConfigureDataType
+
+client = weaviate.connect_to_local()
+
+# Delete collection if it exists
+client.collections.delete(name="Person")
+
+# START ConfigureDataType
+# Create collection
+my_collection = client.collections.create(
+    name="Person",
+    properties=[
+        Property(name="name", data_type=DataType.TEXT),
+        Property(
+            name="home_address",
+            data_type=DataType.OBJECT,
+            nested_properties=[
+                Property(
+                    name="street",
+                    data_type=DataType.OBJECT,
+                    nested_properties=[
+                        Property(name="number", data_type=DataType.INT),
+                        Property(name="name", data_type=DataType.TEXT),
+                    ],
+                ),
+                Property(name="city", data_type=DataType.TEXT),
+            ],
+        ),
+        Property(
+            name="office_addresses",
+            data_type=DataType.OBJECT_ARRAY,
+            nested_properties=[
+                Property(name="office_name", data_type=DataType.TEXT),
+                Property(
+                    name="street",
+                    data_type=DataType.OBJECT,
+                    nested_properties=[
+                        Property(name="name", data_type=DataType.TEXT),
+                        Property(name="number", data_type=DataType.INT),
+                    ],
+                ),
+            ],
+        ),
+    ],
+    # Other properties are omitted for brevity
+)
+# END ConfigureDataType
+
+# START AddObject
+# Create an object
+example_object = {
+    "name": "John Smith",
+    "home_address": {
+        "street": {
+            "number": 123,
+            "name": "Main Street",
+        },
+        "city": "London",
+    },
+    "office_addresses": [
+        {
+            "office_name": "London HQ",
+            "street": {"number": 456, "name": "Oxford Street"},
+        },
+        {
+            "office_name": "Manchester Branch",
+            "street": {"number": 789, "name": "Piccadilly Gardens"},
+        },
+    ],
+}
+
+obj_uuid = my_collection.data.insert(example_object)
+# END AddObject
+
+returned_obj = my_collection.query.fetch_object_by_id(obj_uuid)
+
+assert obj_uuid is not None
+assert returned_obj.properties == example_object
+
+client.close()

--- a/_includes/code/python/config-refs.datatypes.phonenumber.py
+++ b/_includes/code/python/config-refs.datatypes.phonenumber.py
@@ -1,0 +1,41 @@
+import weaviate
+
+# START ConfigureDataType
+from weaviate.classes.config import Property, DataType
+from weaviate.classes.data import PhoneNumber
+
+# END ConfigureDataType
+
+client = weaviate.connect_to_local()
+
+# Delete collection if it exists
+client.collections.delete(name="Person")
+
+# START ConfigureDataType
+# Create collection
+my_collection = client.collections.create(
+    name="Person",
+    properties=[
+        Property(name="name", data_type=DataType.TEXT),
+        Property(name="phone", data_type=DataType.PHONE_NUMBER),
+    ],
+    # Other properties are omitted for brevity
+)
+# END ConfigureDataType
+
+# START AddObject
+# Create an object
+example_object = {
+    "name": "Ray Stantz",
+    "phone": PhoneNumber(number="212 555 2368", default_country="us"),
+}
+
+obj_uuid = my_collection.data.insert(example_object)
+# END AddObject
+
+returned_obj = my_collection.query.fetch_object_by_id(obj_uuid)
+
+assert obj_uuid is not None
+assert returned_obj.properties["phone"].national == 2125552368
+
+client.close()

--- a/_includes/code/python/config-refs.datatypes.text.py
+++ b/_includes/code/python/config-refs.datatypes.text.py
@@ -7,15 +7,13 @@ from weaviate.classes.config import Property, DataType, Configure, Tokenization
 
 client = weaviate.connect_to_local()
 
-collection_name = "TestCollection"
-
 # Delete collection if it exists
-client.collections.delete(name=collection_name)
+client.collections.delete(name="Movie")
 
 # START ConfigureDataType
 # Create collection
 my_collection = client.collections.create(
-    name=collection_name,
+    name="Movie",
     properties=[
         Property(
             name="title", data_type=DataType.TEXT, tokenization=Tokenization.LOWERCASE
@@ -27,6 +25,7 @@ my_collection = client.collections.create(
             name="genres", data_type=DataType.TEXT_ARRAY, tokenization=Tokenization.WORD
         ),
     ],
+    # END ConfigureDataType
     vectorizer_config=[
         Configure.NamedVectors.text2vec_ollama(
             name="main",
@@ -38,18 +37,25 @@ my_collection = client.collections.create(
             model="snowflake-arctic-embed",  # The model to use, e.g. "nomic-embed-text"
         )
     ],
+    # START ConfigureDataType
+    # Other properties are omitted for brevity
 )
 # END ConfigureDataType
 
+# START AddObject
 # Create an object
-obj_uuid = my_collection.data.insert(
-    {
-        "title": "Rogue One",
-        "movie_id": "ro123456",
-        "genres": ["Action", "Adventure", "Sci-Fi"],
-    }
-)
+example_object = {
+    "title": "Rogue One",
+    "movie_id": "ro123456",
+    "genres": ["Action", "Adventure", "Sci-Fi"],
+}
+
+obj_uuid = my_collection.data.insert(example_object)
+# END AddObject
+
+returned_obj = my_collection.query.fetch_object_by_id(obj_uuid)
 
 assert obj_uuid is not None
+assert returned_obj.properties == example_object
 
 client.close()

--- a/_includes/code/python/config-refs.datatypes.text.py
+++ b/_includes/code/python/config-refs.datatypes.text.py
@@ -1,0 +1,55 @@
+import weaviate
+
+# START ConfigureDataType
+from weaviate.classes.config import Property, DataType, Configure, Tokenization
+
+# END ConfigureDataType
+
+client = weaviate.connect_to_local()
+
+collection_name = "TestCollection"
+
+# Delete collection if it exists
+client.collections.delete(name=collection_name)
+
+# START ConfigureDataType
+# Create collection
+my_collection = client.collections.create(
+    name=collection_name,
+    properties=[
+        Property(
+            name="title", data_type=DataType.TEXT, tokenization=Tokenization.LOWERCASE
+        ),
+        Property(
+            name="movie_id", data_type=DataType.TEXT, tokenization=Tokenization.FIELD
+        ),
+        Property(
+            name="genres", data_type=DataType.TEXT_ARRAY, tokenization=Tokenization.WORD
+        ),
+    ],
+    vectorizer_config=[
+        Configure.NamedVectors.text2vec_ollama(
+            name="main",
+            source_properties=[
+                "title",
+                "genres",
+            ],  # Note that "movie_id" is not included
+            api_endpoint="http://host.docker.internal:11434",  # If using Docker, use this to contact your local Ollama instance
+            model="snowflake-arctic-embed",  # The model to use, e.g. "nomic-embed-text"
+        )
+    ],
+)
+# END ConfigureDataType
+
+# Create an object
+obj_uuid = my_collection.data.insert(
+    {
+        "title": "Rogue One",
+        "movie_id": "ro123456",
+        "genres": ["Action", "Adventure", "Sci-Fi"],
+    }
+)
+
+assert obj_uuid is not None
+
+client.close()

--- a/_includes/code/python/config-refs.datatypes.uuid.py
+++ b/_includes/code/python/config-refs.datatypes.uuid.py
@@ -1,0 +1,47 @@
+import weaviate
+
+# START ConfigureDataType
+from weaviate.classes.config import Property, DataType
+from weaviate.util import generate_uuid5
+
+# END ConfigureDataType
+
+client = weaviate.connect_to_local()
+
+# Delete collection if it exists
+client.collections.delete(name="Movie")
+
+# START ConfigureDataType
+# Create collection
+my_collection = client.collections.create(
+    name="Movie",
+    properties=[
+        Property(name="title", data_type=DataType.TEXT),
+        Property(name="movie_uuid", data_type=DataType.UUID),
+        Property(name="related_movie_uuids", data_type=DataType.UUID_ARRAY),
+    ],
+    # Other properties are omitted for brevity
+)
+# END ConfigureDataType
+
+# START AddObject
+# Create an object
+example_object = {
+    "title": "The Matrix",
+    "movie_uuid": generate_uuid5("The Matrix"),
+    "related_movie_uuids": [
+        generate_uuid5("The Matrix Reloaded"),
+        generate_uuid5("The Matrix Revolutions"),
+        generate_uuid5("Matrix Resurrections"),
+    ],
+}
+
+obj_uuid = my_collection.data.insert(example_object)
+# END AddObject
+
+returned_obj = my_collection.query.fetch_object_by_id(obj_uuid)
+
+assert obj_uuid is not None
+assert [str(i) for i in returned_obj.properties["related_movie_uuids"]] == example_object["related_movie_uuids"]
+
+client.close()

--- a/_includes/code/typescript/config-refs.datatypes.blob.ts
+++ b/_includes/code/typescript/config-refs.datatypes.blob.ts
@@ -1,0 +1,49 @@
+import assert from 'assert';
+import weaviate, { WeaviateClient } from 'weaviate-client';
+
+// START ConfigureDataType
+import { dataType } from 'weaviate-client';
+
+// END ConfigureDataType
+
+const client: WeaviateClient = await weaviate.connectToLocal();
+
+await client.collections.delete('Poster');
+
+// START ConfigureDataType
+// Create collection
+const myCollection = await client.collections.create({
+  name: 'Poster',
+  properties: [
+    {
+      name: 'title',
+      dataType: dataType.TEXT,
+    },
+    {
+      name: 'image',
+      dataType: dataType.BLOB,
+    },
+  ],
+  // Other properties are omitted for brevity
+});
+// END ConfigureDataType
+
+const blob_string = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+// START AddObject
+const exampleObject = {
+  title: 'The Matrix',
+  image: blob_string
+};
+
+const obj_uuid = await myCollection.data.insert(exampleObject);
+// END AddObject
+
+const returnedObject = await myCollection.query.fetchObjectById(obj_uuid, {
+  returnProperties: ['name', 'image']  // Need to specify `image` to get the blob
+});
+
+assert.notEqual(obj_uuid, null);
+assert.deepEqual(returnedObject?.properties, exampleObject);
+
+client.close();

--- a/_includes/code/typescript/config-refs.datatypes.date.ts
+++ b/_includes/code/typescript/config-refs.datatypes.date.ts
@@ -1,0 +1,73 @@
+import assert from 'assert';
+import weaviate, { WeaviateClient } from 'weaviate-client';
+
+// START ConfigureDataType
+import { dataType } from 'weaviate-client';
+
+// END ConfigureDataType
+
+const client: WeaviateClient = await weaviate.connectToLocal();
+
+await client.collections.delete('ConcertTour');
+
+// START ConfigureDataType
+// Create collection
+const myCollection = await client.collections.create({
+  name: 'ConcertTour',
+  properties: [
+    {
+      name: 'artist',
+      dataType: dataType.TEXT,
+    },
+    {
+      name: 'tour_name',
+      dataType: dataType.TEXT,
+    },
+    {
+      name: 'tour_start',
+      dataType: dataType.DATE,
+    },
+    {
+      name: 'tour_dates',
+      dataType: dataType.DATE_ARRAY,
+    },
+  ],
+  // Other properties are omitted for brevity
+});
+// END ConfigureDataType
+
+// START AddObject
+const exampleObject = {
+  name: 'Taylor Swift',
+  tour_name: 'Eras Tour',
+  tour_start: new Date(2023, 3, 17),
+  // Use JavaScript Date object
+  tour_dates: [
+    new Date(2023, 3, 17),
+    new Date(2023, 3, 18),
+    // .. more dates
+    new Date(2024, 12, 6),
+    new Date(2024, 12, 7),
+  ],
+  // // Or, use RFC3339 string
+  // tour_dates: [
+  //   '2023-03-17T00:00:00Z',
+  //   '2023-03-18T00:00:00Z',
+  //   // .. more dates
+  //   '2024-12-07T00:00:00Z',
+  //   '2024-12-08T00:00:00Z',
+  // ]
+};
+
+const obj_uuid = await myCollection.data.insert(exampleObject);
+// END AddObject
+
+const returnedObject = await myCollection.query.fetchObjectById(obj_uuid);
+
+assert.notEqual(obj_uuid, null);
+assert.deepEqual(
+  returnedObject?.properties.tour_start,
+  exampleObject.tour_start
+);
+
+client.close();

--- a/_includes/code/typescript/config-refs.datatypes.geocoordinates.ts
+++ b/_includes/code/typescript/config-refs.datatypes.geocoordinates.ts
@@ -1,0 +1,50 @@
+import assert from 'assert';
+import weaviate, { WeaviateClient } from 'weaviate-client';
+import { GeoCoordinate } from 'weaviate-client';
+
+// START ConfigureDataType
+import { dataType } from 'weaviate-client';
+
+// END ConfigureDataType
+
+const client: WeaviateClient = await weaviate.connectToLocal();
+
+await client.collections.delete('City');
+
+// START ConfigureDataType
+// Create collection
+const myCollection = await client.collections.create({
+  name: 'City',
+  properties: [
+    {
+      name: 'name',
+      dataType: dataType.TEXT,
+    },
+    {
+      name: 'location',
+      dataType: dataType.GEO_COORDINATES,
+    },
+  ],
+  // Other properties are omitted for brevity
+});
+// END ConfigureDataType
+
+// START AddObject
+const exampleObject = {
+  name: 'Sydney',
+  location: {
+    latitude: -33.8688,
+    longitude: 151.2093
+  },
+};
+
+const obj_uuid = await myCollection.data.insert(exampleObject);
+// END AddObject
+
+const returnedObject = await myCollection.query.fetchObjectById(obj_uuid);
+
+assert.notEqual(obj_uuid, null);
+assert((returnedObject?.properties.location as GeoCoordinate).latitude - exampleObject.location.latitude < 0.0001);
+assert((returnedObject?.properties.location as GeoCoordinate).longitude - exampleObject.location.longitude < 0.0001);
+
+client.close();

--- a/_includes/code/typescript/config-refs.datatypes.numerical.ts
+++ b/_includes/code/typescript/config-refs.datatypes.numerical.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import weaviate, { WeaviateClient } from 'weaviate-client';
 
 // START ConfigureDataType
-import { vectorizer, dataType, tokenization } from 'weaviate-client';
+import { dataType } from 'weaviate-client';
 
 // END ConfigureDataType
 
@@ -42,12 +42,12 @@ const myCollection = await client.collections.create({
 
 // START AddObject
 const exampleObject = {
-  'name': 'Wireless Headphones',
-  'price': 95.50,
-  'stock_quantity': 100,
-  'is_on_sale': true,
-  'customer_ratings': [4.5, 4.8, 4.2],
-}
+  name: 'Wireless Headphones',
+  price: 95.5,
+  stock_quantity: 100,
+  is_on_sale: true,
+  customer_ratings: [4.5, 4.8, 4.2],
+};
 
 const obj_uuid = await myCollection.data.insert(exampleObject);
 // END AddObject
@@ -56,6 +56,5 @@ const returnedObject = await myCollection.query.fetchObjectById(obj_uuid);
 
 assert.notEqual(obj_uuid, null);
 assert.deepEqual(returnedObject?.properties, exampleObject);
-
 
 client.close();

--- a/_includes/code/typescript/config-refs.datatypes.numerical.ts
+++ b/_includes/code/typescript/config-refs.datatypes.numerical.ts
@@ -1,0 +1,61 @@
+import assert from 'assert';
+import weaviate, { WeaviateClient } from 'weaviate-client';
+
+// START ConfigureDataType
+import { vectorizer, dataType, tokenization } from 'weaviate-client';
+
+// END ConfigureDataType
+
+const client: WeaviateClient = await weaviate.connectToLocal();
+
+await client.collections.delete('Product');
+
+// START ConfigureDataType
+// Create collection
+const myCollection = await client.collections.create({
+  name: 'Product',
+  properties: [
+    {
+      name: 'name',
+      dataType: dataType.TEXT,
+    },
+    {
+      name: 'price',
+      dataType: dataType.NUMBER,
+    },
+    {
+      name: 'stock_quantity',
+      dataType: dataType.INT,
+    },
+    {
+      name: 'is_on_sale',
+      dataType: dataType.BOOLEAN,
+    },
+    {
+      name: 'customer_ratings',
+      dataType: dataType.NUMBER_ARRAY,
+    },
+  ],
+  // Other properties are omitted for brevity
+});
+// END ConfigureDataType
+
+// START AddObject
+const exampleObject = {
+  'name': 'Wireless Headphones',
+  'price': 95.50,
+  'stock_quantity': 100,
+  'is_on_sale': true,
+  'customer_ratings': [4.5, 4.8, 4.2],
+}
+
+const obj_uuid = await myCollection.data.insert(exampleObject);
+// END AddObject
+
+const returnedObject = await myCollection.query.fetchObjectById(obj_uuid);
+
+assert.notEqual(obj_uuid, null);
+assert.deepEqual(returnedObject?.properties, exampleObject);
+
+
+client.close();

--- a/_includes/code/typescript/config-refs.datatypes.object.ts
+++ b/_includes/code/typescript/config-refs.datatypes.object.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import weaviate, { WeaviateClient } from 'weaviate-client';
 
 // START ConfigureDataType
-import { vectorizer, dataType, tokenization } from 'weaviate-client';
+import { dataType } from 'weaviate-client';
 
 // END ConfigureDataType
 

--- a/_includes/code/typescript/config-refs.datatypes.object.ts
+++ b/_includes/code/typescript/config-refs.datatypes.object.ts
@@ -1,0 +1,105 @@
+import assert from 'assert';
+import weaviate, { WeaviateClient } from 'weaviate-client';
+
+// START ConfigureDataType
+import { vectorizer, dataType, tokenization } from 'weaviate-client';
+
+// END ConfigureDataType
+
+const client: WeaviateClient = await weaviate.connectToLocal();
+
+await client.collections.delete('Person');
+
+// START ConfigureDataType
+// Create collection
+const myCollection = await client.collections.create({
+  name: 'Person',
+  properties: [
+    {
+      name: 'name',
+      dataType: dataType.TEXT,
+    },
+    {
+      name: 'home_address',
+      dataType: dataType.OBJECT,
+      nestedProperties: [
+        {
+          name: 'street',
+          dataType: dataType.OBJECT,
+          nestedProperties: [
+            {
+              name: 'number',
+              dataType: dataType.INT,
+            },
+            {
+              name: 'name',
+              dataType: dataType.TEXT,
+            },
+          ],
+        },
+        {
+          name: 'city',
+          dataType: dataType.TEXT,
+        },
+      ],
+    },
+    {
+      name: 'office_addresses',
+      dataType: dataType.OBJECT_ARRAY,
+      nestedProperties: [
+        {
+          name: 'office_name',
+          dataType: dataType.TEXT,
+        },
+        {
+          name: 'street',
+          dataType: dataType.OBJECT,
+          nestedProperties: [
+            {
+              name: 'number',
+              dataType: dataType.INT,
+            },
+            {
+              name: 'name',
+              dataType: dataType.TEXT,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  // Other properties are omitted for brevity
+});
+// END ConfigureDataType
+
+// START AddObject
+const exampleObject = {
+  name: 'John Smith',
+  home_address: {
+    street: {
+      number: 123,
+      name: 'Main Street',
+    },
+    city: 'London',
+  },
+  office_addresses: [
+    {
+      office_name: 'London HQ',
+      street: { number: 456, name: 'Oxford Street' },
+    },
+    {
+      office_name: 'Manchester Branch',
+      street: { number: 789, name: 'Piccadilly Gardens' },
+    },
+  ],
+};
+
+const obj_uuid = await myCollection.data.insert(exampleObject);
+// END AddObject
+
+const returnedObject = await myCollection.query.fetchObjectById(obj_uuid);
+
+assert.notEqual(obj_uuid, null);
+assert.deepEqual(returnedObject?.properties, exampleObject);
+
+client.close();

--- a/_includes/code/typescript/config-refs.datatypes.phonenumber.ts
+++ b/_includes/code/typescript/config-refs.datatypes.phonenumber.ts
@@ -1,0 +1,49 @@
+import assert from 'assert';
+import weaviate, { WeaviateClient } from 'weaviate-client';
+import { PhoneNumber } from 'weaviate-client';
+
+// START ConfigureDataType
+import { dataType } from 'weaviate-client';
+
+// END ConfigureDataType
+
+const client: WeaviateClient = await weaviate.connectToLocal();
+
+await client.collections.delete('Person');
+
+// START ConfigureDataType
+// Create collection
+const myCollection = await client.collections.create({
+  name: 'Person',
+  properties: [
+    {
+      name: 'name',
+      dataType: dataType.TEXT,
+    },
+    {
+      name: 'phone',
+      dataType: dataType.PHONE_NUMBER,
+    },
+  ],
+  // Other properties are omitted for brevity
+});
+// END ConfigureDataType
+
+// START AddObject
+const exampleObject = {
+  name: 'Ray Stantz',
+  phone: {
+    number: '212 555 2368',
+    defaultCountry: 'us'
+  }
+};
+
+const obj_uuid = await myCollection.data.insert(exampleObject);
+// END AddObject
+
+const returnedObject = await myCollection.query.fetchObjectById(obj_uuid);
+
+assert.notEqual(obj_uuid, null);
+assert((returnedObject?.properties.phone as PhoneNumber).national == 2125552368);
+
+client.close();

--- a/_includes/code/typescript/config-refs.datatypes.text.ts
+++ b/_includes/code/typescript/config-refs.datatypes.text.ts
@@ -8,11 +8,12 @@ import { vectorizer, dataType, tokenization } from 'weaviate-client';
 
 const client: WeaviateClient = await weaviate.connectToLocal();
 
-const collectionName = 'TestCollection';
+await client.collections.delete('Movie');
 
 // START ConfigureDataType
+// Create collection
 const myCollection = await client.collections.create({
-  name: collectionName,
+  name: 'Movie',
   properties: [
     {
       name: 'title',
@@ -30,6 +31,7 @@ const myCollection = await client.collections.create({
       tokenization: tokenization.WORD,
     },
   ],
+  // END ConfigureDataType
   vectorizers: [
     vectorizer.text2VecOllama({
       name: 'main',
@@ -38,15 +40,25 @@ const myCollection = await client.collections.create({
       model: 'snowflake-arctic-embed', // The model to use, e.g. "nomic-embed-text"
     }),
   ],
+  // START ConfigureDataType
+  // Other properties are omitted for brevity
 });
 // END ConfigureDataType
 
-const new_uuid = await myCollection.data.insert({
+// START AddObject
+const exampleObject = {
   title: 'Rogue One',
   movie_id: 'ro123456',
   genres: ['Action', 'Adventure', 'Sci-Fi'],
-});
+}
 
-assert.notEqual(new_uuid, null);
+const obj_uuid = await myCollection.data.insert(exampleObject);
+// END AddObject
+
+const returnedObject = await myCollection.query.fetchObjectById(obj_uuid);
+
+assert.notEqual(obj_uuid, null);
+assert.deepEqual(returnedObject?.properties, exampleObject);
+
 
 client.close();

--- a/_includes/code/typescript/config-refs.datatypes.text.ts
+++ b/_includes/code/typescript/config-refs.datatypes.text.ts
@@ -1,0 +1,52 @@
+import assert from 'assert';
+import weaviate, { WeaviateClient } from 'weaviate-client';
+
+// START ConfigureDataType
+import { vectorizer, dataType, tokenization } from 'weaviate-client';
+
+// END ConfigureDataType
+
+const client: WeaviateClient = await weaviate.connectToLocal();
+
+const collectionName = 'TestCollection';
+
+// START ConfigureDataType
+const myCollection = await client.collections.create({
+  name: collectionName,
+  properties: [
+    {
+      name: 'title',
+      dataType: dataType.TEXT,
+      tokenization: tokenization.LOWERCASE,
+    },
+    {
+      name: 'movie_id',
+      dataType: dataType.TEXT,
+      tokenization: tokenization.FIELD,
+    },
+    {
+      name: 'genres',
+      dataType: dataType.TEXT_ARRAY,
+      tokenization: tokenization.WORD,
+    },
+  ],
+  vectorizers: [
+    vectorizer.text2VecOllama({
+      name: 'main',
+      sourceProperties: ['title', 'genres'],
+      apiEndpoint: 'http://host.docker.internal:11434', // If using Docker, use this to contact your local Ollama instance
+      model: 'snowflake-arctic-embed', // The model to use, e.g. "nomic-embed-text"
+    }),
+  ],
+});
+// END ConfigureDataType
+
+const new_uuid = await myCollection.data.insert({
+  title: 'Rogue One',
+  movie_id: 'ro123456',
+  genres: ['Action', 'Adventure', 'Sci-Fi'],
+});
+
+assert.notEqual(new_uuid, null);
+
+client.close();

--- a/_includes/code/typescript/config-refs.datatypes.uuid.ts
+++ b/_includes/code/typescript/config-refs.datatypes.uuid.ts
@@ -1,0 +1,55 @@
+import assert from 'assert';
+import weaviate, { WeaviateClient } from 'weaviate-client';
+
+// START ConfigureDataType
+import { dataType } from 'weaviate-client';
+import { generateUuid5 } from 'weaviate-client';
+
+// END ConfigureDataType
+
+const client: WeaviateClient = await weaviate.connectToLocal();
+
+await client.collections.delete('Movie');
+
+// START ConfigureDataType
+// Create collection
+const myCollection = await client.collections.create({
+  name: 'Movie',
+  properties: [
+    {
+      name: 'title',
+      dataType: dataType.TEXT,
+    },
+    {
+      name: 'movie_uuid',
+      dataType: dataType.UUID,
+    },
+    {
+      name: 'related_movie_uuids',
+      dataType: dataType.UUID_ARRAY,
+    },
+  ],
+  // Other properties are omitted for brevity
+});
+// END ConfigureDataType
+
+// START AddObject
+const exampleObject = {
+  title: 'The Matrix',
+  movie_uuid: generateUuid5('The Matrix'),
+  related_movie_uuids: [
+    generateUuid5('The Matrix Reloaded'),
+    generateUuid5('The Matrix Revolutions'),
+    generateUuid5('The Matrix Resurrections'),
+  ],
+};
+
+const obj_uuid = await myCollection.data.insert(exampleObject);
+// END AddObject
+
+const returnedObject = await myCollection.query.fetchObjectById(obj_uuid);
+
+assert.notEqual(obj_uuid, null);
+assert.deepEqual(returnedObject?.properties, exampleObject);
+
+client.close();

--- a/_includes/datatypes.mdx
+++ b/_includes/datatypes.mdx
@@ -1,16 +1,16 @@
 | Name | Exact type | Formatting | Array (`[]`) available (example) | Note |
 |------|------------|------------|---------------------------|------|
 | text | string | `string` | ✅ `["string one", "string two"]` |
-| object | object | `{"child": "I'm nested!"}` | ✅ `[{"child": "I'm nested!"}, {"child": "I'm nested too!"}` | Available from `1.22` |
-| int | int64 (see [notes](/developers/weaviate/config-refs/datatypes#notes)) | `0` | ✅ `[0, 1]` | |
 | boolean | boolean | `true`/`false` | ✅ `[true, false]` | |
+| int | int64 (see [notes](/developers/weaviate/config-refs/datatypes#notes)) | `123` | ✅ `[123, 456]` | |
 | number | float64 | `0.0` | ✅ `[0.0, 1.1]` | |
-| date | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-date) | ✅ | |
+| date | string | [more info](/developers/weaviate/config-refs/datatypes#date) | ✅ | |
 | uuid | string | `"c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c"` | ✅ `["c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c", "36ddd591-2dee-4e7e-a3cc-eb86d30a4303"]` | |
-| geoCoordinates | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-geocoordinates) | ❌ | |
-| phoneNumber | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-phonenumber) | ❌ | |
-| blob | base64 encoded string | [more info](/developers/weaviate/config-refs/datatypes#datatype-blob) | ❌ | |
-| *cross reference* | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-cross-reference) | ❌ | |
+| geoCoordinates | string | [more info](/developers/weaviate/config-refs/datatypes#geocoordinates) | ❌ | |
+| phoneNumber | string | [more info](/developers/weaviate/config-refs/datatypes#phonenumber) | ❌ | |
+| blob | base64 encoded string | [more info](/developers/weaviate/config-refs/datatypes#blob) | ❌ | |
+| object | object | `{"child": "I'm nested!"}` | ✅ `[{"child": "I'm nested!"}, {"child": "I'm nested too!"}` | Available from `1.22` |
+| *cross reference* | string | [more info](/developers/weaviate/config-refs/datatypes#cross-reference) | ❌ | |
 
 
 <details>

--- a/_includes/datatypes.mdx
+++ b/_includes/datatypes.mdx
@@ -2,7 +2,7 @@
 |------|------------|------------|---------------------------|------|
 | text | string | `string` | ✅ `["string one", "string two"]` |
 | boolean | boolean | `true`/`false` | ✅ `[true, false]` | |
-| int | int64 (see [notes](/developers/weaviate/config-refs/datatypes#notes)) | `123` | ✅ `[123, 456]` | |
+| int | int64 (see [notes](/developers/weaviate/config-refs/datatypes#note-graphql-and-int64)) | `123` | ✅ `[123, -456]` | |
 | number | float64 | `0.0` | ✅ `[0.0, 1.1]` | |
 | date | string | [more info](/developers/weaviate/config-refs/datatypes#date) | ✅ | |
 | uuid | string | `"c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c"` | ✅ `["c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c", "36ddd591-2dee-4e7e-a3cc-eb86d30a4303"]` | |

--- a/_includes/datatypes.mdx
+++ b/_includes/datatypes.mdx
@@ -1,28 +1,24 @@
-| Weaviate Type | Exact Data Type | Formatting | Note |
-|---------------|-----------------|------------|------|
-| text | string | `string` | |
-| text[] | list of strings | `["string one", "string two"]` | |
-| object | object | `{"child": "I'm nested!"}` | Available from `1.22` |
-| object[] | list of objects | `[{"child": "I'm nested!"}, {"child": "I'm nested too!"}` | Available from `1.22` |
-| int | int64 (see note) | `0` | |
-| int[] | list of int64 (see note) | `[0, 1]` | |
-| boolean | boolean | `true`/`false` | |
-| boolean[] | list of booleans | `[true, false]` | |
-| number | float64 | `0.0` | |
-| number[] | list of float64 | `[0.0, 1.1]` | |
-| date | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-date) | |
-| date[] | list of string | [more info](/developers/weaviate/config-refs/datatypes#datatype-date) | |
-| uuid | string | `"c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c"` | |
-| uuid[] | list of strings | `["c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c", "36ddd591-2dee-4e7e-a3cc-eb86d30a4303"]` | |
-| geoCoordinates | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-geocoordinates) | |
-| phoneNumber | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-phonenumber) | |
-| blob | base64 encoded string | [more info](/developers/weaviate/config-refs/datatypes#datatype-blob) | |
-| *cross reference* | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-cross-reference) | |
+| Name | Exact type | Formatting | Array (`[]`) available (example) | Note |
+|------|------------|------------|---------------------------|------|
+| text | string | `string` | ✅ `["string one", "string two"]` |
+| object | object | `{"child": "I'm nested!"}` | ✅ `[{"child": "I'm nested!"}, {"child": "I'm nested too!"}` | Available from `1.22` |
+| int | int64 (see [notes](/developers/weaviate/config-refs/datatypes#notes)) | `0` | ✅ `[0, 1]` | |
+| boolean | boolean | `true`/`false` | ✅ `[true, false]` | |
+| number | float64 | `0.0` | ✅ `[0.0, 1.1]` | |
+| date | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-date) | ✅ | |
+| uuid | string | `"c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c"` | ✅ `["c8f8176c-6f9b-5461-8ab3-f3c7ce8c2f5c", "36ddd591-2dee-4e7e-a3cc-eb86d30a4303"]` | |
+| geoCoordinates | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-geocoordinates) | ❌ | |
+| phoneNumber | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-phonenumber) | ❌ | |
+| blob | base64 encoded string | [more info](/developers/weaviate/config-refs/datatypes#datatype-blob) | ❌ | |
+| *cross reference* | string | [more info](/developers/weaviate/config-refs/datatypes#datatype-cross-reference) | ❌ | |
 
 
-### Deprecated types
+<details>
+  <summary>Deprecated types</summary>
 
-| Weaviate Type | Exact Data Type | Formatting | Deprecated from |
-|---------------|-----------------|------------|-----------------|
-| string | string | `"string"` | `v1.19` |
-| string[] | list of strings | `["string", "second string"]` | `v1.19` |
+| Name | Exact type | Formatting | Array available (example) | Deprecated from |
+|------|------------|------------|---------------------------|------|
+| string | string | `"string"` | ✅ `["string", "second string"]` | `v1.19` |
+
+
+</details>

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -14,16 +14,15 @@ image: og/docs/configuration.jpg
 
 ## Introduction
 
-When creating a property, Weaviate needs to know what type of data you will give it. Weaviate accepts the following types:
+When [creating a property](../manage-data/collections.mdx#add-a-property), you must specify a data type. Weaviate accepts the following types.
+
+:::note Array types
+Arrays of a data type are specified by adding `[]` to the type (e.g. `text` ➡ `text[]`). Note that not all data types support arrays.
+:::
 
 import DataTypes from '/_includes/datatypes.mdx';
 
 <DataTypes />
-
-:::note Notes
--  Although Weaviate supports `int64`, GraphQL currently only supports `int32`, and does not support `int64`. This means that currently _integer_ data fields in Weaviate with integer values larger than `int32`, will not be returned using GraphQL queries. We are working on solving this [issue](https://github.com/weaviate/weaviate/issues/1563). As current workaround is to use a `string` instead.
-- Data types are specified as an array (e.g. ["text"]), as it is required for some cross-reference specifications.
-:::
 
 ## DataType: `text`
 
@@ -229,6 +228,15 @@ There are two fields that accept input. `input` must always be set, while `defau
 
 As you can see in the code snippet above, all other fields are read-only. These fields are filled automatically, and will appear when reading back a field of type `phoneNumber`.
 
+## Notes
+
+### GraphQL and `int64`
+
+Although Weaviate supports `int64`, GraphQL currently only supports `int32`, and does not support `int64`. This means that currently _integer_ data fields in Weaviate with integer values larger than `int32`, will not be returned using GraphQL queries. We are working on solving this [issue](https://github.com/weaviate/weaviate/issues/1563). As current workaround is to use a `string` instead.
+
+### Formatting in payloads
+
+In raw payloads (e.g. JSON payloads for REST), data types are specified as an array (e.g. `["text"]`, or `["text[]"]`), as it is required for some cross-reference specifications.
 
 ## Questions and feedback
 

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -85,6 +85,61 @@ import TextTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.data
   </TabItem>
 </Tabs>
 
+## `boolean` / `int` / `number`
+
+The `boolean`, `int`, and `number` types are used for storing boolean, integer, and floating-point numbers, respectively.
+
+### Examples
+
+import NumericalTypePy from '!!raw-loader!/_includes/code/python/config-refs.datatypes.numerical.py';
+import NumericalTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.numerical.ts';
+
+#### Property definition
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={NumericalTypePy}
+      startMarker="# START ConfigureDataType"
+      endMarker="# END ConfigureDataType"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={NumericalTypeTs}
+      startMarker="// START ConfigureDataType"
+      endMarker="// END ConfigureDataType"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
+#### Object insertion
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={NumericalTypePy}
+      startMarker="# START AddObject"
+      endMarker="# END AddObject"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={NumericalTypeTs}
+      startMarker="// START AddObject"
+      endMarker="// END AddObject"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
+### Note: GraphQL and `int64`
+
+Although Weaviate supports `int64`, GraphQL currently only supports `int32`, and does not support `int64`. This means that currently _integer_ data fields in Weaviate with integer values larger than `int32`, will not be returned using GraphQL queries. We are working on solving this [issue](https://github.com/weaviate/weaviate/issues/1563). As current workaround is to use a `string` instead.
+
 ## `date`
 
 A `date` in Weaviate is represented by an [RFC 3339](https://datatracker.ietf.org/doc/rfc3339/) timestamp in the `date-time` format. The timestamp includes the time and an offset.
@@ -336,10 +391,6 @@ In the above example, our objects can be linked to:
 :::
 
 ### Notes
-
-#### GraphQL and `int64`
-
-Although Weaviate supports `int64`, GraphQL currently only supports `int32`, and does not support `int64`. This means that currently _integer_ data fields in Weaviate with integer values larger than `int32`, will not be returned using GraphQL queries. We are working on solving this [issue](https://github.com/weaviate/weaviate/issues/1563). As current workaround is to use a `string` instead.
 
 #### Formatting in payloads
 

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -21,20 +21,29 @@ import DataTypes from '/_includes/datatypes.mdx';
 
 <DataTypes />
 
-## DataType: `text`
+## `text`
 
-Use this type for any textual data. Properties with the `text` type is used for vectorization and keyword search unless specified otherwise [in the property settings](../manage-data/collections.mdx#property-level-settings).
+Use this type for any textual data.
 
-If using [named vectors](../concepts/data.md#multiple-vectors-named-vectors), the property vectorization is defined in the [named vector definition](../manage-data/collections.mdx#define-multiple-named-vectors).
+- Properties with the `text` type is used for vectorization and keyword search unless specified otherwise [in the property settings](../manage-data/collections.mdx#property-level-settings).
+- If using [named vectors](../concepts/data.md#multiple-vectors-named-vectors), the property vectorization is defined in the [named vector definition](../manage-data/collections.mdx#define-multiple-named-vectors).
+- Text properties are tokenized prior to being indexed for keyword/BM25 searches. See [collection definition: tokenization](../config-refs/schema/index.md#property-tokenization) for more information.
 
-### Tokenization configuration
+<details>
+  <summary><code>string</code> is deprecated</summary>
 
-Text properties are tokenized prior to being indexed for keyword/BM25 searches. See [collection definition: tokenization](../config-refs/schema/index.md#property-tokenization) for more information.
+Prior to `v1.19`, Weaviate supported an additional datatype `string`, which was differentiated by tokenization behavior to `text`. As of `v1.19`, this type is deprecated and will be removed in a future release.
 
-### Usage examples
+Use `text` instead of `string`. `text` supports the tokenization options that are available through `string`.
+
+</details>
+
+### Examples
 
 import TextTypePy from '!!raw-loader!/_includes/code/python/config-refs.datatypes.text.py';
 import TextTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.text.ts';
+
+#### Property definition
 
 <Tabs groupId="languages">
   <TabItem value="py" label="Python Client v4">
@@ -55,89 +64,28 @@ import TextTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.data
   </TabItem>
 </Tabs>
 
-<details>
-  <summary><code>string</code> is deprecated</summary>
+#### Object insertion
 
-Prior to `v1.19`, Weaviate supported an additional datatype `string`, which was differentiated by tokenization behavior to `text`. As of `v1.19`, this type is deprecated and will be removed in a future release.
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={TextTypePy}
+      startMarker="# START AddObject"
+      endMarker="# END AddObject"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={TextTypeTs}
+      startMarker="// START AddObject"
+      endMarker="// END AddObject"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
 
-Use `text` instead of `string`. `text` supports the tokenization options that are available through `string`.
-
-</details>
-
-## DataType: `cross-reference`
-
-The [`cross-reference`](../more-resources/glossary.md) type is the graph element of Weaviate: you can create a link from one object to another. In the schema you can define multiple classes to which a property can point, in a list of strings. The strings in the `dataType` list are names of classes defined elsewhere in the schema. For example:
-
-```json
-{
-  "properties": [
-    {
-      "name": "hasWritten",
-      "dataType": [
-        "Article",
-        "Blog"
-      ]
-    }
-  ]
-}
-```
-
-### Number of linked instances
-
-The `cross-reference` type objects are `arrays` by default. This allows you to link to any number of instances of a given class (including zero).
-
-In the above example, our objects can be linked to:
-* **0** Articles and **1** Blog
-* **1** Article and **3** Blogs
-* **2** Articles and **5** Blogs
-* etc.
-
-## DataType: `object`
-
-:::info Added in `v1.22`
-:::
-
-The `object` type allows you to store nested data structures in Weaviate. The data structure is a JSON object, and can be nested to any depth.
-
-For example, a `Person` class could have an `address` property, as an object. It could in turn include nested properties such as `street` and `city`:
-
-```json
-{
-    "class": "Person",
-    "properties": [
-        {
-            "dataType": ["text"],
-            "name": "last_name",
-        },
-        {
-            "dataType": ["object"],
-            "name": "address",
-            "nestedProperties": [
-                {"dataType": ["text"], "name": "street"},
-                {"dataType": ["text"], "name": "city"}
-            ],
-        }
-    ],
-}
-```
-
-An object for this class may have a structure such as follows:
-
-```json
-{
-    "last_name": "Franklin",
-    "address": {
-        "city": "London",
-        "street": "King Street"
-    }
-}
-```
-
-As of `1.22`, `object` and `object[]` datatype properties are not indexed and not vectorized.
-
-Future plans include the ability to index nested properties, for example to allow for filtering on nested properties and vectorization options.
-
-## DataType: `date`
+## `date`
 
 A `date` in Weaviate is represented by an [RFC 3339](https://datatracker.ietf.org/doc/rfc3339/) timestamp in the `date-time` format. The timestamp includes the time and an offset.
 
@@ -149,7 +97,7 @@ For example:
 
 To add a list of dates as a single entity, use an array of `date-time` formatted strings. For example: `["1985-04-12T23:20:50.52Z", "1937-01-01T12:00:27.87+00:20"]`
 
-## DataType: `blob`
+## `blob`
 
 The datatype blob accepts any binary data. The data should be `base64` encoded, and passed as a `string`. Characteristics:
 * Weaviate doesn't make assumptions about the type of data that is encoded. A module (e.g. `img2vec`) can investigate file headers as it wishes, but Weaviate itself does not do this.
@@ -194,7 +142,7 @@ curl \
   }' \
     http://localhost:8080/v1/objects
 ```
-## DataType: `uuid`
+## `uuid`
 
 :::info Added in `v1.19`
 :::
@@ -208,7 +156,7 @@ The dedicated `uuid` and `uuid[]` data types are more space-efficient than stori
 It is currently not possible to aggregate or sort by `uuid` or `uuid[]` types.
 :::
 
-## DataType: `geoCoordinates`
+## `geoCoordinates`
 
 Weaviate allows you to store geo coordinates. When querying Weaviate, you can use this type to find items in a radius around this area. A geo coordinate value is a float, and is processed as [decimal degree](https://en.wikipedia.org/wiki/Decimal_degrees) according to the [ISO standard](https://www.iso.org/standard/39242.html#:~:text=For%20computer%20data%20interchange%20of,minutes%2C%20seconds%20and%20decimal%20seconds).
 
@@ -231,7 +179,7 @@ import GeoLimitations from '/_includes/geo-limitations.mdx';
 
 <GeoLimitations/>
 
-## DataType: `phoneNumber`
+## `phoneNumber`
 
 There is a special, primitive data type `phoneNumber`. When a phone number is added to this field, the input will be normalized and validated, unlike the single fields as `number` and `string`. The data field is an object, as opposed to a flat type similar to `geoCoordinates`. The object has multiple fields:
 
@@ -254,6 +202,130 @@ There are two fields that accept input. `input` must always be set, while `defau
 - When you entered a national number (e.g. `"020 1234567"`), you need to specify the country in `defaultCountry` (in this case, `"nl"`), so that the parse can correctly convert the number into all formats. The string in `defaultCountry` should be an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
 
 As you can see in the code snippet above, all other fields are read-only. These fields are filled automatically, and will appear when reading back a field of type `phoneNumber`.
+
+## `object`
+
+:::info Added in `v1.22`
+:::
+
+The `object` type allows you to store nested data as a JSON object that can be nested to any depth.
+
+For example, a `Person` collection could have an `address` property as an object. It could in turn include nested properties such as `street` and `city`:
+
+:::note Limitations
+Currently, `object` and `object[]` datatype properties are not indexed and not vectorized.
+
+Future plans include the ability to index nested properties, for example to allow for filtering on nested properties and vectorization options.
+:::
+
+### Examples
+
+import ObjectTypePy from '!!raw-loader!/_includes/code/python/config-refs.datatypes.object.py';
+import ObjectTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.object.ts';
+
+#### Property definition
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={ObjectTypePy}
+      startMarker="# START ConfigureDataType"
+      endMarker="# END ConfigureDataType"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={ObjectTypeTs}
+      startMarker="// START ConfigureDataType"
+      endMarker="// END ConfigureDataType"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
+#### Object insertion
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={ObjectTypePy}
+      startMarker="# START AddObject"
+      endMarker="# END AddObject"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={ObjectTypeTs}
+      startMarker="// START AddObject"
+      endMarker="// END AddObject"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
+<!-- Old example - could re-use for other language examples -->
+<!--
+```json
+{
+    "class": "Person",
+    "properties": [
+        {
+            "dataType": ["text"],
+            "name": "last_name",
+        },
+        {
+            "dataType": ["object"],
+            "name": "address",
+            "nestedProperties": [
+                {"dataType": ["text"], "name": "street"},
+                {"dataType": ["text"], "name": "city"}
+            ],
+        }
+    ],
+}
+```
+
+An object for this class may have a structure such as follows:
+
+```json
+{
+    "last_name": "Franklin",
+    "address": {
+        "city": "London",
+        "street": "King Street"
+    }
+}
+``` -->
+
+## `cross-reference`
+
+The [`cross-reference`](../more-resources/glossary.md) type is the graph element of Weaviate: you can create a link from one object to another. In the schema you can define multiple classes to which a property can point, in a list of strings. The strings in the `dataType` list are names of classes defined elsewhere in the schema. For example:
+
+```json
+{
+  "properties": [
+    {
+      "name": "hasWritten",
+      "dataType": [
+        "Article",
+        "Blog"
+      ]
+    }
+  ]
+}
+```
+
+### Number of linked instances
+
+The `cross-reference` type objects are `arrays` by default. This allows you to link to any number of instances of a given class (including zero).
+
+In the above example, our objects can be linked to:
+* **0** Articles and **1** Blog
+* **1** Article and **3** Blogs
+* **2** Articles and **5** Blogs
+* etc.
 
 ## More information
 

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -5,12 +5,9 @@ image: og/docs/configuration.jpg
 # tags: ['Data types']
 ---
 
-
-:::info Related pages
-- [Configuration: Schema](../manage-data/collections.mdx)
-- [References: REST API: Schema](/developers/weaviate/api/rest#tag/schema)
-- [Concepts: Data Structure](../concepts/data.md)
-:::
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBlock';
 
 ## Introduction
 
@@ -26,16 +23,46 @@ import DataTypes from '/_includes/datatypes.mdx';
 
 ## DataType: `text`
 
+Use this type for any textual data. Properties with the `text` type is used for vectorization and keyword search unless specified otherwise [in the property settings](../manage-data/collections.mdx#property-level-settings).
+
+If using [named vectors](../concepts/data.md#multiple-vectors-named-vectors), the property vectorization is defined in the [named vector definition](../manage-data/collections.mdx#define-multiple-named-vectors).
+
 ### Tokenization configuration
 
-Refer to [this section](../config-refs/schema/index.md#property-tokenization) on how to configure the tokenization behavior of a `text` property.
+Text properties are tokenized prior to being indexed for keyword/BM25 searches. See [collection definition: tokenization](../config-refs/schema/index.md#property-tokenization) for more information.
 
-:::tip `string` is deprecated
+### Usage examples
+
+import TextTypePy from '!!raw-loader!/_includes/code/python/config-refs.datatypes.text.py';
+import TextTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.text.ts';
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={TextTypePy}
+      startMarker="# START ConfigureDataType"
+      endMarker="# END ConfigureDataType"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={TextTypeTs}
+      startMarker="// START ConfigureDataType"
+      endMarker="// END ConfigureDataType"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
+<details>
+  <summary><code>string</code> is deprecated</summary>
 
 Prior to `v1.19`, Weaviate supported an additional datatype `string`, which was differentiated by tokenization behavior to `text`. As of `v1.19`, this type is deprecated and will be removed in a future release.
 
 Use `text` instead of `string`. `text` supports the tokenization options that are available through `string`.
-:::
+
+</details>
 
 ## DataType: `cross-reference`
 
@@ -228,13 +255,21 @@ There are two fields that accept input. `input` must always be set, while `defau
 
 As you can see in the code snippet above, all other fields are read-only. These fields are filled automatically, and will appear when reading back a field of type `phoneNumber`.
 
-## Notes
+## More information
 
-### GraphQL and `int64`
+:::info Related pages
+- [How-to: Manage collections](../manage-data/collections.mdx)
+- [Concepts: Data Structure](../concepts/data.md)
+- [References: REST API: Schema](/developers/weaviate/api/rest#tag/schema)
+:::
+
+### Notes
+
+#### GraphQL and `int64`
 
 Although Weaviate supports `int64`, GraphQL currently only supports `int32`, and does not support `int64`. This means that currently _integer_ data fields in Weaviate with integer values larger than `int32`, will not be returned using GraphQL queries. We are working on solving this [issue](https://github.com/weaviate/weaviate/issues/1563). As current workaround is to use a `string` instead.
 
-### Formatting in payloads
+#### Formatting in payloads
 
 In raw payloads (e.g. JSON payloads for REST), data types are specified as an array (e.g. `["text"]`, or `["text[]"]`), as it is required for some cross-reference specifications.
 

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -157,7 +157,7 @@ In specific client libraries, you may be able to use the native date object as s
 ### Examples
 
 import DateTypePy from '!!raw-loader!/_includes/code/python/config-refs.datatypes.date.py';
-import dateTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.date.ts';
+import DateTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.date.ts';
 
 #### Property definition
 
@@ -172,7 +172,7 @@ import dateTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.data
   </TabItem>
   <TabItem value="js" label="JS/TS Client v3">
     <FilteredTextBlock
-      text={dateTypeTs}
+      text={DateTypeTs}
       startMarker="// START ConfigureDataType"
       endMarker="// END ConfigureDataType"
       language="ts"
@@ -193,7 +193,7 @@ import dateTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.data
   </TabItem>
   <TabItem value="js" label="JS/TS Client v3">
     <FilteredTextBlock
-      text={dateTypeTs}
+      text={DateTypeTs}
       startMarker="// START AddObject"
       endMarker="// END AddObject"
       language="ts"
@@ -201,57 +201,12 @@ import dateTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.data
   </TabItem>
 </Tabs>
 
-## `blob`
-
-The datatype blob accepts any binary data. The data should be `base64` encoded, and passed as a `string`. Characteristics:
-* Weaviate doesn't make assumptions about the type of data that is encoded. A module (e.g. `img2vec`) can investigate file headers as it wishes, but Weaviate itself does not do this.
-* When storing, the data is `base64` decoded (so Weaviate stores it more efficiently).
-* When serving, the data is `base64` encoded (so it is safe to serve as `json`).
-* There is no max file size limit.
-* This `blob` field is always skipped in the inverted index, regardless of setting. This mean you can not search by this `blob` field in a Weaviate GraphQL `where` filter, and there is no `valueBlob` field accordingly. Depending on the module, this field can be used in module-specific filters (e.g. `nearImage`{} in the `img2vec-neural` filter).
-
-Example:
-
-The dataType `blob` can be used as property dataType in the data schema as follows:
-
-```json
-{
-  "properties": [
-    {
-      "name": "image",
-      "dataType": ["blob"]
-    }
-  ]
-}
-```
-
-To obtain the base64-encoded value of an image, you can run the following command - or use the helper methods in the Weaviate clients - to do so:
-
-```bash
-cat my_image.png | base64
-```
-
-You can then import data with `blob` dataType to Weaviate as follows:
-
-```bash
-curl \
-    -X POST \
-    -H "Content-Type: application/json" \
-    -d '{
-      "class": "FashionPicture",
-      "id": "36ddd591-2dee-4e7e-a3cc-eb86d30a4302",
-      "properties": {
-          "image": "iVBORw0KGgoAAAANS..."
-      }
-  }' \
-    http://localhost:8080/v1/objects
-```
 ## `uuid`
 
 :::info Added in `v1.19`
 :::
 
-The dedicated `uuid` and `uuid[]` data types are more space-efficient than storing the same data as text.
+The dedicated `uuid` and `uuid[]` data types efficiently store [UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier).
 
 -   Each `uuid` is a 128-bit (16-byte) number.
 -   The filterable index uses roaring bitmaps.
@@ -259,6 +214,53 @@ The dedicated `uuid` and `uuid[]` data types are more space-efficient than stori
 :::note Aggregate/sort currently not possible
 It is currently not possible to aggregate or sort by `uuid` or `uuid[]` types.
 :::
+
+### Examples
+
+import UUIDTypePy from '!!raw-loader!/_includes/code/python/config-refs.datatypes.uuid.py';
+import UUIDTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.uuid.ts';
+
+#### Property definition
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={UUIDTypePy}
+      startMarker="# START ConfigureDataType"
+      endMarker="# END ConfigureDataType"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={UUIDTypeTs}
+      startMarker="// START ConfigureDataType"
+      endMarker="// END ConfigureDataType"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
+#### Object insertion
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={UUIDTypePy}
+      startMarker="# START AddObject"
+      endMarker="# END AddObject"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={UUIDTypeTs}
+      startMarker="// START AddObject"
+      endMarker="// END AddObject"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
 
 ## `geoCoordinates`
 
@@ -306,6 +308,52 @@ There are two fields that accept input. `input` must always be set, while `defau
 - When you entered a national number (e.g. `"020 1234567"`), you need to specify the country in `defaultCountry` (in this case, `"nl"`), so that the parse can correctly convert the number into all formats. The string in `defaultCountry` should be an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
 
 As you can see in the code snippet above, all other fields are read-only. These fields are filled automatically, and will appear when reading back a field of type `phoneNumber`.
+
+## `blob`
+
+The datatype blob accepts any binary data. The data should be `base64` encoded, and passed as a `string`. Characteristics:
+* Weaviate doesn't make assumptions about the type of data that is encoded. A module (e.g. `img2vec`) can investigate file headers as it wishes, but Weaviate itself does not do this.
+* When storing, the data is `base64` decoded (so Weaviate stores it more efficiently).
+* When serving, the data is `base64` encoded (so it is safe to serve as `json`).
+* There is no max file size limit.
+* This `blob` field is always skipped in the inverted index, regardless of setting. This mean you can not search by this `blob` field in a Weaviate GraphQL `where` filter, and there is no `valueBlob` field accordingly. Depending on the module, this field can be used in module-specific filters (e.g. `nearImage`{} in the `img2vec-neural` filter).
+
+Example:
+
+The dataType `blob` can be used as property dataType in the data schema as follows:
+
+```json
+{
+  "properties": [
+    {
+      "name": "image",
+      "dataType": ["blob"]
+    }
+  ]
+}
+```
+
+To obtain the base64-encoded value of an image, you can run the following command - or use the helper methods in the Weaviate clients - to do so:
+
+```bash
+cat my_image.png | base64
+```
+
+You can then import data with `blob` dataType to Weaviate as follows:
+
+```bash
+curl \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{
+      "class": "FashionPicture",
+      "id": "36ddd591-2dee-4e7e-a3cc-eb86d30a4302",
+      "properties": {
+          "image": "iVBORw0KGgoAAAANS..."
+      }
+  }' \
+    http://localhost:8080/v1/objects
+```
 
 ## `object`
 

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -412,7 +412,7 @@ The datatype blob accepts any binary data. The data should be `base64` encoded, 
 * There is no max file size limit.
 * This `blob` field is always skipped in the inverted index, regardless of setting. This mean you can not search by this `blob` field in a Weaviate GraphQL `where` filter, and there is no `valueBlob` field accordingly. Depending on the module, this field can be used in module-specific filters (e.g. `nearImage`{} in the `img2vec-neural` filter).
 
-Example:
+<!-- Example:
 
 The dataType `blob` can be used as property dataType in the data schema as follows:
 
@@ -425,7 +425,7 @@ The dataType `blob` can be used as property dataType in the data schema as follo
     }
   ]
 }
-```
+``` -->
 
 To obtain the base64-encoded value of an image, you can run the following command - or use the helper methods in the Weaviate clients - to do so:
 
@@ -433,7 +433,7 @@ To obtain the base64-encoded value of an image, you can run the following comman
 cat my_image.png | base64
 ```
 
-You can then import data with `blob` dataType to Weaviate as follows:
+<!-- You can then import data with `blob` dataType to Weaviate as follows:
 
 ```bash
 curl \
@@ -447,7 +447,54 @@ curl \
       }
   }' \
     http://localhost:8080/v1/objects
-```
+``` -->
+
+### Examples
+
+import BlobTypePy from '!!raw-loader!/_includes/code/python/config-refs.datatypes.blob.py';
+import BlobTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.blob.ts';
+
+#### Property definition
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={BlobTypePy}
+      startMarker="# START ConfigureDataType"
+      endMarker="# END ConfigureDataType"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={BlobTypeTs}
+      startMarker="// START ConfigureDataType"
+      endMarker="// END ConfigureDataType"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
+#### Object insertion
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={BlobTypePy}
+      startMarker="# START AddObject"
+      endMarker="# END AddObject"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={BlobTypeTs}
+      startMarker="// START AddObject"
+      endMarker="// END AddObject"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
 
 ## `object`
 

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -152,6 +152,55 @@ For example:
 
 To add a list of dates as a single entity, use an array of `date-time` formatted strings. For example: `["1985-04-12T23:20:50.52Z", "1937-01-01T12:00:27.87+00:20"]`
 
+In specific client libraries, you may be able to use the native date object as shown in the following examples.
+
+### Examples
+
+import DateTypePy from '!!raw-loader!/_includes/code/python/config-refs.datatypes.date.py';
+import dateTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.date.ts';
+
+#### Property definition
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={DateTypePy}
+      startMarker="# START ConfigureDataType"
+      endMarker="# END ConfigureDataType"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={dateTypeTs}
+      startMarker="// START ConfigureDataType"
+      endMarker="// END ConfigureDataType"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
+#### Object insertion
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={DateTypePy}
+      startMarker="# START AddObject"
+      endMarker="# END AddObject"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={dateTypeTs}
+      startMarker="// START AddObject"
+      endMarker="// END AddObject"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
 ## `blob`
 
 The datatype blob accepts any binary data. The data should be `base64` encoded, and passed as a `string`. Characteristics:

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -594,31 +594,11 @@ An object for this class may have a structure such as follows:
 
 ## `cross-reference`
 
-The [`cross-reference`](../more-resources/glossary.md) type is the graph element of Weaviate: you can create a link from one object to another. In the schema you can define multiple classes to which a property can point, in a list of strings. The strings in the `dataType` list are names of classes defined elsewhere in the schema. For example:
+The `cross-reference` type allows a link to be created from one object to another. This is useful for creating relationships between collections, such as linking a `Person` collection to a `Company` collection.
 
-```json
-{
-  "properties": [
-    {
-      "name": "hasWritten",
-      "dataType": [
-        "Article",
-        "Blog"
-      ]
-    }
-  ]
-}
-```
+The `cross-reference` type objects are `arrays` by default. This allows you to link to any number of instances of a given collection (including zero).
 
-### Number of linked instances
-
-The `cross-reference` type objects are `arrays` by default. This allows you to link to any number of instances of a given class (including zero).
-
-In the above example, our objects can be linked to:
-* **0** Articles and **1** Blog
-* **1** Article and **3** Blogs
-* **2** Articles and **5** Blogs
-* etc.
+For more information on cross-references, see the [cross-references](../concepts/data.md#cross-references). To see how to work with cross-references, see [how to manage data: cross-references](../manage-data/cross-references.mdx).
 
 ## More information
 

--- a/developers/weaviate/config-refs/datatypes.md
+++ b/developers/weaviate/config-refs/datatypes.md
@@ -264,11 +264,11 @@ import UUIDTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.data
 
 ## `geoCoordinates`
 
-Weaviate allows you to store geo coordinates. When querying Weaviate, you can use this type to find items in a radius around this area. A geo coordinate value is a float, and is processed as [decimal degree](https://en.wikipedia.org/wiki/Decimal_degrees) according to the [ISO standard](https://www.iso.org/standard/39242.html#:~:text=For%20computer%20data%20interchange%20of,minutes%2C%20seconds%20and%20decimal%20seconds).
+Geo coordinates can be used to find objects in a radius around a query location. A geo coordinate value stored as a float, and is processed as [decimal degree](https://en.wikipedia.org/wiki/Decimal_degrees) according to the [ISO standard](https://www.iso.org/standard/39242.html#:~:text=For%20computer%20data%20interchange%20of,minutes%2C%20seconds%20and%20decimal%20seconds).
 
 To supply a `geoCoordinates` property, specify the `latitude` and `longitude` as floating point decimal degrees.
 
-An example of how geo coordinates are used in a data object:
+<!-- An example of how geo coordinates are used in a data object:
 
 ```json
 {
@@ -279,7 +279,54 @@ An example of how geo coordinates are used in a data object:
     }
   }
 }
-```
+``` -->
+
+### Examples
+
+import GeoTypePy from '!!raw-loader!/_includes/code/python/config-refs.datatypes.geocoordinates.py';
+import GeoTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.geocoordinates.ts';
+
+#### Property definition
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={GeoTypePy}
+      startMarker="# START ConfigureDataType"
+      endMarker="# END ConfigureDataType"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={UUIDTypeTs}
+      startMarker="// START ConfigureDataType"
+      endMarker="// END ConfigureDataType"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
+#### Object insertion
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={GeoTypePy}
+      startMarker="# START AddObject"
+      endMarker="# END AddObject"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={GeoTypeTs}
+      startMarker="// START AddObject"
+      endMarker="// END AddObject"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
 
 import GeoLimitations from '/_includes/geo-limitations.mdx';
 
@@ -287,7 +334,7 @@ import GeoLimitations from '/_includes/geo-limitations.mdx';
 
 ## `phoneNumber`
 
-There is a special, primitive data type `phoneNumber`. When a phone number is added to this field, the input will be normalized and validated, unlike the single fields as `number` and `string`. The data field is an object, as opposed to a flat type similar to `geoCoordinates`. The object has multiple fields:
+A `phoneNumber` input will be normalized and validated, unlike the single fields as `number` and `string`. The data field is an object with multiple fields.
 
 ```yaml
 {
@@ -304,10 +351,57 @@ There is a special, primitive data type `phoneNumber`. When a phone number is ad
 ```
 
 There are two fields that accept input. `input` must always be set, while `defaultCountry` must only be set in specific situations. There are two scenarios possible:
-- When you entered an international number (e.g. `"+31 20 1234567"`) to the `input` field, no `defaultCountry` needs to be entered. The underlying parser will automatically recognize the number's country.
-- When you entered a national number (e.g. `"020 1234567"`), you need to specify the country in `defaultCountry` (in this case, `"nl"`), so that the parse can correctly convert the number into all formats. The string in `defaultCountry` should be an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
+- When you enter an international number (e.g. `"+31 20 1234567"`) to the `input` field, no `defaultCountry` needs to be entered. The underlying parser will automatically recognize the number's country.
+- When you enter a national number (e.g. `"020 1234567"`), you need to specify the country in `defaultCountry` (in this case, `"nl"`), so that the parse can correctly convert the number into all formats. The string in `defaultCountry` should be an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
 
-As you can see in the code snippet above, all other fields are read-only. These fields are filled automatically, and will appear when reading back a field of type `phoneNumber`.
+Weaviate will also add further read-only fields such as `internationalFormatted`, `countryCode`, `national`, `nationalFormatted` and `valid` when reading back a field of type `phoneNumber`.
+
+### Examples
+
+import PhoneTypePy from '!!raw-loader!/_includes/code/python/config-refs.datatypes.phonenumber.py';
+import PhoneTypeTs from '!!raw-loader!/_includes/code/typescript/config-refs.datatypes.phonenumber.ts';
+
+#### Property definition
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={PhoneTypePy}
+      startMarker="# START ConfigureDataType"
+      endMarker="# END ConfigureDataType"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={PhoneTypeTs}
+      startMarker="// START ConfigureDataType"
+      endMarker="// END ConfigureDataType"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
+
+#### Object insertion
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={PhoneTypePy}
+      startMarker="# START AddObject"
+      endMarker="# END AddObject"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+    <FilteredTextBlock
+      text={PhoneTypeTs}
+      startMarker="// START AddObject"
+      endMarker="// END AddObject"
+      language="ts"
+    />
+  </TabItem>
+</Tabs>
 
 ## `blob`
 

--- a/developers/weaviate/config-refs/schema/index.md
+++ b/developers/weaviate/config-refs/schema/index.md
@@ -1,5 +1,5 @@
 ---
-title: Collection schema
+title: Collection definition
 sidebar_position: 10
 image: og/docs/configuration.jpg
 # tags: ['Data types']
@@ -7,7 +7,7 @@ image: og/docs/configuration.jpg
 
 ## Introduction
 
-A collection schema describes how to store and index a set of data objects in Weaviate. This page discuses the collection schema, collection parameters and collection configuration.
+A collection definition describes how to store and index a set of data objects in Weaviate. This page discuses the collection definition, collection parameters and collection configuration.
 
 import Terminology from '/_includes/collection-class-terminology.md';
 
@@ -311,7 +311,7 @@ Using these features requires more resources. The additional inverted indexes mu
 
 ### `vectorizer`
 
-The vectorizer (`"vectorizer": "..."`) can be specified per collection in the schema object. Check the [modules page](../../modules/index.md) for available vectorizer modules.
+The vectorizer (`"vectorizer": "..."`) can be specified per collection in the definition. Check the [modules page](../../modules/index.md) for available vectorizer modules.
 
 You can use Weaviate without a vectorizer by setting `"vectorizer": "none"`. This is useful if you want to upload your own vectors from a custom model ([see how here](../../manage-data/import.mdx#specify-a-vector)), or if you want to create a collection without any vectors.
 
@@ -364,7 +364,7 @@ These parameters are explained below:
 
 <RaftRFChangeWarning/>
 
-[Replication](../../configuration/replication.md) configurations can be set using the schema, through the `replicationConfig` parameter.
+[Replication](../../configuration/replication.md) configurations can be set using the definition, through the `replicationConfig` parameter.
 
 The `factor` parameter sets the number of copies of to be stored for objects in this collection.
 

--- a/developers/weaviate/manage-data/create.mdx
+++ b/developers/weaviate/manage-data/create.mdx
@@ -393,7 +393,7 @@ import GeoLimitations from '/_includes/geo-limitations.mdx';
 
 <GeoLimitations/>
 
-If you want to supply a [`geoCoordinates`](/developers/weaviate/config-refs/datatypes.md#datatype-geocoordinates) property, you need to specify the `latitude` and `longitude` as floating point decimal degrees:
+If you want to supply a [`geoCoordinates`](/developers/weaviate/config-refs/datatypes.md#geocoordinates) property, you need to specify the `latitude` and `longitude` as floating point decimal degrees:
 
 import CreateWithGeo from '/_includes/code/howto/manage-data.create.with.geo.mdx';
 

--- a/src/css/blog-and-docs.scss
+++ b/src/css/blog-and-docs.scss
@@ -107,15 +107,15 @@ html {
   }
 
   h2 {
-    padding-top: 0.9em;
+    padding-top: 0.95em;
     padding-bottom: 0.25em;
   }
   h3 {
-    padding-top: 0.55em;
+    padding-top: 0.85em;
     padding-bottom: 0.2em;
   }
   h4 {
-    padding-top: 0.2em;
+    padding-top: 0.75em;
     padding-bottom: 0.15em;
   }
 
@@ -128,7 +128,7 @@ html {
   }
 
   h4 {
-    font-size: 16px;
+    font-size: 17px;
   }
 
   h5 {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,16 @@
 // Enable top-level await in .ts files and importing JSON files directly
 {
   "compilerOptions": {
-    "resolveJsonModule": true,  // to import JSON data files directly
-    "target": "esnext", // top-level await
-    "module": "esnext", // output `import`/`export` ES modules
-    "allowSyntheticDefaultImports": true,  // allow default imports from modules with no default export. This does not affect code emit, just typechecking.
-    "moduleResolution": "node", // find modules in node_modules - https://github.com/Microsoft/TypeScript/issues/8189#issuecomment-212079251
-    "types": ["node"],
-    "sourceMap": true
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+
+    // "resolveJsonModule": true,
+    // "types": ["node"],
+    // "sourceMap": true,
   }
 }


### PR DESCRIPTION
### What's being changed:

Datatype page updates & add config/insert Py/TS examples

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
