### PR TITLE
Adding Examples to Documentation

### DIFF
--- a/_includes/code/howto/manage-data.migrate.data.ts
+++ b/_includes/code/howto/manage-data.migrate.data.ts
@@ -142,7 +142,7 @@ async function migrateData(collection_src: Collection, collection_tgt: Collectio
 
         let objectToInsert = {
             properties: item.properties,
-            vector: item.vectors.default,
+            vectors: item.vectors.default,
             uuid: item.uuid,
         }
 

--- a/_includes/code/howto/search.aggregate.ts
+++ b/_includes/code/howto/search.aggregate.ts
@@ -166,7 +166,14 @@ console.log(result.properties['points']);
 // =========================================
 {
 // HybridExample
-// TS client support coming soon
+const jeopardy = client.collections.get("JeopardyQuestion")
+
+const response = await jeopardy.aggregate.hybrid("animals in space", {
+    objectLimit: 10,
+    returnMetrics: jeopardy.metrics.aggregate("points").number(["sum"])
+})
+
+console.log("", response.properties['points'].sum)
 // END HybridExample
 
   // Test

--- a/_includes/code/howto/search.hybrid.ts
+++ b/_includes/code/howto/search.hybrid.ts
@@ -229,11 +229,11 @@ for (let object of result.objects) {
 // VectorSimilarity
 
 const result = await jeopardy.query.hybrid('California', {
+  maxVectorDistance: 0.4, // Maximum threshold for the vector search component
   vector: {
     query: 'large animal',
-    moveAway: { force: 0.5, concepts:['mamal', 'terrestrial'] }
+    moveAway: { force: 0.5, concepts:['mammal', 'terrestrial'] }
   },
-  // maxVectorDistance support coming soon
   alpha: 0.75,
   limit: 5,
   

--- a/blog/2025-01-15-hono-search-apis/index.mdx
+++ b/blog/2025-01-15-hono-search-apis/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Building Search APIs with Hono.js'
+title: 'Building AI Search APIs with Hono.js'
 slug: hono-search-apis
 description: "Master modern search capabilities by building a powerful API server with Hono.js. Learn how to implement vector, hybrid, and generative search while maintaining performance and reliability."
 authors: [daniel]

--- a/developers/weaviate/model-providers/_includes/provider.vectorizer.ts
+++ b/developers/weaviate/model-providers/_includes/provider.vectorizer.ts
@@ -547,7 +547,7 @@ await client.collections.create({
   ],
   // highlight-start
   vectorizers: [
-    weaviate.configure.vectorizer.text2VecJina({
+    weaviate.configure.vectorizer.text2VecJinaAI({
       name: 'title_vector',
       sourceProperties: ['title'],
     }),
@@ -571,7 +571,7 @@ await client.collections.create({
   ],
   // highlight-start
   vectorizers: [
-    weaviate.configure.vectorizer.text2VecJina({
+    weaviate.configure.vectorizer.text2VecJinaAI({
       name: 'title_vector',
       sourceProperties: ['title'],
       model: 'jina-embeddings-v3'
@@ -595,9 +595,9 @@ await client.collections.create({
   ],
   // highlight-start
   vectorizers: [
-    weaviate.configure.vectorizer.text2VecJina({
+    weaviate.configure.vectorizer.text2VecJinaAI({
       name: 'title_vector',
-      sourceProperties: ['title'],
+      sourceProperties: ['title'],    
       // model: 'jina-embeddings-v3-small-en'
       // dimensions: 512,  // e.g. 1024, 256, 64  Support for this parameter is coming soon (Only applicable for some models)
     },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "tailwindcss": "^3.2.7",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",
-    "weaviate-client": "^3.3.1",
+    "weaviate-client": "^3.3.4",
     "weaviate-ts-client": "^2.2.0",
     "weaviate-ts-embedded": "^1.2.0"
   },

--- a/src/components/Documentation/Home/index.jsx
+++ b/src/components/Documentation/Home/index.jsx
@@ -168,10 +168,20 @@ const DocHomePage = () => {
             <div className={`${styles.scenarioLogo} ${styles.data}`}></div>
             <div className={styles.scenarioText}>
               <span>
-                <a href="/developers/academy/py/starter_text_data/">
-                  Work with text data
+                <span>
+                  Work with text data 
+                </span>
+                <span>
+                <p>
+                  <a href="/developers/academy/py/starter_text_data/">
+                  Python
+                </a> / <a href="/developers/academy/js/starter_text_data/">
+                  JavaScript
                 </a>
+                </p>
               </span>
+              </span>
+              
 
               <p>
                 Just bring your text data to Weaviate and it will do the rest.
@@ -200,7 +210,7 @@ const DocHomePage = () => {
             <div className={`${styles.scenarioLogo} ${styles.custom}`}></div>
             <div className={styles.scenarioText}>
               <span>
-                <a href="/developers/academy/py/starter_custom_vectors">
+                <a href="/developers/weaviate/starter-guides/custom-vectors">
                   Bring your own vectors
                 </a>
               </span>
@@ -230,10 +240,20 @@ const DocHomePage = () => {
             <div className={`${styles.scenarioLogo} ${styles.semantic}`}></div>
             <div className={styles.scenarioText}>
               <span>
-                <a href="/developers/academy/py/starter_multimodal_data">
+                <span>
                   Multimodality
+                </span>
+                <span>
+                <p>
+                  <a href="/developers/academy/py/starter_multimodal_data">
+                  Python
+                </a> / <a href="/developers/academy/js/starter_multimodal_data">
+                  JavaScript
                 </a>
+                </p>
               </span>
+              </span>
+              
 
               <p>For many, data comes in multiple forms beyond text.</p>
               <p>


### PR DESCRIPTION
### What's being changed:

- Updated examples for `aggregate` in Hybrid Search
- Added `maxVectorDistance` to examples
- Fixed property in migration snippet
- few others

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [x] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
