### PR TITLE
Add multi-vector snippets for Go

### DIFF
--- a/_includes/code/howto/go/docs/manage-data.classes_test.go
+++ b/_includes/code/howto/go/docs/manage-data.classes_test.go
@@ -634,4 +634,119 @@ func Test_ManageDataClasses(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+
+	t.Run("add multi-vector collection", func(t *testing.T) {
+		err = client.Schema().ClassDeleter().WithClassName("Article").Do(ctx)
+		require.NoError(t, err)
+
+		// START MultiValueVectorCollection
+		// Define the collection with multi-vector configurations
+		articleClass := &models.Class{
+			Class: "Article",
+			Properties: []*models.Property{
+				{
+					Name:     "text",
+					DataType: []string{"text"},
+				},
+			},
+			// Named vectors configuration
+			VectorConfig: map[string]models.VectorConfig{
+				// Example 1: Jina AI ColBERT integration
+				"jina_colbert": {
+					Vectorizer: map[string]interface{}{
+						"text2colbert-jinaai": map[string]interface{}{
+							"sourceProperties": []string{"text"},
+						},
+					},
+					VectorIndexType: "hnsw",
+				},
+				// Example 2: Custom multi-vector configuration
+				"custom_multi_vector": {
+					Vectorizer: map[string]interface{}{
+						"none": nil,
+					},
+					VectorIndexType: "hnsw",
+					VectorIndexConfig: map[string]interface{}{
+						"multivector": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+			},
+		}
+		// END MultiValueVectorCollection
+
+		err := client.Schema().ClassCreator().
+			WithClass(articleClass).
+			Do(ctx)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("multi-vector with muvera encoding", func(t *testing.T) {
+		err = client.Schema().ClassDeleter().WithClassName("Article").Do(ctx)
+		require.NoError(t, err)
+
+		// START MultiValueVectorMuvera
+		// Create class with multi-vector configurations using MUVERA encoding
+		articleClass := &models.Class{
+			Class: "Article",
+			Properties: []*models.Property{
+				{
+					Name:     "text",
+					DataType: []string{"text"},
+				},
+			},
+			VectorConfig: map[string]models.VectorConfig{
+				// Example 1 - Use a model integration (Jina AI ColBERT)
+				"jina_colbert": {
+					Vectorizer: map[string]interface{}{
+						"text2colbert-jinaai": map[string]interface{}{
+							"sourceProperties": []string{"text"},
+						},
+					},
+					VectorIndexType: "hnsw",
+					VectorIndexConfig: map[string]interface{}{
+						// Multi-vector configuration with MUVERA encoding
+						"multivector": map[string]interface{}{
+							"enabled": true,
+							// Configure MUVERA encoding
+							"muvera": map[string]interface{}{
+								"enabled":      true,
+								"ksim":         4,
+								"dprojections": 16,
+								"repetitions":  20,
+							},
+						},
+					},
+				},
+				// Example 2 - User-provided multi-vector representations
+				"custom_multi_vector": {
+					Vectorizer: map[string]interface{}{
+						"none": nil,
+					},
+					VectorIndexType: "hnsw",
+					VectorIndexConfig: map[string]interface{}{
+						// Multi-vector configuration with MUVERA encoding (minimal config)
+						"multivector": map[string]interface{}{
+							"enabled": true,
+							"muvera": map[string]interface{}{
+								"enabled":      true,
+								"ksim":         4,
+								"dprojections": 16,
+								"repetitions":  20,
+							},
+						},
+					},
+				},
+			},
+		}
+		// END MultiValueVectorMuvera
+
+		err := client.Schema().ClassCreator().
+			WithClass(articleClass).
+			Do(ctx)
+
+		require.NoError(t, err)
+	})
 }

--- a/_includes/code/howto/go/docs/manage-data.classes_test.go
+++ b/_includes/code/howto/go/docs/manage-data.classes_test.go
@@ -731,10 +731,7 @@ func Test_ManageDataClasses(t *testing.T) {
 						"multivector": map[string]interface{}{
 							"enabled": true,
 							"muvera": map[string]interface{}{
-								"enabled":      true,
-								"ksim":         4,
-								"dprojections": 16,
-								"repetitions":  20,
+								"enabled": true,
 							},
 						},
 					},

--- a/developers/weaviate/configuration/compression/multi-vectors.md
+++ b/developers/weaviate/configuration/compression/multi-vectors.md
@@ -9,6 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBlock';
 import PyCode from '!!raw-loader!/\_includes/code/howto/manage-data.collections.py';
+import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/manage-data.classes_test.go';
 
 Multi-vector embeddings represent a single data object, like a document or image, using a set of multiple vectors rather than a single vector. This approach allows for a more granular capture of semantic information, as each vector can represent different parts of the object. However, this leads to a significant increase in memory consumption, as multiple vectors are stored for each item.
 
@@ -44,12 +45,13 @@ Compression techniques become especially crucial for multi-vector systems to man
 
  </TabItem>
   <TabItem value="go" label="Go">
-
-```go
-// Go support coming soon
-```
-
-</TabItem>
+    <FilteredTextBlock
+      text={GoCode}
+      startMarker="// START MultiValueVectorCollection"
+      endMarker="// END MultiValueVectorCollection"
+      language="go"
+    />
+  </TabItem>
 </Tabs>
 
 The final dimensionality of the MUVERA encoded vector will be

--- a/developers/weaviate/manage-data/collections.mdx
+++ b/developers/weaviate/manage-data/collections.mdx
@@ -444,6 +444,14 @@ Multi-vector embeddings, also known as multi-vectors, represent a single object 
       language="java"
     />
   </TabItem>
+  <TabItem value="go" label="Go">
+    <FilteredTextBlock
+      text={GoCode}
+      startMarker="// START MultiValueVectorCollection"
+      endMarker="// END MultiValueVectorCollection"
+      language="go"
+    />
+  </TabItem>
 </Tabs>
 
 :::tip Use quantization and encoding to compress your vectors


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

Add multi-vector snippets for Go.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
