### PR TITLE
QuickStart: Update <a> links to absolute 

### DIFF
--- a/blog/2024-05-08-Modal-and-Weaviate/index.mdx
+++ b/blog/2024-05-08-Modal-and-Weaviate/index.mdx
@@ -61,7 +61,7 @@ In this section, we walk through some of the key Weaviate features we used to im
 5. [Batch Imports](#batch-imports)
 
 ### Async Indexing
-Importing data into a vector database is a two-step process: 1. Object creation, and 2. Vector index construction. Typically, the database won’t receive another batch of objects until it has finished indexing the prior batch. Weaviate `1.22` introduced [async indexing](/developers/weaviate/release-notes/release_1_22#asynchronous-vector-indexing-experimental) to speed up data ingestion.
+Importing data into a vector database is a two-step process: 1. Object creation, and 2. Vector index construction. Typically, the database won’t receive another batch of objects until it has finished indexing the prior batch. Weaviate `1.22` introduced [async indexing](/developers/weaviate/release-notes/older-releases/release_1_22#asynchronous-vector-indexing-experimental) to speed up data ingestion.
 
 Async indexing speeds up object ingestion by separating it from the vector index construction process. Rather than waiting for the new objects to be indexed, the objects are put in an in-memory queue before getting indexed. Since we imported millions of objects, it was important to enable this feature to reduce the import time.
 

--- a/developers/weaviate/quickstart/index.md
+++ b/developers/weaviate/quickstart/index.md
@@ -501,7 +501,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            See <a href="./search">how to perform searches</a>, such as <a href="./search/bm25">keyword</a>, <a href="./search/similarity">similarity</a>, <a href="./search/hybrid">hybrid</a>, <a href="./search/image">image</a>, <a href="./search/filters">filtered</a> and <a href="./search/rerank">reranked</a> searches.
+            See <a href="/developers/weaviate/search">how to perform searches</a>, such as <a href="/developers/weaviate/search/bm25">keyword</a>, <a href="/developers/weaviate/search/similarity">similarity</a>, <a href="/developers/weaviate/search/hybrid">hybrid</a>, <a href="/developers/weaviate/search/image">image</a>, <a href="/developers/weaviate/search/filters">filtered</a> and <a href="/developers/weaviate/search/rerank">reranked</a> searches.
           </p>
         </div>
       </div>
@@ -513,7 +513,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            See <a href="./manage-data">how to manage data</a>, such as <a href="./manage-data/collections">manage collections</a>, <a href="./manage-data/create">create objects</a>, <a href="./manage-data/import">batch import data</a> and <a href="./manage-data/multi-tenancy">use multi-tenancy</a>.
+            See <a href="/developers/weaviate/manage-data">how to manage data</a>, such as <a href="/developers/weaviate/manage-data/collections">manage collections</a>, <a href="/developers/weaviate/manage-data/create">create objects</a>, <a href="/developers/weaviate/manage-data/import">batch import data</a> and <a href="/developers/weaviate/manage-data/multi-tenancy">use multi-tenancy</a>.
           </p>
         </div>
       </div>
@@ -525,7 +525,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            Check out the <a href="./starter-guides/generative">Starter guide: retrieval augmented generation</a>, and the <a href="../academy">Weaviate Academy</a> unit on <a href="../academy/py/standalone/chunking">chunking</a>.
+            Check out the <a href="/developers/weaviate/starter-guides/generative">Starter guide: retrieval augmented generation</a>, and the <a href="/developers/academy">Weaviate Academy</a> unit on <a href="/developers/academy/py/standalone/chunking">chunking</a>.
           </p>
         </div>
       </div>

--- a/developers/weaviate/quickstart/local.md
+++ b/developers/weaviate/quickstart/local.md
@@ -417,7 +417,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            See <a href="../search">how to perform searches</a>, such as <a href="../search/bm25">keyword</a>, <a href="../search/similarity">similarity</a>, <a href="../search/hybrid">hybrid</a>, <a href="../search/image">image</a>, <a href="../search/filters">filtered</a> and <a href="../search/rerank">reranked</a> searches.
+            See <a href="/developers/weaviate/search">how to perform searches</a>, such as <a href="/developers/weaviate/search/bm25">keyword</a>, <a href="/developers/weaviate/search/similarity">similarity</a>, <a href="/developers/weaviate/search/hybrid">hybrid</a>, <a href="/developers/weaviate/search/image">image</a>, <a href="/developers/weaviate/search/filters">filtered</a> and <a href="/developers/weaviate/search/rerank">reranked</a> searches.
           </p>
         </div>
       </div>
@@ -429,7 +429,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            See <a href="../manage-data">how to manage data</a>, such as <a href="../manage-data/collections">manage collections</a>, <a href="../manage-data/create">create objects</a>, <a href="../manage-data/import">batch import data</a> and <a href="../manage-data/multi-tenancy">use multi-tenancy</a>.
+            See <a href="/developers/weaviate/manage-data">how to manage data</a>, such as <a href="/developers/weaviate/manage-data/collections">manage collections</a>, <a href="/developers/weaviate/manage-data/create">create objects</a>, <a href="/developers/weaviate/manage-data/import">batch import data</a> and <a href="/developers/weaviate/manage-data/multi-tenancy">use multi-tenancy</a>.
           </p>
         </div>
       </div>
@@ -441,7 +441,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            Check out the <a href="../starter-guides/generative">Starter guide: retrieval augmented generation</a>, and the <a href="/developers/academy">Weaviate Academy</a> unit on <a href="../../academy/py/standalone/chunking">chunking</a>.
+            Check out the <a href="/developers/weaviate/starter-guides/generative">Starter guide: retrieval augmented generation</a>, and the <a href="/developers/academy">Weaviate Academy</a> unit on <a href="/developers/academy/py/standalone/chunking">chunking</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
QuickStart: Update <a> links to absolute. 

- Addresses the fact that the link checker tends to be confused about relative paths