### PR TITLE
chore(llms.txt): refresh recommended versions

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -13,7 +13,7 @@ If you run Weaviate yourself (Docker / Kubernetes / on-prem), **use at least the
 - **Weaviate Server (OSS)**: v1.38.2+
 - **Python client (weaviate-client)**: v4.22.0+
 - **TypeScript client (weaviate-client)**: v3.13.1+
-- **Java client (client6)**: v6.2.1+
+- **Java client (client6)**: v6.3.0+
 - **C# client (Weaviate.Client)**: v1.1.1+
 - **Agents SDK (weaviate-agents, if using Query Agent / agents features)**: v1.6.0+
 
@@ -604,7 +604,7 @@ response = qa.ask("Recommend sci-fi movies with good reviews under $15")
 print(response.final_answer)
 
 # Retrieval only (no generation)
-search_response = qa.search("sci-fi movies", filtering="recall", limit=5)
+search_response = qa.search("sci-fi movies", limit=5)
 ```
 
 ```typescript

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -10,12 +10,12 @@ Weaviate is an open-source vector database (Go) that stores objects, vectors, an
 
 If you run Weaviate yourself (Docker / Kubernetes / on-prem), **use at least these versions** to avoid outdated examples:
 
-- **Weaviate Server (OSS)**: v1.37.4+
-- **Python client (weaviate-client)**: v4.21.0+
-- **TypeScript client (weaviate-client)**: v3.13.0+
-- **Java client (client6)**: v6.2.0+
-- **C# client (Weaviate.Client)**: v1.1.0+
-- **Agents SDK (weaviate-agents, if using Query Agent / agents features)**: v1.5.0+
+- **Weaviate Server (OSS)**: v1.38.2+
+- **Python client (weaviate-client)**: v4.22.0+
+- **TypeScript client (weaviate-client)**: v3.13.1+
+- **Java client (client6)**: v6.2.1+
+- **C# client (Weaviate.Client)**: v1.1.1+
+- **Agents SDK (weaviate-agents, if using Query Agent / agents features)**: v1.6.0+
 
 **Quick checks**
 - Server: check your Docker tag / Helm chart version (e.g. `weaviate:<tag>`)
@@ -604,7 +604,7 @@ response = qa.ask("Recommend sci-fi movies with good reviews under $15")
 print(response.final_answer)
 
 # Retrieval only (no generation)
-search_response = qa.search("sci-fi movies", limit=5)
+search_response = qa.search("sci-fi movies", filtering="recall", limit=5)
 ```
 
 ```typescript


### PR DESCRIPTION
Updates `static/llms.txt` so the weaviate/docs CI llms.txt freshness check passes.

## Changes
Bump the "Latest versions" block to the current GitHub releases:
- Weaviate Server `v1.37.4` → `v1.38.2`
- Python client `v4.21.0` → `v4.22.0`
- TypeScript client `v3.13.0` → `v3.13.1`
- Java client `v6.2.0` → `v6.3.0`
- C# client `v1.1.0` → `v1.1.1`
- Agents SDK `v1.5.0` → `v1.6.0`

(The Query Agent `filtering` argument is no longer required, so an earlier commit that added `filtering="recall"` to the search example was reverted — the net change here is versions only.)

## Verification
`test_llms_txt_recommended_versions_are_current` and `test_llms_txt_snippets_are_covered` both pass locally against this file (via `LLMS_TXT_PATH`).