### PR TITLE
Add per million price to clarify pricing page

### DIFF
--- a/src/components/Pricing/Plan/standard.jsx
+++ b/src/components/Pricing/Plan/standard.jsx
@@ -71,7 +71,7 @@ export default function PricingStandard() {
           </p>
           <div className={styles.bottomPrice}>
             <span>Starting at $25 /mo</span>
-            <p>per 1M vector dimensions stored/month</p>
+            <p>$0.095 per 1M vector dimensions stored/month</p>
           </div>
           <Link
             className={styles.buttonTryOutline}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
Add $0.095 on per million dimensions stored to make it more clear.
### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
