### PR TITLE
Replace `<a>` HTML tags

### DIFF
--- a/_includes/wcs/retrieve-api-keys.mdx
+++ b/_includes/wcs/retrieve-api-keys.mdx
@@ -1,5 +1,6 @@
 To retrieve your API keys, follow these steps:
 
+import Link from '@docusaurus/Link';
 import Register from '/developers/wcs/img/weaviate-cloud-api-keys.png';
 
 <div class="row">
@@ -7,10 +8,10 @@ import Register from '/developers/wcs/img/weaviate-cloud-api-keys.png';
     <ol>
       <li>
         Open the{' '}
-        <a href="https://console.weaviate.cloud">Weaviate Cloud console</a> and{' '}
-        <a href="/developers/wcs/manage-clusters/status#select-your-cluster">
+        <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link> and{' '}
+        <Link to="/developers/wcs/manage-clusters/status#select-your-cluster">
           select your cluster
-        </a>
+        </Link>
         .
       </li>
       <li>

--- a/_includes/wcs/weaviate-cloud-edit-organization.mdx
+++ b/_includes/wcs/weaviate-cloud-edit-organization.mdx
@@ -1,3 +1,4 @@
+import Link from '@docusaurus/Link';
 import OrganizationSettings from '/developers/wcs/img/weaviate-cloud-organization-settings.png';
 
 <div class="row">
@@ -5,7 +6,7 @@ import OrganizationSettings from '/developers/wcs/img/weaviate-cloud-organizatio
     <ol>
       <li>
         Open the{' '}
-        <a href="https://console.weaviate.cloud">Weaviate Cloud console</a>.
+        <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link>.
       </li>
       <li>
         Open the organization dropdown menu (<span class="callout">1</span>).

--- a/developers/wcs/embeddings/administration.md
+++ b/developers/wcs/embeddings/administration.md
@@ -45,7 +45,6 @@ import DisableWeaviateEmbeddings from '/developers/wcs/img/weaviate-cloud-disabl
 
 ## Pricing and billing
 
-<!-- TODO[g-despot] Update link -->
 If you would like to learn about the pricing model, you can visit the Weaviate Embeddings [product page](https://weaviate.io/product/embeddings). 
 The pricing works on a per-token basis. This means that you will only be billed for the tokens that are successfully consumed. 
 In other words, only requests that result in valid responses from the API are considered.

--- a/developers/wcs/manage-clusters/create.mdx
+++ b/developers/wcs/manage-clusters/create.mdx
@@ -13,7 +13,7 @@ image: og/wcs/user_guides.jpg
 
 When you log into the Weaviate Cloud web console, the `Clusters` panel lists your clusters (<span class="callout">1</span>). There are no clusters when you log in to a new account.
 
-To create a cluster: 
+To create a cluster:
 
 import CreateCluster from '/developers/wcs/img/weaviate-cloud-create-new-cluster.png';
 import SandboxCluster from '/developers/wcs/img/weaviate-cloud-sandbox-cluster.png';
@@ -23,7 +23,8 @@ import ServerlessCluster from '/developers/wcs/img/weaviate-cloud-serverless-clu
   <div class="col col--6">
     <ol>
       <li>
-        Click the plus icon ➕ in the <code>Clusters</code> panel (<span class="callout">2</span>).
+        Click the plus icon ➕ in the <code>Clusters</code> panel (
+        <span class="callout">2</span>).
       </li>
       <li>
         Click on <code>Create cluster</code>.
@@ -83,6 +84,8 @@ Serverless clusters require billing details. Weaviate Cloud prompts you to add b
 
 To create a serverless cluster, follow these steps:
 
+import Link from '@docusaurus/Link';
+
 <div class="row">
   <div class="col col--6">
     <ol>
@@ -93,9 +96,9 @@ To create a serverless cluster, follow these steps:
       <li>Select a cloud region from the dropdown.</li>
       <li>
         Set the{' '}
-        <code>
-          <a href="#advanced-configuration">Advanced configuration</a>
-        </code>{' '}
+        <Link to="#advanced-configuration">
+          <code>Advanced configuration</code>
+        </Link>
         settings.
       </li>
       <li>
@@ -125,16 +128,24 @@ The following advanced configuration settings are available:
   <div class="col col--6">
     <ul>
       <li>
-        <code><a href="/developers/weaviate/configuration/rbac">Enable RBAC</a></code>
+        <Link to="/developers/weaviate/configuration/rbac">
+          <code>Enabl RBAC</code>
+        </Link>
       </li>
       <li>
-        <code><a href="/developers/weaviate/config-refs/schema#auto-schema">Enable auto schema generation</a></code>
+        <Link to="/developers/weaviate/config-refs/schema#auto-schema">
+          <code>Enable auto schema generation</code>
+        </Link>
       </li>
       <li>
-        <code><a href="/developers/weaviate/concepts/vector-index#asynchronous-indexing">Enable async indexing</a></code>
+        <Link to="/developers/weaviate/concepts/vector-index#asynchronous-indexing">
+          <code>Enable async indexing</code>
+        </Link>
       </li>
       <li>
-        <code><a href="/developers/weaviate/configuration/replication#async-replication-settings">Enable async replication</a></code>
+        <Link to="/developers/weaviate/configuration/replication#async-replication-settings">
+          <code>Enable async replication</code>
+        </Link>
       </li>
       <li>
         <code>Allow all CORS origins</code>

--- a/developers/wcs/manage-clusters/status.mdx
+++ b/developers/wcs/manage-clusters/status.mdx
@@ -12,11 +12,12 @@ sidebar_position: 3
 
 ### Select your cluster {#select-your-cluster}
 
+import Link from '@docusaurus/Link';
 import ClusterDetails from '/developers/wcs/img/weaviate-cloud-cluster-details.png';
 
 <ol>
   <li>
-    Open the <a href="https://console.weaviate.cloud">Weaviate Cloud console</a>.
+    Open the <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link>.
   </li>
   <li>
     Open the <code>Clusters</code> list from the left sidebar (

--- a/developers/wcs/manage-clusters/upgrade.mdx
+++ b/developers/wcs/manage-clusters/upgrade.mdx
@@ -12,6 +12,7 @@ If you have a stand-alone cluster, an upgrade requires system downtime. Consider
 
 The `Cluster details` panel contains information about the current Weaviate version and if an update is available:
 
+import Link from '@docusaurus/Link';
 import UpdateCluster from '/developers/wcs/img/weaviate-cloud-update-cluster.png';
 
 <div class="row">
@@ -19,10 +20,10 @@ import UpdateCluster from '/developers/wcs/img/weaviate-cloud-update-cluster.png
     <ol>
       <li>
         Open the{' '}
-        <a href="https://console.weaviate.cloud">Weaviate Cloud console</a> and{' '}
-        <a href="/developers/wcs/manage-clusters/status#select-your-cluster">
+        <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link> and{' '}
+        <Link to="/developers/wcs/manage-clusters/status#select-your-cluster">
           select your cluster
-        </a>
+        </Link>
         .
       </li>
       <li>

--- a/developers/wcs/platform/create-account.mdx
+++ b/developers/wcs/platform/create-account.mdx
@@ -12,13 +12,14 @@ Weaviate Cloud (WCD) has an interactive console. Create a user account, then log
 
 Follow these steps to create a new Weaviate Cloud account.
 
+import Link from '@docusaurus/Link';
 import Register from '/developers/wcs/img/weaviate-cloud-register.png';
 
 <div class="row">
   <div class="col col--6">
     <ol>
       <li>
-        Open the <a href="https://console.weaviate.cloud">Weaviate Cloud console</a>.
+        Open the <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link>.
       </li>
       <li>
         Choose the <code>Sign up</code> option.
@@ -26,7 +27,7 @@ import Register from '/developers/wcs/img/weaviate-cloud-register.png';
       <li>Provide an email address and password and click on the <code>Sign up</code> button.</li>
       <li>
         After you confirm your email address, go back to the{' '}
-        <a href="https://console.weaviate.cloud">login page</a>.
+        <Link to="https://console.weaviate.cloud">login page</Link>.
       </li>
       <li>Log in to Weaviate Cloud.</li>
     </ol>

--- a/developers/wcs/platform/manage-api-keys.mdx
+++ b/developers/wcs/platform/manage-api-keys.mdx
@@ -28,16 +28,17 @@ import RetrieveAPIKeys from '/_includes/wcs/retrieve-api-keys.mdx';
 
 If you have a Serverless cluster, you can create new API keys. To create a new API key, follow these steps:
 
+import Link from '@docusaurus/Link';
 import NewAPIKey from '/developers/wcs/img/weaviate-cloud-new-api-key.png';
 
 <div class="row">
   <div class="col col--4">
     <ol>
       <li>
-        Open the <a href="https://console.weaviate.cloud">Weaviate Cloud console</a>.
+        Open the <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link>.
       </li>
       <li>
-        <a href="/developers/wcs/manage-clusters/status#select-your-cluster">Select your cluster</a> and find the <code>API Keys</code> section.
+        <Link to="/developers/wcs/manage-clusters/status#select-your-cluster">Select your cluster</Link> and find the <code>API Keys</code> section.
       </li>
       <li>Click on the <code>New Key</code> button (<span class="callout">1</span>).</li>
     </ol>
@@ -92,10 +93,10 @@ import DeleteAPIKey from '/developers/wcs/img/weaviate-cloud-delete-api-key.png'
   <div class="col col--4">
     <ol>
       <li>
-        Open the <a href="https://console.weaviate.cloud">Weaviate Cloud console</a>.
+        Open the <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link>.
       </li>
       <li>
-        <a href="/developers/wcs/manage-clusters/status#select-your-cluster">Select your cluster</a> and find the <code>API Keys</code> section.
+        <Link to="/developers/wcs/manage-clusters/status#select-your-cluster">Select your cluster</Link> and find the <code>API Keys</code> section.
       </li>
       <li>Click on the <code>Delete</code> button next to the key you want to delete (<span class="callout">1</span>).</li>
     </ol>

--- a/developers/wcs/platform/multi-factor-auth.mdx
+++ b/developers/wcs/platform/multi-factor-auth.mdx
@@ -13,6 +13,7 @@ Multi-factor authentication (MFA) increases the security of browser logins. MFA 
 
 To enable MFA, follow these steps:
 
+import Link from '@docusaurus/Link';
 import EnableMFA from '/developers/wcs/img/weaviate-cloud-enable-mfa.png';
 import MFA from '/developers/wcs/img/weaviate-cloud-mfa.png';
 
@@ -21,7 +22,7 @@ import MFA from '/developers/wcs/img/weaviate-cloud-mfa.png';
     <ol>
       <li>
         Open the{' '}
-        <a href="https://console.weaviate.cloud">Weaviate Cloud console</a>.
+        <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link>.
       </li>
       <li>
         Click on the <code>Account</code> dropdown menu in the lower left corner

--- a/developers/wcs/platform/users-and-organizations.mdx
+++ b/developers/wcs/platform/users-and-organizations.mdx
@@ -41,6 +41,7 @@ import EditOrganization from '/_includes/wcs/weaviate-cloud-edit-organization.md
 
 To create a new organization, follow these steps:
 
+import Link from '@docusaurus/Link';
 import AddOrganization from '/developers/wcs/img/weaviate-cloud-add-organization.png';
 
 <div class="row">
@@ -48,7 +49,7 @@ import AddOrganization from '/developers/wcs/img/weaviate-cloud-add-organization
     <ol>
       <li>
         Open the{' '}
-        <a href="https://console.weaviate.cloud">Weaviate Cloud console</a>.
+        <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link>.
       </li>
       <li>
          Open the organization dropdown menu (<span class="callout">1</span>).
@@ -88,7 +89,7 @@ To edit an organization name, follow these steps:
   <div class="col col--6">
     <ol>
       <li>
-        Open the <a href="#organization-settings">Organization settings</a>{' '}
+        Open the <Link to="#organization-settings">Organization settings</Link>{' '}
         page.
       </li>
       <li>
@@ -132,7 +133,7 @@ import DeleteOrganization from '/developers/wcs/img/weaviate-cloud-delete-organi
     <ol>
       <li>
         Open the{' '}
-        <a href="https://console.weaviate.cloud">Weaviate Cloud console</a>.
+        <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link>.
       </li>
       <li>
          Open the organization dropdown menu (<span class="callout">1</span>).

--- a/developers/wcs/quickstart.mdx
+++ b/developers/wcs/quickstart.mdx
@@ -84,6 +84,7 @@ In order to perform Retrieval Augmented Generation (RAG) in the last step, you w
 
 ### 1.1 Create a Weaviate Cloud account
 
+import Link from '@docusaurus/Link';
 import Register from '/developers/wcs/img/weaviate-cloud-register.png';
 
 <div class="row">
@@ -91,7 +92,7 @@ import Register from '/developers/wcs/img/weaviate-cloud-register.png';
     <ol>
       <li>
         Open the{' '}
-        <a href="https://console.weaviate.cloud">Weaviate Cloud console</a>.
+        <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link>.
       </li>
       <li>
         Click on <code>Sign up</code>.
@@ -99,7 +100,7 @@ import Register from '/developers/wcs/img/weaviate-cloud-register.png';
       <li>Provide an email address and password.</li>
       <li>
         After you confirm your email address, open the{' '}
-        <a href="https://console.weaviate.cloud">login page</a>.
+        <Link to="https://console.weaviate.cloud">login page</Link>.
       </li>
       <li>Log in to Weaviate Cloud.</li>
     </ol>

--- a/developers/wcs/tools/explorer-tool.mdx
+++ b/developers/wcs/tools/explorer-tool.mdx
@@ -84,6 +84,8 @@ Some details are initially shown as collapsed. Click on the color-coded property
 </div>
 <br/>
 
+import Link from '@docusaurus/Link';
+
 <div class="row">
     <div class="card">
         <div class="card__image">
@@ -92,7 +94,7 @@ Some details are initially shown as collapsed. Click on the color-coded property
         <div class="card__body">
             <p>Click on the color-coded property group such as metadata (item <span class="callout">8</span>) or vectors (item <span class="callout">9</span>) to expand collapsed details.</p>
             <br/>
-            <p>Vectors are shown initially by its name where <a href="/developers/weaviate/concepts/data#multiple-vectors-named-vectors">named vectors</a> are used and number of dimensions. Expand the item further to see some of the vectors, or click `copy` (item <span class="callout">10</span>) to copy the entire vector to clipboard.</p>
+            <p>Vectors are shown initially by its name where <Link to="/developers/weaviate/concepts/data#multiple-vectors-named-vectors">named vectors</Link> are used and number of dimensions. Expand the item further to see some of the vectors, or click `copy` (item <span class="callout">10</span>) to copy the entire vector to clipboard.</p>
         </div>
     </div>
 </div>

--- a/developers/wcs/tools/query-tool.mdx
+++ b/developers/wcs/tools/query-tool.mdx
@@ -6,14 +6,15 @@ image: og/wcs/user_guides.jpg
 
 The Weaviate Cloud (WCD) query tool is a browser-based GraphQL IDE. Use the query tool to work interactively with your Weaviate Cloud clusters.
 
+import Link from '@docusaurus/Link';
 import QueryToolPreview from '/developers/wcs/img/weaviate-cloud-query-tool-preview.png';
 
 <div class="row">
   <div class="col col--6">
     <p>
-      <a href="https://github.com/graphql/graphiql/tree/main/packages/graphiql">
+      <Link to="https://github.com/graphql/graphiql/tree/main/packages/graphiql">
         GraphiQL
-      </a>{' '}
+      </Link>{' '}
       is built into the query tool. GraphiQL provides many features that make
       GraphQL easier to use interactively:
     </p>
@@ -48,7 +49,7 @@ import QueryTool from '/developers/wcs/img/weaviate-cloud-query-tool.png';
     <ol>
       <li>
         Open the{' '}
-        <a href="https://console.weaviate.cloud">Weaviate Cloud console</a>.
+        <Link to="https://console.weaviate.cloud">Weaviate Cloud console</Link>.
       </li>
       <li>
         Click on the <code>Query</code> button and choose a cluster from the list.
@@ -85,7 +86,7 @@ import QueryToolConsole from '/developers/wcs/img/weaviate-cloud-query-tool-cons
       </li>
       <li>
         A panel for{' '}
-        <a href="#pass-inference-keys">passing variables and headers</a> (
+        <Link to="#pass-inference-keys">passing variables and headers</Link> (
         <span class="callout">4</span>).
       </li>
     </ol>

--- a/developers/weaviate/concepts/vector-index.md
+++ b/developers/weaviate/concepts/vector-index.md
@@ -246,7 +246,7 @@ To avoid indexing a collection, set `"skip"` to `"true"`. By default, collection
 
 ### What ANN algorithms exist?
 
-There are different ANN algorithms, you can find a nice overview of them on <a href="http://ann-benchmarks.com/" data-proofer-ignore>this website</a>.
+There are different ANN algorithms, you can find a nice overview of them on [this website](http://ann-benchmarks.com/).
 
 ### Are there indicative benchmarks for Weaviate's ANN performance?
 

--- a/developers/weaviate/config-refs/env-vars.md
+++ b/developers/weaviate/config-refs/env-vars.md
@@ -15,6 +15,8 @@ All other values are interpreted as `false`.
 
 ## General
 
+import Link from '@docusaurus/Link';
+
 | Variable | Description | Type | Example Value |
 | --- | --- | --- | --- |
 | `ASYNC_INDEXING` | (Experimental, added in `v1.22`.) <br/><br/>If set, Weaviate creates vector indexes asynchronously to the object creation process. This can be useful for importing large amounts of data. (default: `false`) | `boolean` | `false` |
@@ -60,8 +62,8 @@ All other values are interpreted as `false`.
 | `TOMBSTONE_DELETION_MAX_PER_CYCLE` | Maximum number of tombstones to delete per cleanup cycle. Set this to limit cleanup cycles, as they are resource-intensive. As an example, set a maximum of 10000000 (10M) for a cluster with 300 million-object shards. Default: none | `string - int` (New in `v1.24.15` / `v1.25.2`) | `10000000` |
 | `TOMBSTONE_DELETION_MIN_PER_CYCLE` | Minimum number of tombstones to delete per cleanup cycle. Set this to prevent triggering unnecessary cleanup cycles below a threshold. As an example, set a minimum of 1000000 (1M) for a cluster with 300 million-object shards. Default: 0 (New in `v1.24.15`, `v1.25.2`) | `string - int` | `100000` |
 | `USE_GSE` | Enable the [`GSE` tokenizer](../config-refs/schema/index.md#gse-and-trigram-tokenization-methods) for use. <br/> (The same as `ENABLE_TOKENIZER_GSE`. We recommend using `ENABLE_TOKENIZER_GSE` for consistency in naming with other optional tokenizers.) | `boolean` | `true` |
-| `USE_INVERTED_SEARCHABLE` | (Preview) Store searchable properties using a more efficient in-disk format, designed for the BlockMax WAND algorithm. Set as `true` together with `USE_BLOCKMAX_WAND` to enable BlockMax WAND at query time. Added in `v1.28`. (Default: `false`) <br/><br/><ul><li>This format is in preview and may be subject to breaking changes in future versions. Expect to need to re-index your data again if you enable this feature.</li> <li>Migrations are not supported with this feature enabled. Will only affect newly created collections. </li></ul> <a href="/developers/weaviate/concepts/indexing#blockmax-wand-algorithm">Read more</a> | `boolean` | `true` |
-| `USE_BLOCKMAX_WAND` | (Preview) Use BlockMax WAND algorithm for BM25 and hybrid searches. Enable it together with `USE_INVERTED_SEARCHABLE` to get the performance benefits. Added in `v1.28`. (Default: `false`) <br/><a href="/developers/weaviate/concepts/indexing#blockmax-wand-algorithm">Read more</a> | `boolean` | `true` |
+| `USE_INVERTED_SEARCHABLE` | (Preview) Store searchable properties using a more efficient in-disk format, designed for the BlockMax WAND algorithm. Set as `true` together with `USE_BLOCKMAX_WAND` to enable BlockMax WAND at query time. Added in `v1.28`. (Default: `false`) <br/><br/><ul><li>This format is in preview and may be subject to breaking changes in future versions. Expect to need to re-index your data again if you enable this feature.</li> <li>Migrations are not supported with this feature enabled. Will only affect newly created collections. </li></ul> <Link to="/developers/weaviate/concepts/indexing#blockmax-wand-algorithm">Read more</Link> | `boolean` | `true` |
+| `USE_BLOCKMAX_WAND` | (Preview) Use BlockMax WAND algorithm for BM25 and hybrid searches. Enable it together with `USE_INVERTED_SEARCHABLE` to get the performance benefits. Added in `v1.28`. (Default: `false`) <br/><Link to="/developers/weaviate/concepts/indexing#blockmax-wand-algorithm">Read more</Link> | `boolean` | `true` |
 
 ## Module-specific
 

--- a/developers/weaviate/manage-data/delete.mdx
+++ b/developers/weaviate/manage-data/delete.mdx
@@ -383,7 +383,7 @@ client.batch().objectsBatchDeleter()
 
 ## Delete all objects
 
-Objects must belong to a collection in Weaviate. Accordingly, <a href="/developers/weaviate/manage-data/collections#delete-a-collection">deleting collections</a> will remove all objects within them.
+Objects must belong to a collection in Weaviate. Accordingly [deleting collections](/developers/weaviate/manage-data/collections#delete-a-collection) will remove all objects within them.
 
 ## Optional parameters
 

--- a/developers/weaviate/quickstart/index.md
+++ b/developers/weaviate/quickstart/index.md
@@ -88,13 +88,14 @@ If you have another preferred [model provider](/developers/weaviate/model-provid
 Go to the [Weaviate Cloud console](https://console.weaviate.cloud) and create a free Sandbox instance.
 
 <!-- TODO[g-despot] Update with new screenshots -->
+import Link from '@docusaurus/Link';
 import CreateCluster from '/developers/weaviate/quickstart/img/create_cluster.png';
 import CreateSandbox from '/developers/weaviate/quickstart/img/create_sandbox.png';
 
 <div class="row">
   <div class="col col--4">
     <ol>
-      <li><a href="https://console.weaviate.cloud">Log onto WCD</a>.</li>
+      <li><Link to="https://console.weaviate.cloud">Log onto WCD</Link>.</li>
       <li>Click on <code>Clusters</code> on the sidebar.</li>
       <li>In the following pane, click <code>Create cluster</code>.</li>
     </ol>
@@ -244,7 +245,7 @@ Weaviate is very flexible. If you prefer a different model provider integration,
         <h4>Prefer a different model provider?</h4>
       </div>
       <div class="card__body">
-        See <a href="#can-i-use-different-integrations">this section</a> for information on how to user another provider, such as AWS, Cohere, Google, and many more.
+        See <Link to="#can-i-use-different-integrations">this section</Link> for information on how to user another provider, such as AWS, Cohere, Google, and many more.
       </div>
     </div>
   </div>
@@ -254,7 +255,7 @@ Weaviate is very flexible. If you prefer a different model provider integration,
         <h4>Want to specify object vectors?</h4>
       </div>
       <div class="card__body">
-        If you prefer to add vectors yourself along with the object data, see <a href="/developers/weaviate/starter-guides/custom-vectors">Starter Guide: Bring Your Own Vectors</a>.
+        If you prefer to add vectors yourself along with the object data, see <Link to="/developers/weaviate/starter-guides/custom-vectors">Starter Guide: Bring Your Own Vectors</Link>.
       </div>
     </div>
   </div>
@@ -474,7 +475,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            See <a href="/developers/weaviate/search">how to perform searches</a>, such as <a href="/developers/weaviate/search/bm25">keyword</a>, <a href="/developers/weaviate/search/similarity">similarity</a>, <a href="/developers/weaviate/search/hybrid">hybrid</a>, <a href="/developers/weaviate/search/image">image</a>, <a href="/developers/weaviate/search/filters">filtered</a> and <a href="/developers/weaviate/search/rerank">reranked</a> searches.
+            See <Link to="/developers/weaviate/search">how to perform searches</Link>, such as <Link to="/developers/weaviate/search/bm25">keyword</Link>, <Link to="/developers/weaviate/search/similarity">similarity</Link>, <Link to="/developers/weaviate/search/hybrid">hybrid</Link>, <Link to="/developers/weaviate/search/image">image</Link>, <Link to="/developers/weaviate/search/filters">filtered</Link> and <Link to="/developers/weaviate/search/rerank">reranked</Link> searches.
           </p>
         </div>
       </div>
@@ -486,7 +487,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            See <a href="/developers/weaviate/manage-data">how to manage data</a>, such as <a href="/developers/weaviate/manage-data/collections">manage collections</a>, <a href="/developers/weaviate/manage-data/create">create objects</a>, <a href="/developers/weaviate/manage-data/import">batch import data</a> and <a href="/developers/weaviate/manage-data/multi-tenancy">use multi-tenancy</a>.
+            See <Link to="/developers/weaviate/manage-data">how to manage data</Link>, such as <Link to="/developers/weaviate/manage-data/collections">manage collections</Link>, <Link to="/developers/weaviate/manage-data/create">create objects</Link>, <Link to="/developers/weaviate/manage-data/import">batch import data</Link> and <Link to="/developers/weaviate/manage-data/multi-tenancy">use multi-tenancy</Link>.
           </p>
         </div>
       </div>
@@ -498,7 +499,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            Check out the <a href="/developers/weaviate/starter-guides/generative">Starter guide: retrieval augmented generation</a>, and the <a href="/developers/academy">Weaviate Academy</a> unit on <a href="/developers/academy/py/standalone/chunking">chunking</a>.
+            Check out the <Link to="/developers/weaviate/starter-guides/generative">Starter guide: retrieval augmented generation</Link>, and the <Link to="/developers/academy">Weaviate Academy</Link> unit on <Link to="/developers/academy/py/standalone/chunking">chunking</Link>.
           </p>
         </div>
       </div>
@@ -510,7 +511,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-          We hold in-person and online <a href="/community/events">workshops, office hours and events</a> for different experience levels. Join us!
+          We hold in-person and online <Link to="/community/events">workshops, office hours and events</Link> for different experience levels. Join us!
           </p>
         </div>
       </div>

--- a/developers/weaviate/quickstart/local.md
+++ b/developers/weaviate/quickstart/local.md
@@ -177,6 +177,8 @@ Run this code to create the collection to which you can add data.
 
 Weaviate is very flexible. If you prefer a different model provider integration, or prefer to import your own vectors, see one of the following guides:
 
+import Link from '@docusaurus/Link';
+
 <div class="row">
   <div class="col col--6 margin-top--xs padding-top--xs">
     <div class="card">
@@ -184,7 +186,7 @@ Weaviate is very flexible. If you prefer a different model provider integration,
         <h4>Prefer a different model provider?</h4>
       </div>
       <div class="card__body">
-        See <a href="#can-i-use-different-integrations">this section</a> for information on how to user another provider, such as AWS, Cohere, Google, and many more.
+        See <Link to="#can-i-use-different-integrations">this section</Link> for information on how to user another provider, such as AWS, Cohere, Google, and many more.
       </div>
     </div>
   </div>
@@ -194,7 +196,7 @@ Weaviate is very flexible. If you prefer a different model provider integration,
         <h4>Want to specify object vectors?</h4>
       </div>
       <div class="card__body">
-        If you prefer to add vectors yourself along with the object data, see <a href="/developers/weaviate/starter-guides/custom-vectors">Starter Guide: Bring Your Own Vectors</a>.
+        If you prefer to add vectors yourself along with the object data, see <Link to="/developers/weaviate/starter-guides/custom-vectors">Starter Guide: Bring Your Own Vectors</Link>.
       </div>
     </div>
   </div>
@@ -410,7 +412,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            See <a href="/developers/weaviate/search">how to perform searches</a>, such as <a href="/developers/weaviate/search/bm25">keyword</a>, <a href="/developers/weaviate/search/similarity">similarity</a>, <a href="/developers/weaviate/search/hybrid">hybrid</a>, <a href="/developers/weaviate/search/image">image</a>, <a href="/developers/weaviate/search/filters">filtered</a> and <a href="/developers/weaviate/search/rerank">reranked</a> searches.
+            See <Link to="/developers/weaviate/search">how to perform searches</Link>, such as <Link to="/developers/weaviate/search/bm25">keyword</Link>, <Link to="/developers/weaviate/search/similarity">similarity</Link>, <Link to="/developers/weaviate/search/hybrid">hybrid</Link>, <Link to="/developers/weaviate/search/image">image</Link>, <Link to="/developers/weaviate/search/filters">filtered</Link> and <Link to="/developers/weaviate/search/rerank">reranked</Link> searches.
           </p>
         </div>
       </div>
@@ -422,7 +424,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            See <a href="/developers/weaviate/manage-data">how to manage data</a>, such as <a href="/developers/weaviate/manage-data/collections">manage collections</a>, <a href="/developers/weaviate/manage-data/create">create objects</a>, <a href="/developers/weaviate/manage-data/import">batch import data</a> and <a href="/developers/weaviate/manage-data/multi-tenancy">use multi-tenancy</a>.
+            See <Link to="/developers/weaviate/manage-data">how to manage data</Link>, such as <Link to="/developers/weaviate/manage-data/collections">manage collections</Link>, <Link to="/developers/weaviate/manage-data/create">create objects</Link>, <Link to="/developers/weaviate/manage-data/import">batch import data</Link> and <Link to="/developers/weaviate/manage-data/multi-tenancy">use multi-tenancy</Link>.
           </p>
         </div>
       </div>
@@ -434,7 +436,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-            Check out the <a href="/developers/weaviate/starter-guides/generative">Starter guide: retrieval augmented generation</a>, and the <a href="/developers/academy">Weaviate Academy</a> unit on <a href="/developers/academy/py/standalone/chunking">chunking</a>.
+            Check out the <Link to="/developers/weaviate/starter-guides/generative">Starter guide: retrieval augmented generation</Link>, and the <Link to="/developers/academy">Weaviate Academy</Link> unit on <Link to="/developers/academy/py/standalone/chunking">chunking</Link>.
           </p>
         </div>
       </div>
@@ -446,7 +448,7 @@ Try these additional resources to learn more about Weaviate:
         </div>
         <div class="card__body">
           <p>
-          We hold in-person and online <a href="/community/events">workshops, office hours and events</a> for different experience levels. Join us!
+          We hold in-person and online <Link to="/community/events">workshops, office hours and events</Link> for different experience levels. Join us!
           </p>
         </div>
       </div>

--- a/developers/weaviate/search/aggregate.md
+++ b/developers/weaviate/search/aggregate.md
@@ -33,7 +33,7 @@ To run an `Aggregate` query, specify the following:
 
 - Select at least one sub-property for each selected property
 
-For details, see <a href="https://weaviate.io/developers/weaviate/api/graphql/aggregate">Aggregate</a>.
+For details, see [Aggregate](/developers/weaviate/api/graphql/aggregate).
 
 </details>
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

Replace `<a>` HTML tags with `<Link>` component in order for Docusaurus broken link checking to work. 

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
