### PR TITLE
Fixed broken links in Academy

### DIFF
--- a/developers/academy/js/standalone/client-server/10_why-client-server.mdx
+++ b/developers/academy/js/standalone/client-server/10_why-client-server.mdx
@@ -25,9 +25,9 @@ This section aims to guide you through how to do that as you build applications 
 
 The v3 client uses gRPC to connect to your Weaviate instance. The client supports Node.js, server-based development. It does not support browser-based web client development.
 
-Install the client by following [these instructions](../../../../weaviate/client-libraries/typescript/typescript-v3#install-the-package). A big benefit of using the new v3 client is the introduction of the gRPC protocol. A faster, more reliable platform to handle interactions with the database at scale. Unfortunately, gRPC does not support browser-based client development.
+Install the client by following [these instructions](../../../../weaviate/client-libraries/typescript/typescript-v3.mdx/#install-the-package). A big benefit of using the new v3 client is the introduction of the gRPC protocol. A faster, more reliable platform to handle interactions with the database at scale. Unfortunately, gRPC does not support browser-based client development.
 
-Besides the requirements of running the [weaviate-client](../../../../weaviate/client-libraries/typescript/typescript-v3#node-support-only), the client-server architecture is reliably more secure than interactions directly from the client.
+Besides the requirements of running the [weaviate-client](../../../../weaviate/client-libraries/typescript/typescript-v3.mdx#node-support-only), the client-server architecture is reliably more secure than interactions directly from the client.
 
 Having a client-server approach means you can optimize your use of Weaviate by implementing load balancing, user and session management, middleware and various other optimizations. 
 

--- a/developers/academy/js/standalone/which-search/30_strategies.mdx
+++ b/developers/academy/js/standalone/which-search/30_strategies.mdx
@@ -68,8 +68,6 @@ Chunking refers to the process of splitting a text into smaller chunks, and vect
 
 As a rule of thumb, the more granular the search needs, the smaller the chunk size should be. For example, if you are searching for specific concepts and ideas, you should chunk data into smaller units such as sentences or small windows of text. Alternatively, if you are searching for broader concepts, such as finding relevant chapters or books, you might chunk text accordingly.
 
-Read more about it in the [chunking unit](../../standalone/chunking/index.mdx) of Weaviate Academy.
-
 ## <i class="fa-solid fa-square-chevron-right"></i> Improve keyword search
 
 ### <i class="fa-solid fa-chalkboard"></i> Tokenization


### PR DESCRIPTION
### What's being changed:

Academy course content is changing to fix a broken link
### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
