### PR TITLE
fix: trailing commas make json invalid and cause parsing error

### DIFF
--- a/_includes/code/quickstart/local.quickstart.create_collection.mdx
+++ b/_includes/code/quickstart/local.quickstart.create_collection.mdx
@@ -63,11 +63,11 @@ curl -X POST \
   "moduleConfig": {
     "text2vec-ollama": {
 				"apiEndpoint": "http://host.docker.internal:11434",
-				"model": "nomic-embed-text",
+				"model": "nomic-embed-text"
     },
     "generative-ollama": {
 				"apiEndpoint": "http://host.docker.internal:11434",
-				"model": "llama3.2",
+				"model": "llama3.2"
     }
   }
 }' \


### PR DESCRIPTION
Fixing two misplaced trailing commas which are not allowed in json before
and closing brace. They make the json invalid and result in curl failing with a
parser error.

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [x] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)
