### PR TITLE
fix: escape asterisks in multi-vector-embeddings.md

### DIFF
--- a/developers/weaviate/tutorials/multi-vector-embeddings.md
+++ b/developers/weaviate/tutorials/multi-vector-embeddings.md
@@ -116,7 +116,7 @@ This approach often leads to better search results, as it can capture more nuanc
 
 Multi-vector embeddings are particularly useful for search tasks where word order and exact phrase matching are important. This is due to multi-vector embeddings preserving token-level information and enabling late interaction. However, multi-vector embeddings will typically require more resources than single-vector embeddings.
 
-Although each vector in a multi-vector embedding is smaller than a single-vector embedding, the total size of the multi-vector embedding typically larger, as each embedding contains many vectors. As an example, single-vector embedding of 1536 dimensions is (1536 * 4 bytes) = 6 kB, while a multi-vector embedding of 64 vectors of 96 dimensions is (64 * 96 * 4 bytes) = 25 kB - over 4 times larger.
+Although each vector in a multi-vector embedding is smaller than a single-vector embedding, the total size of the multi-vector embedding typically larger, as each embedding contains many vectors. As an example, single-vector embedding of 1536 dimensions is (1536 \* 4 bytes) = 6 kB, while a multi-vector embedding of 64 vectors of 96 dimensions is (64 \* 96 \* 4 bytes) = 25 kB - over 4 times larger.
 
 Multi-vector embeddings therefore require more memory to store and more compute to search.
 


### PR DESCRIPTION



See the last sentence of the paragraph detailing how to estimate the size of a multi-vector embedding: 
<img width="942" alt="image" src="https://github.com/user-attachments/assets/37260981-a0ac-48b1-8ee2-e0260e2ef947" />

This happens in both Chrome and Safari.


### What's being changed:

docusaurus seems to treat `*` as a meta character for italicizing text regardless of its positioning, so some formulas become mangled.

Escaping them like so `\*` seems to do the trick.

### Type of change:

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

Tested in a [Docusaurus Playground](https://codesandbox.io/p/devbox/wild-dust-ltgrg3?workspaceId=ws_7ZwZBX3vvx2Q2XvrF5z9ud):
- navigate to tutorial/intro.md for raw markdown
- open devtools (`>` icon), run `dev` task, and Open Preview

(sorry, I still haven't tried running this locally, just wanted to leave this PR as a note about sth I noticed)  

- [ ] **GitHub action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`
