### PR TITLE
Add notes on runtime module parameters

### DIFF
--- a/developers/weaviate/model-providers/_includes/provider.generative.ts
+++ b/developers/weaviate/model-providers/_includes/provider.generative.ts
@@ -443,12 +443,12 @@ await client.collections.create({
   // highlight-end
   // Additional parameters not shown
 });
-// END GenerativeOpenAICustomModel
+// END BasicGenerativeOpenAI
 
 // Clean up
 await client.collections.delete('DemoCollection');
 
-// START BasicGenerativeOpenAI
+// START GenerativeOpenAICustomModel
 await client.collections.create({
   name: 'DemoCollection',
   // highlight-start

--- a/developers/weaviate/model-providers/anthropic/generative.md
+++ b/developers/weaviate/model-providers/anthropic/generative.md
@@ -159,7 +159,7 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [Anthropic API documentation](https://www.anthropic.com/docs).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/anthropic/generative.md
+++ b/developers/weaviate/model-providers/anthropic/generative.md
@@ -159,6 +159,17 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [Anthropic API documentation](https://www.anthropic.com/docs).
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Anthropic-Api-Key`: The Anthropic API key.
+- `X-Anthropic-Baseurl`: The base URL to use (e.g. a proxy) instead of the default Anthropic URL.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Retrieval augmented generation
 
 After configuring the generative AI integration, perform RAG operations, either with the [single prompt](#single-prompt) or [grouped task](#grouped-task) method.

--- a/developers/weaviate/model-providers/cohere/embeddings.md
+++ b/developers/weaviate/model-providers/cohere/embeddings.md
@@ -250,6 +250,17 @@ The following examples show how to configure Cohere-specific options.
 
 For further details on model parameters, see the [Cohere API documentation](https://docs.cohere.com/reference/embed).
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Cohere-Api-Key`: The Cohere API key.
+- `X-Cohere-Baseurl`: The base URL to use (e.g. a proxy) instead of the default Cohere URL.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Data import
 
 After configuring the vectorizer, [import data](../../manage-data/import.mdx) into Weaviate. Weaviate generates embeddings for text objects using the specified model.

--- a/developers/weaviate/model-providers/cohere/embeddings.md
+++ b/developers/weaviate/model-providers/cohere/embeddings.md
@@ -250,7 +250,7 @@ The following examples show how to configure Cohere-specific options.
 
 For further details on model parameters, see the [Cohere API documentation](https://docs.cohere.com/reference/embed).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/cohere/generative.md
+++ b/developers/weaviate/model-providers/cohere/generative.md
@@ -160,7 +160,7 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [Cohere API documentation](https://docs.cohere.com/reference/chat).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/cohere/generative.md
+++ b/developers/weaviate/model-providers/cohere/generative.md
@@ -160,6 +160,17 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [Cohere API documentation](https://docs.cohere.com/reference/chat).
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Cohere-Api-Key`: The Cohere API key.
+- `X-Cohere-Baseurl`: The base URL to use (e.g. a proxy) instead of the default Cohere URL.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Retrieval augmented generation
 
 After configuring the generative AI integration, perform RAG operations, either with the [single prompt](#single-prompt) or [grouped task](#grouped-task) method.

--- a/developers/weaviate/model-providers/cohere/reranker.md
+++ b/developers/weaviate/model-providers/cohere/reranker.md
@@ -133,6 +133,17 @@ You can specify one of the [available models](#available-models) for Weaviate to
 
 The [default model](#available-models) is used if no model is specified.
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Cohere-Api-Key`: The Cohere API key.
+- `X-Cohere-Baseurl`: The base URL to use (e.g. a proxy) instead of the default Cohere URL.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Reranking query
 
 Once the reranker is configured, Weaviate performs [reranking operations](../../search/rerank.md) using the specified Cohere model.

--- a/developers/weaviate/model-providers/cohere/reranker.md
+++ b/developers/weaviate/model-providers/cohere/reranker.md
@@ -133,7 +133,7 @@ You can specify one of the [available models](#available-models) for Weaviate to
 
 The [default model](#available-models) is used if no model is specified.
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/databricks/embeddings.md
+++ b/developers/weaviate/model-providers/databricks/embeddings.md
@@ -132,7 +132,7 @@ This will configure Weaviate to use the vectorizer served through the endpoint y
 
 For further details on model parameters, see the [Databricks documentation](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html#embedding-request).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/databricks/embeddings.md
+++ b/developers/weaviate/model-providers/databricks/embeddings.md
@@ -132,6 +132,18 @@ This will configure Weaviate to use the vectorizer served through the endpoint y
 
 For further details on model parameters, see the [Databricks documentation](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html#embedding-request).
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Databricks-Token`: The Databricks API token.
+- `X-Databricks-Endpoint`: The endpoint to use for the Databricks model.
+- `X-Databricks-User-Agent`: The user agent to use for the Databricks model.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Data import
 
 After configuring the vectorizer, [import data](../../manage-data/import.mdx) into Weaviate. Weaviate generates embeddings for text objects using [the specified model](#vectorizer-parameters).

--- a/developers/weaviate/model-providers/databricks/generative.md
+++ b/developers/weaviate/model-providers/databricks/generative.md
@@ -134,7 +134,7 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [Databricks documentation](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html#chat-task).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/databricks/generative.md
+++ b/developers/weaviate/model-providers/databricks/generative.md
@@ -134,6 +134,18 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [Databricks documentation](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html#chat-task).
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Databricks-Token`: The Databricks API token.
+- `X-Databricks-Endpoint`: The endpoint to use for the Databricks model.
+- `X-Databricks-User-Agent`: The user agent to use for the Databricks model.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Retrieval augmented generation
 
 After configuring the generative AI integration, perform RAG operations, either with the [single prompt](#single-prompt) or [grouped task](#grouped-task) method.

--- a/developers/weaviate/model-providers/friendliai/generative.md
+++ b/developers/weaviate/model-providers/friendliai/generative.md
@@ -162,7 +162,7 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [FriendliAI API documentation](https://docs.friendli.ai/openapi/create-chat-completions).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/friendliai/generative.md
+++ b/developers/weaviate/model-providers/friendliai/generative.md
@@ -162,6 +162,17 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [FriendliAI API documentation](https://docs.friendli.ai/openapi/create-chat-completions).
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Friendli-Api-Key`: The Friendli API key.
+- `X-Friendli-Baseurl`: The base URL to use (e.g. a proxy) instead of the default Friendli URL.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Retrieval augmented generation
 
 After configuring the generative AI integration, perform RAG operations, either with the [single prompt](#single-prompt) or [grouped task](#grouped-task) method.

--- a/developers/weaviate/model-providers/mistral/embeddings.md
+++ b/developers/weaviate/model-providers/mistral/embeddings.md
@@ -166,6 +166,17 @@ import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';
 
 </details>
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Mistral-Api-Key`: The Mistral API key.
+- `X-Mistral-Baseurl`: The base URL to use (e.g. a proxy) instead of the default Mistral URL.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Data import
 
 After configuring the vectorizer, [import data](../../manage-data/import.mdx) into Weaviate. Weaviate generates embeddings for text objects using the specified model.

--- a/developers/weaviate/model-providers/mistral/embeddings.md
+++ b/developers/weaviate/model-providers/mistral/embeddings.md
@@ -166,7 +166,7 @@ import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';
 
 </details>
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/mistral/generative.md
+++ b/developers/weaviate/model-providers/mistral/generative.md
@@ -160,7 +160,7 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [Mistral API documentation](https://docs.mistral.ai/api/).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/mistral/generative.md
+++ b/developers/weaviate/model-providers/mistral/generative.md
@@ -160,6 +160,17 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [Mistral API documentation](https://docs.mistral.ai/api/).
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Mistral-Api-Key`: The Mistral API key.
+- `X-Mistral-Baseurl`: The base URL to use (e.g. a proxy) instead of the default Mistral URL.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Retrieval augmented generation
 
 After configuring the generative AI integration, perform RAG operations, either with the [single prompt](#single-prompt) or [grouped task](#grouped-task) method.

--- a/developers/weaviate/model-providers/openai-azure/embeddings.md
+++ b/developers/weaviate/model-providers/openai-azure/embeddings.md
@@ -173,6 +173,18 @@ The following examples show how to configure Azure OpenAI-specific options.
 
 For further details on these parameters, see consult the [Azure OpenAI API documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/).
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Azure-Api-Key`: The Azure API key.
+- `X-Azure-Deployment-Id`: The Azure deployment ID.
+- `X-Azure-Resource-Name`: The Azure resource name.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Data import
 
 After configuring the vectorizer, [import data](../../manage-data/import.mdx) into Weaviate. Weaviate generates embeddings for text objects using the specified model.

--- a/developers/weaviate/model-providers/openai-azure/embeddings.md
+++ b/developers/weaviate/model-providers/openai-azure/embeddings.md
@@ -173,7 +173,7 @@ The following examples show how to configure Azure OpenAI-specific options.
 
 For further details on these parameters, see consult the [Azure OpenAI API documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/openai-azure/generative.md
+++ b/developers/weaviate/model-providers/openai-azure/generative.md
@@ -135,6 +135,18 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on these parameters, see consult the [Azure OpenAI API documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/).
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-Azure-Api-Key`: The Azure API key.
+- `X-Azure-Deployment-Id`: The Azure deployment ID.
+- `X-Azure-Resource-Name`: The Azure resource name.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Retrieval augmented generation
 
 After configuring the generative AI integration, perform RAG operations, either with the [single prompt](#single-prompt) or [grouped task](#grouped-task) method.

--- a/developers/weaviate/model-providers/openai-azure/generative.md
+++ b/developers/weaviate/model-providers/openai-azure/generative.md
@@ -135,7 +135,7 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on these parameters, see consult the [Azure OpenAI API documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/openai/embeddings.md
+++ b/developers/weaviate/model-providers/openai/embeddings.md
@@ -262,7 +262,7 @@ For further details on model parameters, see the [OpenAI API documentation](http
 
 ### Runtime parameters
 
-You can provide the OpenAI API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 
 - `X-OpenAI-Api-Key`: The OpenAI API key.
 - `X-OpenAI-Baseurl`: The base URL to use (e.g. a proxy) instead of the default OpenAI URL.

--- a/developers/weaviate/model-providers/openai/embeddings.md
+++ b/developers/weaviate/model-providers/openai/embeddings.md
@@ -260,7 +260,7 @@ The following examples show how to configure OpenAI-specific options.
 
 For further details on model parameters, see the [OpenAI API documentation](https://platform.openai.com/docs/api-reference/embeddings).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/openai/embeddings.md
+++ b/developers/weaviate/model-providers/openai/embeddings.md
@@ -260,6 +260,18 @@ The following examples show how to configure OpenAI-specific options.
 
 For further details on model parameters, see the [OpenAI API documentation](https://platform.openai.com/docs/api-reference/embeddings).
 
+### Runtime parameters
+
+You can provide the OpenAI API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-OpenAI-Api-Key`: The OpenAI API key.
+- `X-OpenAI-Baseurl`: The base URL to use (e.g. a proxy) instead of the default OpenAI URL.
+- `X-OpenAI-Organization`: The OpenAI organization ID.
+
+Any additional headers provided at runtime will override the configuration set in the vectorizer.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Data import
 
 After configuring the vectorizer, [import data](../../manage-data/import.mdx) into Weaviate. Weaviate generates embeddings for text objects using the specified model.

--- a/developers/weaviate/model-providers/openai/embeddings.md
+++ b/developers/weaviate/model-providers/openai/embeddings.md
@@ -268,7 +268,7 @@ You can provide the OpenAI API key as well as some optional parameters at runtim
 - `X-OpenAI-Baseurl`: The base URL to use (e.g. a proxy) instead of the default OpenAI URL.
 - `X-OpenAI-Organization`: The OpenAI organization ID.
 
-Any additional headers provided at runtime will override the configuration set in the vectorizer.
+Any additional headers provided at runtime will override the existing Weaviate configuration.
 
 Provide the headers as shown in the [API credentials examples](#api-credentials) above.
 

--- a/developers/weaviate/model-providers/openai/generative.md
+++ b/developers/weaviate/model-providers/openai/generative.md
@@ -173,7 +173,7 @@ You can provide the OpenAI API key as well as some optional parameters at runtim
 - `X-OpenAI-Baseurl`: The base URL to use (e.g. a proxy) instead of the default OpenAI URL.
 - `X-OpenAI-Organization`: The OpenAI organization ID.
 
-Any additional headers provided at runtime will override the configuration set in the vectorizer.
+Any additional headers provided at runtime will override the existing Weaviate configuration.
 
 Provide the headers as shown in the [API credentials examples](#api-credentials) above.
 

--- a/developers/weaviate/model-providers/openai/generative.md
+++ b/developers/weaviate/model-providers/openai/generative.md
@@ -165,6 +165,18 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [OpenAI API documentation](https://platform.openai.com/docs/api-reference/chat).
 
+### Runtime parameters
+
+You can provide the OpenAI API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-OpenAI-Api-Key`: The OpenAI API key.
+- `X-OpenAI-Baseurl`: The base URL to use (e.g. a proxy) instead of the default OpenAI URL.
+- `X-OpenAI-Organization`: The OpenAI organization ID.
+
+Any additional headers provided at runtime will override the configuration set in the vectorizer.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Retrieval augmented generation
 
 After configuring the generative AI integration, perform RAG operations, either with the [single prompt](#single-prompt) or [grouped task](#grouped-task) method.

--- a/developers/weaviate/model-providers/openai/generative.md
+++ b/developers/weaviate/model-providers/openai/generative.md
@@ -167,7 +167,7 @@ For further details on model parameters, see the [OpenAI API documentation](http
 
 ### Runtime parameters
 
-You can provide the OpenAI API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 
 - `X-OpenAI-Api-Key`: The OpenAI API key.
 - `X-OpenAI-Baseurl`: The base URL to use (e.g. a proxy) instead of the default OpenAI URL.

--- a/developers/weaviate/model-providers/openai/generative.md
+++ b/developers/weaviate/model-providers/openai/generative.md
@@ -165,7 +165,7 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [OpenAI API documentation](https://platform.openai.com/docs/api-reference/chat).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/voyageai/embeddings-multimodal.md
+++ b/developers/weaviate/model-providers/voyageai/embeddings-multimodal.md
@@ -170,7 +170,7 @@ The following examples show how to configure VoyageAI-specific options.
 For further details on model parameters, see the [VoyageAI API documentation](https://docs.voyageai.com/reference/multimodal-embeddings-api).
 
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/voyageai/embeddings-multimodal.md
+++ b/developers/weaviate/model-providers/voyageai/embeddings-multimodal.md
@@ -169,6 +169,18 @@ The following examples show how to configure VoyageAI-specific options.
 
 For further details on model parameters, see the [VoyageAI API documentation](https://docs.voyageai.com/reference/multimodal-embeddings-api).
 
+
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-VoyageAI-Api-Key`: The Voyage AI API key.
+- `X-VoyageAI-Baseurl`: The base URL to use (e.g. a proxy) instead of the default Voyage AI URL.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Data import
 
 After configuring the vectorizer, [import data](../../manage-data/import.mdx) into Weaviate. Weaviate generates embeddings for text objects using the specified model.

--- a/developers/weaviate/model-providers/voyageai/embeddings.md
+++ b/developers/weaviate/model-providers/voyageai/embeddings.md
@@ -203,7 +203,7 @@ The following examples show how to configure Voyage AI-specific options.
 
 For further details on model parameters, see the [Voyage AI Embedding API documentation](https://docs.voyageai.com/docs/embeddings).
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/voyageai/embeddings.md
+++ b/developers/weaviate/model-providers/voyageai/embeddings.md
@@ -203,6 +203,17 @@ The following examples show how to configure Voyage AI-specific options.
 
 For further details on model parameters, see the [Voyage AI Embedding API documentation](https://docs.voyageai.com/docs/embeddings).
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-VoyageAI-Api-Key`: The Voyage AI API key.
+- `X-VoyageAI-Baseurl`: The base URL to use (e.g. a proxy) instead of the default Voyage AI URL.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Data import
 
 After configuring the vectorizer, [import data](../../manage-data/import.mdx) into Weaviate. Weaviate generates embeddings for text objects using the specified model.

--- a/developers/weaviate/model-providers/voyageai/reranker.md
+++ b/developers/weaviate/model-providers/voyageai/reranker.md
@@ -110,7 +110,7 @@ You can specify one of the [available models](#available-models) for the reranke
 
 The [default model](#available-models) is used if no model is specified.
 
-### Runtime parameters
+## Runtime parameters
 
 You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 

--- a/developers/weaviate/model-providers/voyageai/reranker.md
+++ b/developers/weaviate/model-providers/voyageai/reranker.md
@@ -110,6 +110,17 @@ You can specify one of the [available models](#available-models) for the reranke
 
 The [default model](#available-models) is used if no model is specified.
 
+### Runtime parameters
+
+You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+
+- `X-VoyageAI-Api-Key`: The Voyage AI API key.
+- `X-VoyageAI-Baseurl`: The base URL to use (e.g. a proxy) instead of the default Voyage AI URL.
+
+Any additional headers provided at runtime will override the existing Weaviate configuration.
+
+Provide the headers as shown in the [API credentials examples](#api-credentials) above.
+
 ## Reranking query
 
 Once the reranker is configured, Weaviate performs [reranking operations](../../search/rerank.md) using the specified Voyage AI model.


### PR DESCRIPTION
### What's being changed:

Add notes on runtime module parameters on module config docs.

- X-Openai-Organization
- X-Openai-Baseurl
- X-Anyscale-Baseurl
- X-Cohere-Baseurl
- X-Azure-Deployment-Id
- X-Azure-Resource-Name
- X-Voyageai-Baseurl
- X-Mistral-Baseurl
- X-Anthropic-Baseurl
- X-Databricks-Endpoint
- X-Databricks-User-Agent
- X-Friendli-Baseurl

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
