### PR TITLE
Fix for broken academy link

### DIFF
--- a/_includes/code/howto/search.aggregate.ts
+++ b/_includes/code/howto/search.aggregate.ts
@@ -173,7 +173,7 @@ const response = await jeopardy.aggregate.hybrid("animals in space", {
     returnMetrics: jeopardy.metrics.aggregate("points").number(["sum"])
 })
 
-console.log("", response.properties['points'].sum)
+console.log(response.properties['points'].sum)
 // END HybridExample
 
   // Test

--- a/developers/academy/js/_snippets/intro_next_steps_js.mdx
+++ b/developers/academy/js/_snippets/intro_next_steps_js.mdx
@@ -16,7 +16,7 @@ Some of our more popular resources include:
 ### Academy
 
 - [Working with Text](/developers/academy/js/starter_text_data): Learn how to use work with text data in Weaviate.
-- [Which search is right for me?](/developers/academy/js/standalone/which_search): Learn about the different types of searches in Weaviate and when to use them.
+- [Which search is right for me?](/developers/academy/js/standalone/which-search): Learn about the different types of searches in Weaviate and when to use them.
 
 
 import CTASocials from './cta_socials.mdx';


### PR DESCRIPTION
### What's being changed:

Updating a link in an academy next steps

### Type of change:


- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?


- [ ] **GitHub action** – automated build completed without errors
- [ ] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
