### PR TITLE
pip install weaviate command fails with comment as suffix

### DIFF
--- a/developers/weaviate/client-libraries/python/index.md
+++ b/developers/weaviate/client-libraries/python/index.md
@@ -33,7 +33,8 @@ If you are migrating from the `v3` client to the `v4`, see this [dedicated guide
 The Python client library is developed and tested using Python 3.8+. It is available on [PyPI.org](https://pypi.org/project/weaviate-client/), and can be installed with:
 
 ```bash
-pip install -U weaviate-client  # For beta versions: `pip install --pre -U "weaviate-client==4.*"`
+# For beta versions: `pip install --pre -U "weaviate-client==4.*"`
+pip install -U weaviate-client
 ```
 
 ### Requirements


### PR DESCRIPTION
If you copy paste the current pip install line (which include the comment) using the "copy" button, you get this error from pip
```sh
ERROR: Invalid requirement: '#': Expected package name at the start of dependency specifier
```

This PR just moves the comment to the line above the actual pip install to avoid the error. I haven't tested this, but am assuming it will look fine/work.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
