### PR TITLE
gtag fix

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -75,13 +75,7 @@ module.exports = async function createConfigAsync() {
       };
     },
   }),
-        [
-            '@docusaurus/plugin-google-gtag',
-            {
-                trackingID:  'None',
-                anonymizeIP: true,
-            },
-        ],
+      
 
         [
             '@docusaurus/plugin-google-tag-manager',


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Fix Google Analytics tag configuration

- Removed unused Docusaurus Google gtag plugin that was outputting `gtag/js?id=None`
- Kept Google Tag Manager as the single source for GA4 tracking
- Prevents invalid Google tag detection in Tag Assistant / GA diagnostics

### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [x] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
