### PR TITLE
Use recommended filenames for compose config and binary

### DIFF
--- a/developers/weaviate/quickstart/local.md
+++ b/developers/weaviate/quickstart/local.md
@@ -92,7 +92,7 @@ We will be running Weaviate and language models locally. We recommend that you u
 
 ### 1.1 Create a Weaviate database
 
-Save the following code to a file named `docker-compose.yml` in your project directory.
+Save the following code to a file named `compose.yaml` in your project directory.
 
 ```yaml
 ---
@@ -127,7 +127,7 @@ volumes:
 Run the following command to start a Weaviate instance using Docker:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 ### 1.2 Install a client library


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

The recommended filename for Compose files is `compose.yaml`, and compose is now invoked as a subcommand to the main `docker` CLI, as opposed to a separate `docker-compose` binary.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
