### PR TITLE
fix typo in subprocessors page

### DIFF
--- a/src/pages/subprocessors.md
+++ b/src/pages/subprocessors.md
@@ -29,7 +29,7 @@ The following subprocessors are authorized by the Data Controller to process Per
 | Infrastructure | Grafana Cloud | Observability and system monitoring | https://grafana.com |
 | Infrastructure | Github | Code repository and CI/CD | https://github.com |
 | Infrastructure | MongoDB | Data storage for billing and provisioning | https://mongodb.com |
-| Infrastrucutre | Temporal Cloud | Workload orchestration | https://temporal.io | 
+| Infrastructure | Temporal Cloud | Workload orchestration | https://temporal.io | 
 | Communications | Google Workspace | Productivity and communications services | https://workspace.google.com |
 | Communications | Twilio | Email communications, alerts and marketing | https://www.twilio.com |
 | Communications | Hubspot | CRM for marketing | https://www.hubspot.com |


### PR DESCRIPTION
There was a typo - "infrastrutcure" instead of "infrastructure"