### PR TITLE
blog: 1.38 — free tier mention + WCD availability note

### DIFF
--- a/blog/2026-06-25-weaviate-1-38/_core-1-38-include.mdx
+++ b/blog/2026-06-25-weaviate-1-38/_core-1-38-include.mdx
@@ -227,7 +227,11 @@ Weaviate `v1.38` brings two capabilities to general availability — HFresh and 
 
 **Ready to get started?**
 
-The release is available open-source on [GitHub](https://github.com/weaviate/weaviate/releases/tag/v1.38.0) and is already available for new Sandboxes on [Weaviate Cloud](https://console.weaviate.cloud/).
+The release is available open-source on [GitHub](https://github.com/weaviate/weaviate/releases/tag/v1.38.0) and on [Weaviate Cloud](https://console.weaviate.cloud/), where you can spin up a cluster on the free tier.
+
+:::note
+Not all features may be available on Weaviate Cloud. Some capabilities — preview features in particular, and those that require specific environment configuration — may not be enabled on managed clusters, or may become available on a different schedule.
+:::
 
 For those upgrading a self-hosted version, please check the [migration guide](https://docs.weaviate.io/deploy/migration#general-upgrade-instructions) for version-specific notes.
 


### PR DESCRIPTION
Follow-up to #3636, which was squash-merged before this change landed.

Updates the 1.38 release post's "Ready to get started?" section:

- Replace the outdated "new Sandboxes" mention with the Weaviate Cloud **free tier**
- Add a note that not all features may be available on Weaviate Cloud — preview features and those that require specific environment configuration may not be enabled on managed clusters, or may roll out on a different schedule
