### PR TITLE
[v1.31] Backward compatible named vectors

### DIFF
--- a/_includes/code/howto/manage-data.collections.py
+++ b/_includes/code/howto/manage-data.collections.py
@@ -507,6 +507,23 @@ client.collections.create(
 )
 # END PropModuleSettings
 
+# ====================================
+# ===== MODULE SETTINGS PROPERTY =====
+# ====================================
+
+# START AddNamedVectors
+from weaviate.classes.config import Configure
+
+articles = client.collections.get("Article")
+
+articles.config.add_vector(
+    vector_config=Configure.NamedVectors.text2vec_cohere(
+        name="body_vector",
+        source_properties=["body"],
+    )
+)
+# END AddNamedVectors
+
 # Test
 collection = client.collections.get("Article")
 config = collection.config.get()

--- a/developers/weaviate/config-refs/schema/index.md
+++ b/developers/weaviate/config-refs/schema/index.md
@@ -98,7 +98,7 @@ import CollectionMutableParameters from '/_includes/collection-mutable-parameter
 
 </details>
 
-After you create a collection, you can add new properties. You cannot modify existing properties after you create the collection.
+After you create a collection, you can add new properties. You cannot modify existing properties after you create the collection. You can also [add new named vectors](#adding-a-named-vector-after-collection-creation).
 
 ### Auto-schema
 
@@ -150,9 +150,17 @@ To avoid this, you can either:
 
 We are working on a re-indexing API to allow you to re-index the data after adding a property. This will be available in a future release.
 
+### Adding a named vector after collection creation
+
+:::info Added in `v1.31`
+:::
+
+When you add a new named vector to an existing collection, it's important to understand that **existing objects will not be automatically revectorized**. Only objects created or updated after the named vector addition will receive these new vector embeddings.
+This behavior is intentional and provides performance benefits when working with large datasets, as it prevents the system from having to recalculate embeddings for all the objects.
+
 ### Collections count limit {#collections-count-limit}
 
-:::info Added in **`v1.30`**
+:::info Added in `v1.30`
 :::
 
 To ensure optimal performance, Weaviate **limits the number of collections per node**. Each collection adds overhead in terms of indexing, definition management, and storage. This limit aims to ensure Weaviate remains performant.

--- a/developers/weaviate/config-refs/schema/multi-vector.md
+++ b/developers/weaviate/config-refs/schema/multi-vector.md
@@ -23,11 +23,7 @@ Single vector collections are valid and continue to use the original collection 
 
 ### Collection definition
 
-Use the collection definition to [configure the vector spaces](/developers/weaviate/manage-data/collections#define-named-vectors) for each data object.
-
-:::info Named vectors must be defined at collection creation
-All named vectors must be defined when you create a collection. Currently, it is not possible to add or remove named vectors from a collection after it has been created.
-:::
+Use the collection definition to [configure the vector spaces](/developers/weaviate/manage-data/collections#define-named-vectors) for each data object. You can also [add new named vectors](../../manage-data/collections.mdx#add-new-named-vectors) after you created a collection. 
 
 ### Query a named vector
 

--- a/developers/weaviate/manage-data/collections.mdx
+++ b/developers/weaviate/manage-data/collections.mdx
@@ -362,6 +362,49 @@ To configure how a vectorizer works (i.e. what model to use) with a specific col
 
 </Tabs>
 
+## Add new named vectors
+
+:::info Added in `v1.31`
+:::
+
+Named vectors can be added to existing collections.
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+    <FilteredTextBlock
+      text={PyCode}
+      startMarker="# START AddNamedVectors"
+      endMarker="# END AddNamedVectors"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="js" label="JS/TS Client v3">
+
+```typescript
+// TS support coming soon
+```
+
+  </TabItem>
+  <TabItem value="java" label="Java">
+
+```java
+// Java support coming soon
+```
+
+  </TabItem>
+  <TabItem value="go" label="Go">
+
+```go
+// Go support coming soon
+```
+  
+  </TabItem>
+</Tabs>
+
+:::caution Objects aren't automatically revectorized
+Newly added named vectors [won't generate embeddings for existing objects](../config-refs/schema/index.md#adding-a-named-vector-after-collection-creation). Only new or updated objects will receive embeddings for the newly added named vector.
+:::
+
 ## Set vector index type
 
 The vector index type can be set for each collection at creation time, between `hnsw`, `flat` and `dynamic` index types.

--- a/versions-config.json
+++ b/versions-config.json
@@ -1,7 +1,7 @@
 {
   "COMMENT1": "These values are used for yarn local yarn builds",
   "COMMENT2": "Build time values are set in _build_scripts/update-config-versions.js",
-  "weaviate_version": "1.30.0",
+  "weaviate_version": "1.31.0",
   "helm_version": "17.3.3",
   "weaviate_cli_version": "3.1.0",
   "weaviate_agents_version": "0.4.5",


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

Named vevtors can be added to existing collections. 

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
