### PR TITLE
Fix output parameter location

### DIFF
--- a/developers/weaviate/config-refs/nodes.md
+++ b/developers/weaviate/config-refs/nodes.md
@@ -11,7 +11,7 @@ You can retrieve information about individual nodes in a Weaviate cluster. The q
 
 | Name | Location | Type | Description |
 | ---- | -------- | ---- | ----------- |
-| `output` | body | string | How much information to include in the output. Options:  `minimal` (default) and `verbose` (includes shard information). |
+| `output` | query | string | How much information to include in the output. Options:  `minimal` (default) and `verbose` (includes shard information). |
 
 ### Returned data:
 


### PR DESCRIPTION
### What's being changed:
Documentation fix: `v1/nodes` is a GET request, passing the parameter within the body does not make sense, it is expected as a query parameter as usual for HTTP GET requests.

### Type of change:
- [x] **Documentation** updates (non-breaking change to fix/update documentation)
