### PR TITLE
Enable email support for free plan in pricing page

### DIFF
--- a/src/components/Pricing/V2/data/databaseCompare.js
+++ b/src/components/Pricing/V2/data/databaseCompare.js
@@ -250,7 +250,7 @@ const databaseCompare = {
         {
           label: 'Email support',
           values: {
-            free: false,
+            free: true,
             flex: true,
             plus: true,
             premiumShared: true,


### PR DESCRIPTION
Adds email support to the free plan in the pricing comparison table. Free plan now includes basic email support alongside other tiers.

-
### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`