### PR TITLE
[v1.32] Rotational quantization

### DIFF
--- a/_includes/code/howto/configure-rq/rq-compression-v4.py
+++ b/_includes/code/howto/configure-rq/rq-compression-v4.py
@@ -1,0 +1,68 @@
+# THIS FILE NEEDS TESTS
+
+# ==============================
+# =====  CONNECT =====
+# ==============================
+
+# START ConnectCode
+import weaviate, os
+import weaviate.classes.config as wc
+
+client = weaviate.connect_to_local(
+    headers={
+        "X-OpenAI-Api-Key": os.environ[
+            "OPENAI_API_KEY"
+        ]  # Replace with your OpenAI API key
+    }
+)
+
+client.is_ready()
+
+# END ConnectCode
+
+# ==============================
+# =====  EnableRQ =====
+# ==============================
+
+client.collections.delete("MyCollection")
+
+# START EnableRQ
+import weaviate.classes.config as wc
+
+client.collections.create(
+    name="MyCollection",
+    vectorizer_config=wc.Configure.Vectorizer.text2vec_openai(),
+    # highlight-start
+    vector_index_config=wc.Configure.VectorIndex.hnsw(
+        quantizer=wc.Configure.VectorIndex.Quantizer.rq()
+    ),
+    # highlight-end
+)
+# END EnableRQ
+
+# ==============================
+# =====  EnableRQ with Options =====
+# ==============================
+
+client.collections.delete("MyCollection")
+
+# START RQWithOptions
+import weaviate.classes.config as wc
+
+client.collections.create(
+    name="MyCollection",
+    vectorizer_config=wc.Configure.Vectorizer.text2vec_openai(),
+    vector_index_config=wc.Configure.VectorIndex.hnsw(
+        distance_metric=wc.VectorDistances.COSINE,
+        vector_cache_max_objects=100000,
+        # highlight-start
+        quantizer=wc.Configure.VectorIndex.Quantizer.rq(
+            rescore_limit=200,
+            cache=True,
+        )
+        # highlight-end
+    ),
+)
+# END RQWithOptions
+
+client.close()

--- a/_includes/starter-guides/compression-types.mdx
+++ b/_includes/starter-guides/compression-types.mdx
@@ -2,5 +2,9 @@
 
   The PQ compression algorithm is [configurable](/developers/weaviate/config-refs/schema/vector-index#pq-configuration-parameters).
 You control the number of segments, segment granularity, and the size of the training set.
+
 - [Scalar Quantization (SQ)](/developers/weaviate/configuration/compression/sq-compression) SQ reduces the size of each vector dimension from 32 bits to 8 bits. SQ trains on your data to create custom buckets for each dimension. This training helps SQ to preserve data characteristics when it maps information from the 32 bit dimensions into 8 bit buckets.
+
+- [Rotational Quantization (RQ)](/developers/weaviate/configuration/compression/rq-compression) RQ reduces the size of each vector dimension from 32 bits to 8 bits without requiring training. RQ first applies a fast pseudorandom rotation to the vector, then quantizes each dimension to 8 bits. The rotation spreads information evenly across dimensions, enabling up to 98-99% recall without any configuration or training phase.
+
 - [Binary Quantization (BQ)](/developers/weaviate/configuration/compression/bq-compression) BQ reduces the size of each vector dimension to a single bit. This compression algorithm works best for vectors with high dimensionality.

--- a/developers/weaviate/configuration/compression/index.md
+++ b/developers/weaviate/configuration/compression/index.md
@@ -11,4 +11,5 @@ To balance resource costs and system performance, consider one of these options:
 
 - [Binary Quantization (BQ)](/developers/weaviate/configuration/compression/bq-compression)
 - [Product Quantization (PQ)](/developers/weaviate/configuration/compression/pq-compression)
+- [Rotational Quantization (RQ)](/developers/weaviate/configuration/compression/rq-compression)
 - [Scalar Quantization (SQ)](/developers/weaviate/configuration/compression/sq-compression)

--- a/developers/weaviate/configuration/compression/multi-vectors.md
+++ b/developers/weaviate/configuration/compression/multi-vectors.md
@@ -86,7 +86,7 @@ These parameters can be used to fine-tune MUVERA:
   of the original multi-vector similarity.
 
 :::note Quantization
-Quantization is also available as a compression technique for multi-vector embeddings. It reduces the memory footprint of individual vectors by approximating their values with less precision. Just like with single vectors, multi-vectors support [PQ](./pq-compression.md), [BQ](./bq-compression.md) and [SQ](./sq-compression.md) quantization.
+Quantization is also available as a compression technique for multi-vector embeddings. It reduces the memory footprint of individual vectors by approximating their values with less precision. Just like with single vectors, multi-vectors support [PQ](./pq-compression.md), [BQ](./bq-compression.md), [RQ](./rq-compression.md) and [SQ](./sq-compression.md) quantization.
 :::
 
 ## Further resources

--- a/developers/weaviate/configuration/compression/rq-compression.md
+++ b/developers/weaviate/configuration/compression/rq-compression.md
@@ -1,0 +1,167 @@
+---
+title: Rotational Quantization (RQ)
+sidebar_position: 25
+image: og/docs/configuration.jpg
+# tags: ['configuration', 'compression', 'rq']
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBlock';
+import PyCode from '!!raw-loader!/\_includes/code/howto/configure-rq/rq-compression-v4.py';
+
+:::info Added in v1.32
+:::
+
+[Rotational quantization (RQ)](/developers/weaviate/concepts/vector-quantization#rotational-quantization) is a fast **untrained** vector compression technique that offers 4x compression while retaining almost perfect recall (98-99% on most datasets).
+
+Unlike scalar quantization (SQ), RQ does not require training and can be enabled immediately at index creation without any training phase or switchover point. RQ works by performing a fast pseudorandom rotation of the input vector followed by scalar quantization of each entry to an 8-bit integer.
+
+:::note HNSW only
+RQ is currently only supported by the HNSW index.
+:::
+
+## Basic configuration
+
+RQ can be enabled at collection creation time. To enable RQ, set `vector_index_config`.
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+      <FilteredTextBlock
+        text={PyCode}
+        startMarker="# START EnableRQ"
+        endMarker="# END EnableRQ"
+        language="py"
+      />
+  </TabItem>
+</Tabs>
+
+## Custom configuration
+
+To tune RQ, set these `vectorIndexConfig` parameters.
+
+| Parameter               | Type    | Default | Details                                                                                                                                                                                                                                                                                   |
+| :---------------------- | :------ | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rq`: `enabled`         | boolean | `false` | Uses RQ when `true`. <br/><br/> The Python client v4 does not use the `enabled` parameter. To enable RQ with the v4 client, set a `quantizer` in the collection definition.                                                                                                               |
+| `rq`: `rescoreLimit`    | integer | 20      | The number of candidates to fetch before rescoring. Set to 0 to disable rescoring.                                                                                                                                                                                                        |
+| `rq`: `bits`            | integer | 8       | The number of bits used to quantize each data point. Currently only 8 bits is supported.                                                                                                                                                                                                  |
+| `rq`: `cache`           | boolean | `false` | Use the vector cache when true.                                                                                                                                                                                                                                                           |
+| `vectorCacheMaxObjects` | integer | `1e12`  | Maximum number of objects in the memory cache. By default, this limit is set to one trillion (`1e12`) objects when a new collection is created. For sizing recommendations, see [Vector cache considerations](/developers/weaviate/concepts/vector-index.md#vector-cache-considerations). |
+
+<Tabs groupId="languages">
+  <TabItem value="py" label="Python Client v4">
+      <FilteredTextBlock
+        text={PyCode}
+        startMarker="# START RQWithOptions"
+        endMarker="# END RQWithOptions"
+        language="py"
+      />
+  </TabItem>
+</Tabs>
+
+## RQ characteristics
+
+Rotational quantization offers several advantages:
+
+- **No training required**: Unlike SQ, RQ can be enabled immediately without a training phase or switchover point where the index becomes unresponsive
+- **High recall**: Achieves 98-99% recall on most benchmark datasets (compared to 95-97% for SQ)
+- **Fast compression**: SIMD-optimized distance computations are typically 2-3x faster than uncompressed vectors
+- **Moderate compression**: Provides 4x compression ratio
+- **No configuration needed**: Works out of the box without special tuning
+
+### When to use RQ vs SQ
+
+**Use RQ when:**
+
+- You need immediate compression without a training phase
+- You require the highest possible recall (98-99%)
+- Working with standard vector embeddings (e.g., from OpenAI) with dimensionality ≥ 128
+- You want a simple, no-configuration solution
+
+**Consider SQ when:**
+
+- Working with low-dimensional data (< 64 or 128 dimensions) - RQ rounds up dimensions to multiples of 64
+- Your vectors have special structure suitable for direct quantization (e.g., already uniformly distributed 8-bit integers)
+- You can tolerate a training phase and slightly lower recall
+
+## Algorithm details
+
+RQ consists of two steps:
+
+1. **Fast pseudorandom rotation**: A rotation based on the Fast Walsh Hadamard Transform is applied to the input vector. The output dimension is rounded up to the nearest multiple of 64. This rotation takes ~7-10 microseconds for a 1536-dimensional vector.
+2. **Scalar quantization**: Each entry of the rotated vector is quantized to an 8-bit integer using the min and max values of each individual rotated vector to define the quantization interval.
+
+The random rotation provides two key benefits:
+
+- Smoothens the vector, reducing quantization error by narrowing the quantization interval
+- Spreads distance information evenly across dimensions, improving distance estimates
+
+### Technical implementation
+
+- **Storage format**: Quantized vectors are stored in byte arrays of length `16 + d` where `d` is the output dimension after rotation
+- **Metadata**: The first 16 bytes store four float32 values containing quantization interval and norm information
+- **Distance computation**: Uses the same SIMD-optimized `dotByteImpl()` function as scalar quantization
+- **No centering**: Unlike some other quantization methods, RQ does not center or normalize vectors
+
+### Differences from RaBitQ
+
+While inspired by extended RaBitQ, this implementation differs significantly for performance reasons:
+
+- Uses fast pseudorandom rotations (O(d) complexity) instead of truly random rotations (O(d²) complexity)
+- Employs scalar quantization instead of RaBitQ's encoding algorithm, which becomes prohibitively slow with more bits per entry
+- Achieves almost the same precision as extended RaBitQ while being much faster
+
+## Performance considerations
+
+### Encoding and query performance
+
+- **Encoding speed**: RQ is slightly slower than SQ when encoding vectors due to the rotation step, but this is a one-time cost
+- **Query performance**: Distance computations with RQ are as fast or faster than SQ, providing 2-3x speedup compared to uncompressed vectors
+- **Memory usage**: Roughly equivalent to SQ with 8-bit quantization
+
+### Rescoring
+
+RQ achieves 98-99% recall in isolation (recall100@100). When combined with HNSW indexing, there may be additional recall loss depending on the EF value configuration.
+
+:::tip
+For maximum query performance with minimal recall impact, consider setting `rescoreLimit` to 0. This disables rescoring and can significantly boost QPS while only causing a very minor drop in recall.
+:::
+
+### Dimensionality considerations
+
+RQ rounds up vector dimensions to the nearest multiple of 64 for the rotation operation. This means:
+
+- A 96-dimensional vector will use 128 dimensions worth of storage
+- This can result in less than 4x compression for certain dimensionalities
+- For vectors with dimensions that are already multiples of 64, compression is exactly 4x
+
+## Multiple vector embeddings (named vectors)
+
+import NamedVectorCompress from '/\_includes/named-vector-compress.mdx';
+
+<NamedVectorCompress />
+
+## Multi-vector embeddings (ColBERT, ColPali, etc.)
+
+import MultiVectorCompress from '/\_includes/multi-vector-compress.mdx';
+
+<MultiVectorCompress />
+
+:::note Multi-vector performance
+RQ supports multi-vector embeddings. Each token vector is rounded up to a multiple of 64 dimensions, which may result in less than 4x compression for very short vectors. This is a technical limitation that may be addressed in future versions.
+:::
+
+## Related pages
+
+- [Configuration: Vector index](/developers/weaviate/config-refs/schema/vector-index.md)
+- [Concepts: Vector index](/developers/weaviate/concepts/vector-index.md)
+- [Concepts: Vector quantization](/developers/weaviate/concepts/vector-quantization.md)
+- [Tutorial: Schema](/developers/weaviate/starter-guides/managing-collections)
+- [Configuration: Scalar Quantization](/developers/weaviate/configuration/compression/sq-compression.md)
+- [GitHub PR: RQ Implementation](https://github.com/weaviate/weaviate/pull/8260#issue-3087297283)
+
+## Questions and feedback
+
+import DocsFeedback from '/\_includes/docs-feedback.mdx';
+
+<DocsFeedback/>

--- a/developers/weaviate/configuration/compression/sq-compression.md
+++ b/developers/weaviate/configuration/compression/sq-compression.md
@@ -1,6 +1,6 @@
 ---
 title: Scalar Quantization (SQ)
-sidebar_position: 25
+sidebar_position: 27
 image: og/docs/configuration.jpg
 # tags: ['configuration', 'compression', 'sq']
 ---

--- a/developers/weaviate/starter-guides/managing-resources/compression.mdx
+++ b/developers/weaviate/starter-guides/managing-resources/compression.mdx
@@ -41,9 +41,14 @@ This table shows the compression algorithms that are available for each index ty
 | :- | :- | :- | :- |
 | PQ | Yes | No | Yes |
 | SQ | Yes | No | Yes |
+| RQ | Yes | No | No |
 | BQ | Yes | Yes | Yes |
 
 The [dynamic index](/developers/weaviate/config-refs/schema/vector-index#dynamic-indexes) is new in v1.25. This type of index is a [flat index](/developers/weaviate/config-refs/schema/vector-index#flat-indexes) until a collection reaches a threshold size. When the collection grows larger than the threshold size, the default is 10,000 objects, the collection is automatically reindexed and converted to an HNSW index.
+
+:::note
+RQ is currently only supported with HNSW indexes and is not available for dynamic indexes.
+:::
 
 ### Cost, recall and speed
 
@@ -59,6 +64,7 @@ The cost savings are most visible with in-memory indexes such as HNSW. More RAM 
 
 - PQ compressed vectors typically use 85% less memory than uncompressed vectors.
 - SQ compressed vectors use 75% less memory than uncompressed vectors.
+- RQ compressed vectors use 75% less memory than uncompressed vectors.
 - BQ compressed vectors use 97% less memory than uncompressed vectors.
 
 An HNSW index comprises a connection graph as well as the vectors. Quantization methods reduce the size of the vectors, but does not affect the size of the graph. As a result the overall reduction in memory usage is less than the reduction in vector size, but still significant.
@@ -68,6 +74,12 @@ An HNSW index comprises a connection graph as well as the vectors. Quantization 
 Recall measures how well an algorithm finds true positive matches in a data set.
 
 A compressed vector has less information than the corresponding uncompressed vector. An uncompressed vector that would normally match a search query might be missed if the target information is missing in the compressed vector. That missed match lowers recall.
+
+Typical recall rates:
+- PQ: Varies based on configuration
+- SQ: 95-97% recall
+- RQ: 98-99% recall (highest among compression methods)
+- BQ: Varies significantly based on data characteristics
 
 To improve recall with compressed vectors, Weaviate over-fetches a list of candidate vectors during a search. For each item on the candidate list, Weaviate fetches the corresponding uncompressed vector. To determine the final ranking, Weaviate calculates the distances from the uncompressed vectors to the query vector.
 
@@ -89,7 +101,9 @@ Each compression algorithm has its own characteristics with regard to speed.
 
 - SQ significantly improves search speeds. SQ is new in v1.26. It is faster than PQ, perhaps 3 to 4 times as fast as searching uncompressed vectors. SQ has a higher dimensional resolution than BQ that helps recall. Look for an upcoming blog post that discusses the tradeoffs with SQ compression.
 
-SQ and BQ both have optional vector caches. Use these configurable caches to load frequently used, uncompressed vectors into memory to improve overall search times.
+- RQ provides the fastest query performance among 8-bit quantization methods. RQ uses SIMD-optimized distance computations that are typically 2-3x faster than uncompressed vectors. RQ is as fast or faster than SQ while providing better recall. For maximum performance, RQ can run without rescoring with minimal impact on recall.
+
+SQ, RQ, and BQ all have optional vector caches. Use these configurable caches to load frequently used, uncompressed vectors into memory to improve overall search times.
 
 #### Import speed
 
@@ -99,13 +113,15 @@ Starting in v1.22, Weaviate has an optional, [asynchronous indexing](/developers
 
 ### Activate compression
 
-- BQ and SQ have to be enabled when you create the collection.
+- BQ, SQ, and RQ have to be enabled when you create the collection.
 
 - PQ and SQ both require training data before they begin to compress data.
 
   - PQ's training step defines centroids for each segment.
   - SQ's training step determines the minimum and maximum values for bucket boundaries.
   - PQ and SQ both begin to compress data after you have imported a large enough training set and the training step is complete.
+
+- RQ requires no training and begins compressing data immediately upon collection creation. This makes RQ ideal for applications that need immediate compression without waiting for a training phase.
 
 - If you have async indexing and [AutoPQ enabled](/developers/weaviate/configuration/compression/pq-compression#configure-autopq), PQ compression can be enabled anytime. If AutoPQ is not enabled, you should only enable PQ after you have imported enough objects to [train the algorithm](/developers/weaviate/configuration/compression/pq-compression#manually-configure-pq).
 
@@ -116,8 +132,12 @@ Starting in v1.22, Weaviate has an optional, [asynchronous indexing](/developers
 Most applications benefit from compression. The cost savings are significant. In [Weaviate Cloud](https://weaviate.io/pricing), for example, compressed collections can be more than 80% cheaper than uncompressed collections.
 
 - If you have a small collection that uses a flat index, consider a BQ index. The BQ index is 32 times smaller and much faster than the uncompressed equivalent.
-- Most users with medium to large data sets should consider SQ compression. SQ compressed vectors are one quarter the size of uncompressed vectors. Searches with SQ are faster than searches with uncompressed vectors. Recall is similar to uncompressed vectors.
-- If you have a very large data set or specialized search needs, consider PQ compression. PQ compression is very configurable, but it requires more expertise to tune well than SQ or BQ.
+
+- For most users with HNSW indexes who want the best combination of simplicity, performance, and recall, consider RQ compression. RQ provides 4x compression with 98-99% recall and requires no configuration or training. It's ideal for standard use cases with embeddings from providers like OpenAI.
+
+- Most users with medium to large data sets should consider SQ compression if they can tolerate a training phase. SQ compressed vectors are one quarter the size of uncompressed vectors. Searches with SQ are faster than searches with uncompressed vectors. Recall is similar to uncompressed vectors (95-97%).
+
+- If you have a very large data set or specialized search needs, consider PQ compression. PQ compression is very configurable, but it requires more expertise to tune well than SQ, RQ, or BQ.
 
 For collections that are small, but that are expected to grow, consider a dynamic index. In addition to setting the dynamic index type, configure the collection to use BQ compression while the index is flat and SQ compression when the collection grows large enough to move from a flat index to an HNSW index.
 
@@ -131,6 +151,7 @@ To enable compression, follow the steps on these pages:
 
 - [Product quantization (PQ)](../../configuration/compression/pq-compression.md)
 - [Scalar quantization (SQ)](../../configuration/compression/sq-compression.md)
+- [Rotational quantization (RQ)](../../configuration/compression/rq-compression.md)
 - [Binary quantization (BQ)](../../configuration/compression/bq-compression.md)
 
 For more documentation details, see:

--- a/developers/weaviate/starter-guides/managing-resources/index.md
+++ b/developers/weaviate/starter-guides/managing-resources/index.md
@@ -144,6 +144,7 @@ Weaviate supports the following vector compression methods:
 | Product Quantization (PQ) | HNSW       | Yes               | Each vector becomes an array of integer-based centroids ([read more](../../concepts/vector-quantization.md#product-quantization)) |
 | Binary Quantization (BQ)  | HNSW, Flat | No                | Each vector dimension becomes a bit ([read more](../../concepts/vector-quantization.md#binary-quantization)) |
 | Scalar Quantization (SQ)  | HNSW       | Yes               | Each vector dimension becomes an integer ([read more](../../concepts/vector-quantization.md#scalar-quantization)) |
+| Rotational Quantization (RQ) | HNSW    | No                | Each vector is rotated then quantized to 8-bit integers ([read more](../../concepts/vector-quantization.md#rotational-quantization)) |
 
 As a starting point, use the following guidelines for selecting a compression method:
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

Add documentation for Rotational Quantization (RQ), a new untrained compression method in v1.32 that provides 4x compression with 98-99% recall. Updates include a new RQ configuration page and additions to existing compression documentation pages.

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [ ] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
