### PR TITLE
Fix sorting API docs

### DIFF
--- a/developers/weaviate/api/graphql/additional-operators.md
+++ b/developers/weaviate/api/graphql/additional-operators.md
@@ -287,9 +287,11 @@ import GraphQLFiltersAfter from '/_includes/code/graphql.filters.after.mdx';
 Added in `v1.13.0`.
 :::
 
-You can sort results by any primitive property, such as `text`, `number`, or `int`. When query results, for example, `near<Media>` vector search results, have a natural order, sort functions override that order.
+You can sort results by any primitive property, such as `text`, `number`, or `int`. 
 
 ### Sorting considerations
+
+Sorting can be applied when fetching objects, but it's unavailable for the `near<Media>` vector search operators. 
 
 Weaviate's sorting implementation does not lead to massive memory spikes. Weaviate does not load all object properties into memory; only the property values being sorted are kept in memory.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

Sorting is only available for fetching objects, not with searches. 

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
