### PR TITLE
Document azure backup blocksize and concurrency env vars and client header parameter

### DIFF
--- a/developers/weaviate/configuration/backups.md
+++ b/developers/weaviate/configuration/backups.md
@@ -282,7 +282,9 @@ At least one of `AZURE_STORAGE_CONNECTION_STRING` or `AZURE_STORAGE_ACCOUNT` mus
 | `AZURE_BLOCK_SIZE` | no |  int64(40 x 1024 x 1024) | Configure block size upload parameter |
 | `AZURE_CONCURRENCY` | no |  11 | Configure upload concurrency parameter |
 
-
+:::note
+You can also use `X-Azure-Block-Size` and `X-Azure-Concurrency` as a client header parameter
+:::
 ### Filesystem
 
 - Works with Google Cloud Storage

--- a/developers/weaviate/configuration/backups.md
+++ b/developers/weaviate/configuration/backups.md
@@ -276,6 +276,12 @@ If both of `AZURE_STORAGE_CONNECTION_STRING` and `AZURE_STORAGE_ACCOUNT` are pro
 At least one of `AZURE_STORAGE_CONNECTION_STRING` or `AZURE_STORAGE_ACCOUNT` must be present.
 :::
 
+#### Azure Blocksize and Concurrency
+| Environment variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `AZURE_BLOCK_SIZE` | no |  int64(40 x 1024 x 1024) | Configure block size upload parameter |
+| `AZURE_CONCURRENCY` | no |  11 | Configure upload concurrency parameter |
+
 
 ### Filesystem
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:
Documented the new environment variables introduced on this PR: https://github.com/weaviate/weaviate/pull/6468
`AZURE_BLOCK_SIZE`, `AZURE_CONCURRENCY` and a note about using `X-Azure-Block-Size` and `X-Azure-Concurrency` as client header parameters

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)
- [ ] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
