### PR TITLE
Add notes re mutability of reranker/gen config

### DIFF
--- a/_includes/mutable-generative-config.md
+++ b/_includes/mutable-generative-config.md
@@ -1,3 +1,3 @@
-:::info Generative model integration mutable from `v1.25.23`, `v1.26.8` and `v1.27.1`
+:::info Generative model integration mutability
 A collection's `generative` model integration configuration is mutable from `v1.25.23`, `v1.26.8` and `v1.27.1`. See [this section](/developers/weaviate/manage-data/collections#update-the-generative-model-integration) for details on how to update the collection configuration.
 :::

--- a/developers/academy/js/starter_text_data/102_text_collections/20_create_collection.mdx
+++ b/developers/academy/js/starter_text_data/102_text_collections/20_create_collection.mdx
@@ -62,6 +62,10 @@ In this code example, we specify the `openai` module (`generative-openai` is the
   language="ts"
 />
 
+import MutableGenerativeConfig from '/_includes/mutable-generative-config.md';
+
+<MutableGenerativeConfig />
+
 ### <i class="fa-solid fa-code"></i> Javascript classes
 
 The code example makes use of methods such as `property`, `dataType` and `configure`. They are defined in the `weaviate.configure` object and are used to define the collection.

--- a/developers/academy/py/starter_custom_vectors/102_object_collections/20_create_collection.mdx
+++ b/developers/academy/py/starter_custom_vectors/102_object_collections/20_create_collection.mdx
@@ -60,6 +60,10 @@ In this code example, we specify the `cohere` module (`generative-cohere` is the
   language="py"
 />
 
+import MutableGenerativeConfig from '/_includes/mutable-generative-config.md';
+
+<MutableGenerativeConfig />
+
 ### <i class="fa-solid fa-code"></i> Python classes
 
 The code example makes use of classes such as `Property`, `DataType` and `Configure`. They are defined in the `weaviate.classes.config` submodule and are used to define the collection.

--- a/developers/academy/py/starter_multimodal_data/102_mm_collections/20_create_collection.mdx
+++ b/developers/academy/py/starter_multimodal_data/102_mm_collections/20_create_collection.mdx
@@ -66,6 +66,10 @@ In this code example, we specify the `openai` module (`generative-openai` is the
   language="py"
 />
 
+import MutableGenerativeConfig from '/_includes/mutable-generative-config.md';
+
+<MutableGenerativeConfig />
+
 ### <i class="fa-solid fa-code"></i> Python classes
 
 The code example makes use of classes such as `Property`, `DataType` and `Configure`. They are defined in the `weaviate.classes.config` submodule and are used to define the collection.

--- a/developers/academy/py/starter_text_data/102_text_collections/20_create_collection.mdx
+++ b/developers/academy/py/starter_text_data/102_text_collections/20_create_collection.mdx
@@ -62,6 +62,10 @@ In this code example, we specify the `openai` module (`generative-openai` is the
   language="py"
 />
 
+import MutableGenerativeConfig from '/_includes/mutable-generative-config.md';
+
+<MutableGenerativeConfig />
+
 ### <i class="fa-solid fa-code"></i> Python classes
 
 The code example makes use of classes such as `Property`, `DataType` and `Configure`. They are defined in the `weaviate.classes.config` submodule and are used to define the collection.


### PR DESCRIPTION
### What's being changed:

- Add notes re mutability of reranker/gen config

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`
