### PR TITLE
Add Image Search Snippets for Java Docs

### DIFF
--- a/_includes/code/howto/java/pom.xml
+++ b/_includes/code/howto/java/pom.xml
@@ -24,7 +24,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <weaviate.client.version>4.8.2</weaviate.client.version>
+    <weaviate.client.version>4.8.3</weaviate.client.version>
     <junit.version>5.9.3</junit.version>
     <assertj-core.version>3.24.2</assertj-core.version>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>

--- a/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/ImageSearchTest.java
+++ b/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/ImageSearchTest.java
@@ -1,0 +1,131 @@
+package io.weaviate.docs.search;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.graphql.model.GraphQLResponse;
+import io.weaviate.client.v1.graphql.query.argument.NearImageArgument;
+import io.weaviate.client.v1.graphql.query.builder.GetBuilder;
+import io.weaviate.client.v1.graphql.query.fields.Field;
+import io.weaviate.client.v1.graphql.query.fields.Fields;
+import io.weaviate.docs.helper.EnvHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Base64;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("crud")
+@Tag("image-search")
+public class ImageSearchTest {
+
+  private static WeaviateClient client;
+
+  @BeforeAll
+  public static void beforeAll() {
+    String scheme = EnvHelper.scheme("http");
+    String host = EnvHelper.host("localhost");
+    String port = EnvHelper.port("8080");
+
+    Config config = new Config(scheme, host + ":" + port);
+    client = new WeaviateClient(config);
+
+    Result<Boolean> result = client.schema().allDeleter().run();
+    assertThat(result).isNotNull()
+      .withFailMessage(() -> result.getError().toString())
+      .returns(false, Result::hasErrors)
+      .withFailMessage(null)
+      .returns(true, Result::getResult);
+  }
+
+  @Test
+  public void shouldPerformImageSearch() {
+    String className = "Dog";
+    searchWithNearLocalImage(className);
+    searchWithNearBase64Image(className);
+    urlToBase64();
+  }
+
+  private void searchWithNearLocalImage(String className) {
+    // START ImageFileSearch
+    NearImageArgument nearImage = NearImageArgument.builder()
+      .imageFile(new File("./images/search-image.jpg"))
+      .build();
+
+    Fields fields = Fields.builder()
+      .fields(new Field[]{
+        Field.builder().name("Breed").build()
+      })
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .fields(fields)
+      .withNearImageFilter(nearImage)
+      .limit(1)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END ImageFileSearch
+  }
+
+  private void searchWithNearBase64Image(String className) {
+    // START search with base64
+    String base64_string = "SOME_BASE_64_REPRESENTATION";
+
+    NearImageArgument nearImage = NearImageArgument.builder()
+      .image(base64_string)
+      .build();
+
+    Fields fields = Fields.builder()
+      .fields(new Field[]{
+        Field.builder().name("Breed").build()
+      })
+      .build();
+
+    String query = GetBuilder.builder()
+      .className(className)
+      .fields(fields)
+      .withNearImageFilter(nearImage)
+      .limit(1)
+      .build()
+      .buildQuery();
+
+    Result<GraphQLResponse> result = client.graphQL().raw().withQuery(query).run();
+    // END search with base64
+  }
+
+  private void urlToBase64() {
+    // START helper base64 functions
+    try {
+      // Open the input stream for the image URL
+      URL url = new URL("https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Deutsches_Museum_Portrait_4.jpg/500px-Deutsches_Museum_Portrait_4.jpg");
+      InputStream inputStream = url.openStream();
+      // Read the image bytes into a ByteArrayOutputStream
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      byte[] buffer = new byte[8192];
+      int bytesRead;
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        outputStream.write(buffer, 0, bytesRead);
+      }
+      // Convert the bytes to a base64 encoded string
+      byte[] imageBytes = outputStream.toByteArray();
+      String base64String = Base64.getEncoder().encodeToString(imageBytes);
+      System.out.println(base64String);
+
+      inputStream.close();
+      outputStream.close();
+    } catch (IOException e) {
+      System.err.println("Error occurred while converting image to base64: " + e.getMessage());
+      e.printStackTrace();
+    }
+    // END helper base64 functions
+  }
+
+}

--- a/developers/weaviate/search/image.md
+++ b/developers/weaviate/search/image.md
@@ -13,6 +13,7 @@ import PyCodeV3 from '!!raw-loader!/_includes/code/howto/search.image-v3.py';
 import TSCode from '!!raw-loader!/_includes/code/howto/search.image.ts';
 import TSCodeLegacy from '!!raw-loader!/_includes/code/howto/search.image-v2.ts';
 import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/mainpkg/search-image_test.go';
+import JavaCode from '!!raw-loader!/_includes/code/howto/java/src/test/java/io/weaviate/docs/search/ImageSearchTest.java';
 
 `Image` search uses an **image as a search input** to perform vector similarity search.
 
@@ -93,6 +94,15 @@ If your query image is stored in a file, you can use the client library to searc
     />
   </TabItem>
 
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START ImageFileSearch"
+      endMarker="// END ImageFileSearch"
+      language="java"
+    />
+  </TabItem>
+
 </Tabs>
 
 <details>
@@ -157,6 +167,15 @@ You can search by a base64 representation of an image:
       language="gonew"
     />
   </TabItem>
+
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START search with base64"
+      endMarker="// END search with base64"
+      language="java"
+    />
+  </TabItem>
 </Tabs>
 
 
@@ -200,6 +219,15 @@ You can create a base64 representation of an online image, and use it as input f
       startMarker="// START helper base64 functions"
       endMarker="// END helper base64 functions"
       language="gonew"
+    />
+  </TabItem>
+
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaCode}
+      startMarker="// START helper base64 functions"
+      endMarker="// END helper base64 functions"
+      language="java"
     />
   </TabItem>
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
Add new class: ImageSearchTest
Add new methods: searchWithNearLocalImage & searchWithNearBase64Image & urlToBase64

Status:
- modified:   _includes/code/howto/java/pom.xml
- new file:   _includes/code/howto/java/src/test/java/io/weaviate/docs/search/ImageSearchTest.java
- modified:   developers/weaviate/search/image.md

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
