### PR TITLE
Update go.md

### DIFF
--- a/developers/weaviate/client-libraries/go.md
+++ b/developers/weaviate/client-libraries/go.md
@@ -24,7 +24,7 @@ go mod tidy
 To get the latest stable version of the Go client library, run the following:
 
 ```bash
-go get github.com/weaviate/weaviate-go-client/v4
+go install github.com/weaviate/weaviate-go-client/v4@latest
 ```
 
 ## Example


### PR DESCRIPTION
go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.