### PR TITLE
Docs code snippet: Make interval bigger than batch_size

### DIFF
--- a/_includes/code/howto/manage-data.import-v3.py
+++ b/_includes/code/howto/manage-data.import-v3.py
@@ -172,7 +172,7 @@ import pandas as pd
 
 # Settings for displaying the import progress
 counter = 0
-interval = 20  # print progress every this many records; should be bigger than the batch_size
+interval = 200  # print progress every this many records; should be bigger than the batch_size
 
 def add_object(obj) -> None:
     global counter

--- a/_includes/code/howto/manage-data.import.py
+++ b/_includes/code/howto/manage-data.import.py
@@ -344,10 +344,10 @@ import ijson
 
 # Settings for displaying the import progress
 counter = 0
-interval = 100  # print progress every this many records; should be bigger than the batch_size
+interval = 200  # print progress every this many records; should be bigger than the batch_size
 
 print("JSON streaming, to avoid running out of memory on large files...")
-with client.batch.fixed_size(batch_size=200) as batch:
+with client.batch.fixed_size(batch_size=100) as batch:
     with open("jeopardy_1k.json", "rb") as f:
         objects = ijson.items(f, "item")
         for obj in objects:
@@ -393,7 +393,7 @@ import pandas as pd
 
 # Settings for displaying the import progress
 counter = 0
-interval = 100  # print progress every this many records; should be bigger than the batch_size
+interval = 200  # print progress every this many records; should be bigger than the batch_size
 
 def add_object(obj) -> None:
     global counter
@@ -402,7 +402,7 @@ def add_object(obj) -> None:
         "answer": obj["Answer"],
     }
 
-    with client.batch.fixed_size(batch_size=200) as batch:
+    with client.batch.fixed_size(batch_size=100) as batch:
         batch.add_object(
             collection="JeopardyQuestion",
             properties=properties,


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
There’s a code snippet in the [documentation](https://weaviate.io/developers/weaviate/manage-data/import#stream-data-from-large-files) that states the interval should be bigger than the batch_size. However, this was not the case in the examples provided.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **GitHub action** – automated build completed without errors
