### PR TITLE
OctoAI deprecation notes

### DIFF
--- a/blog/2024-05-20-weaviate-1-25-release/_core-1-25-include.mdx
+++ b/blog/2024-05-20-weaviate-1-25-release/_core-1-25-include.mdx
@@ -66,6 +66,10 @@ This release brings important new integrations with third party APIs.
 
 ### OctoAI integration
 
+import OctoAIDeprecationNote from './_includes/octoai_deprecation.md';
+
+<OctoAIDeprecationNote/>
+
 With version 1.25 we’re announcing an integration with OctoAI which will make it even easier for users to access many open source embedding and language models such as Llama3-70b, Mixtral-8x22b and more.
 
 We are releasing two integrations: text2vec-octoai and generative-octoai that integrate Weaviate and the OctoAI service. OctoAI provides hosted inference services for embedding models and large language models.

--- a/developers/weaviate/model-providers/index.md
+++ b/developers/weaviate/model-providers/index.md
@@ -27,7 +27,7 @@ This enables an enhanced developed experience, such as the ability to:
 | [Hugging Face](./huggingface/index.md) | [Text](./huggingface/embeddings.md) | - | - |
 | [Jina AI](./jinaai/index.md) | [Text](./jinaai/embeddings.md) | - | - |
 | [Mistral](./mistral/index.md) | [Text](./mistral/embeddings.md) | [Text](./mistral/generative.md) | - |
-| [OctoAI](./octoai/index.md) | [Text](./octoai/embeddings.md) | [Text](./octoai/generative.md) | - |
+| [OctoAI (Deprecated)](./octoai/index.md) | [Text](./octoai/embeddings.md) | [Text](./octoai/generative.md) | - |
 | [OpenAI](./openai/index.md) | [Text](./openai/embeddings.md) | [Text](./openai/generative.md) | - |
 | [Azure OpenAI](./openai-azure/index.md) | [Text](./openai-azure/embeddings.md) | [Text](./openai-azure/generative.md) | - |
 | [Voyage AI](./voyageai/index.md) | [Text](./voyageai/embeddings.md) | - | [Reranker](./voyageai/reranker.md) |

--- a/developers/weaviate/model-providers/octoai/_category_.json
+++ b/developers/weaviate/model-providers/octoai/_category_.json
@@ -1,4 +1,4 @@
 {
-    "label": "OctoAI",
+    "label": "OctoAI (Deprecated)",
     "position": 247
 }

--- a/developers/weaviate/model-providers/octoai/_includes/octoai_deprecation.md
+++ b/developers/weaviate/model-providers/octoai/_includes/octoai_deprecation.md
@@ -2,36 +2,49 @@
 
 ### OctoAI integrations are deprecated
 
-OctoAI announced that they are winding down the commercial availability of its services by **31 October 2024**.
+<!-- They have been removed from the Weaviate codebase from `v1.25.22`, `v1.26.8` and `v1.27.1`. -->
+
+OctoAI announced that they are winding down the commercial availability of its services by **31 October 2024**. Accordingly, the Weaviate OctoAI integrations are deprecated. Do not use these integrations for new projects.
 <br/>
 
-Accordingly, the Weaviate OctoAI integrations are deprecated. They have been removed from the Weaviate codebase from `v1.25.22`, `v1.26.8` and `v1.27.1`.
+If you have a collection that is using an OctoAI integration, consider your options depending on whether you are using OctoAI's embedding models ([your options](#for-collections-with-octoai-embedding-integrations)) or generative models ([your options](#for-collections-with-octoai-generative-ai-integrations)).
+
+#### For collections with OctoAI embedding integrations
+
+OctoAI provided `thenlper/gte-large` as the embedding model. This model is also available through the [Hugging Face API](../../huggingface/embeddings.md).
+<!-- , and through the [locally hosted Transformers](../../transformers/embeddings.md) integration. -->
 <br/>
 
-If you have a collection that is using an OctoAI integration, you should migrate to a new collection with [another model provider](../../index.md).
+After the shutdown date, this model will no longer be available through OctoAI. If you are using this integration, you have the following options:
 <br/>
 
-First, select a model provider integration that you want to migrate to.
+**Option 1: Use the existing collection, and provide your own vectors**
 <br/>
 
-#### Suitable model providers: Embedding models
+You can continue to use the existing collection, provided that you rely on some other method to generate the required embeddings yourself for any new data, and for queries. If you are unfamiliar with the "bring your own vectors" approach, [refer to this starter guide](../../../starter-guides/custom-vectors.mdx).
+<br/>
 
-While migrating your data, you can choose to re-use the existing embeddings or choose a new model.
+**Option 2: Migrate to a new collection with another model provider**
+
+Alternatively, you can migrate your data to a new collection ([read how](#how-to-migrate)). At this point, you can re-use the existing embeddings or choose a new model.
 <br/>
 
 - **Re-using the existing embeddings** will save on time and inference costs.
 - **Choosing a new model** will allow you to explore new models and potentially improve the performance of your application.
 
-If you would like to re-use the existing embeddings, you must select a model provider that offers the same embedding model.
-<br/>
-
-OctoAI provided `thenlper/gte-large` as the embedding model. This model is also available through the [Hugging Face API](../../huggingface/embeddings.md), and through the [locally hosted Transformers](../../transformers/embeddings.md) integration.
+If you would like to re-use the existing embeddings, you must select a model provider (e.g. [Hugging Face API](../../huggingface/embeddings.md)) that offers the same embedding model.
 <br/>
 
 You can also select a new model with any embedding model provider. This will require you to re-generate the embeddings for your data, as the existing embeddings will not be compatible with the new model.
 <br/>
 
-#### Suitable model providers: Generative AI models
+#### For collections with OctoAI generative AI integrations
+
+If you are only using the generative AI integration, you do not need to migrate your data to a new collection.
+<br/>
+
+In the near future, you will be able to re-configure the generative AI integration to use a different model provider. At that point, you can continue to use the existing collection with a new model provider.
+<br/>
 
 You can select any model provider that offers generative AI models.
 <br/>

--- a/developers/weaviate/model-providers/octoai/_includes/octoai_deprecation.md
+++ b/developers/weaviate/model-providers/octoai/_includes/octoai_deprecation.md
@@ -1,0 +1,57 @@
+:::warning Deprecated integrations
+
+### OctoAI integrations are deprecated
+
+OctoAI announced that they are winding down the commercial availability of its services by **31 October 2024**.
+<br/>
+
+Accordingly, the Weaviate OctoAI integrations are deprecated. They have been removed from the Weaviate codebase from `v1.25.22`, `v1.26.8` and `v1.27.1`.
+<br/>
+
+If you have a collection that is using an OctoAI integration, you should migrate to a new collection with [another model provider](../../index.md).
+<br/>
+
+First, select a model provider integration that you want to migrate to.
+<br/>
+
+#### Suitable model providers: Embedding models
+
+While migrating your data, you can choose to re-use the existing embeddings or choose a new model.
+<br/>
+
+- **Re-using the existing embeddings** will save on time and inference costs.
+- **Choosing a new model** will allow you to explore new models and potentially improve the performance of your application.
+
+If you would like to re-use the existing embeddings, you must select a model provider that offers the same embedding model.
+<br/>
+
+OctoAI provided `thenlper/gte-large` as the embedding model. This model is also available through the [Hugging Face API](../../huggingface/embeddings.md), and through the [locally hosted Transformers](../../transformers/embeddings.md) integration.
+<br/>
+
+You can also select a new model with any embedding model provider. This will require you to re-generate the embeddings for your data, as the existing embeddings will not be compatible with the new model.
+<br/>
+
+#### Suitable model providers: Generative AI models
+
+You can select any model provider that offers generative AI models.
+<br/>
+
+If you would like to continue to use the same model that you used with OctoAI, providers such as [Anyscale](../../anyscale/generative.md), [FriendliAI](../../friendliai/generative.md), [Mistral](../../mistral/generative.md) or local models with [Ollama](../../ollama/generative.md) each offer some of the suite of models that OctoAI provided.
+<br/>
+
+#### How to migrate
+
+An outline of the migration process is as follows:
+<br/>
+
+- Create a new collection with the desired model provider integration(s).
+- Export the data from the existing collection.
+    - (Optional) To re-use the existing embeddings, export the data with the existing embeddings.
+- Import the data into the new collection.
+    - (Optional) To re-use the existing embeddings, import the data with the existing embeddings.
+- Update your application to use the new collection.
+<br/>
+
+See [How-to manage data: migrate data](../../../manage-data/migrate.mdx) for examples on migrating data objects between collections.
+
+:::

--- a/developers/weaviate/model-providers/octoai/embeddings.md
+++ b/developers/weaviate/model-providers/octoai/embeddings.md
@@ -1,12 +1,15 @@
 ---
-title: Text Embeddings
+title: Text Embeddings (Deprecated)
 sidebar_position: 20
 image: og/docs/integrations/provider_integrations_octoai.jpg
 # tags: ['model providers', 'octoai', 'embeddings']
 ---
 
-# OctoAI Embeddings with Weaviate
+import OctoAIDeprecationNote from './_includes/octoai_deprecation.md';
 
+<OctoAIDeprecationNote/>
+
+# OctoAI Embeddings with Weaviate
 
 :::info Added in `v1.25.0`
 :::

--- a/developers/weaviate/model-providers/octoai/generative.md
+++ b/developers/weaviate/model-providers/octoai/generative.md
@@ -1,9 +1,13 @@
 ---
-title: Generative AI
+title: Generative AI (Deprecated)
 sidebar_position: 50
 image: og/docs/integrations/provider_integrations_octoai.jpg
 # tags: ['model providers', 'octoai', 'generative', 'rag']
 ---
+
+import OctoAIDeprecationNote from './_includes/octoai_deprecation.md';
+
+<OctoAIDeprecationNote/>
 
 # OctoAI Generative AI with Weaviate
 

--- a/developers/weaviate/model-providers/octoai/index.md
+++ b/developers/weaviate/model-providers/octoai/index.md
@@ -1,11 +1,15 @@
 ---
-title: OctoAI + Weaviate
+title: OctoAI + Weaviate (Deprecated)
 sidebar_position: 10
 image: og/docs/integrations/provider_integrations_octoai.jpg
 # tags: ['model providers', 'octoai']
 ---
 
 <!-- Note: for images, use https://docs.google.com/presentation/d/15opIcJuaIjEEcs_1Zm8B6pccox2p7_MHSjCnRv4dPfU/edit?usp=sharing -->
+
+import OctoAIDeprecationNote from './_includes/octoai_deprecation.md';
+
+<OctoAIDeprecationNote/>
 
 :::info Added in `v1.25.0`
 :::


### PR DESCRIPTION


### What's being changed:

OctoAI deprecation notes

### Type of change:


- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
