### PR TITLE
Component Blog Pass

### DIFF
--- a/_includes/what-next.mdx
+++ b/_includes/what-next.mdx
@@ -1,11 +1,13 @@
+import BlogSignupLink from "/src/components/BlogSignup";
+
 ## Ready to start building?
 
-Check out the [Quickstart tutorial](https://docs.weaviate.io/weaviate/quickstart), or build amazing apps with a free trial of [Weaviate Cloud (WCD)](https://console.weaviate.cloud/).
+Check out the [Quickstart tutorial](https://docs.weaviate.io/weaviate/quickstart), or <BlogSignupLink term="ready-to-start-building">sign up for a free Weaviate Cloud account</BlogSignupLink>.
 
-import CommunityPanel from '/src/components/CommunityPanel';
+import CommunityPanel from "/src/components/CommunityPanel";
 
 <CommunityPanel />
 
-import { GiscusBlogPostComment } from '/src/components/GiscusComment';
+import { GiscusBlogPostComment } from "/src/components/GiscusComment";
 
 <GiscusBlogPostComment />

--- a/src/components/BlogSignup/index.jsx
+++ b/src/components/BlogSignup/index.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import Link from "@docusaurus/Link";
+import { useLocation } from "@docusaurus/router";
+
+export default function BlogSignupLink({ children, className }) {
+  const location = useLocation();
+
+  const blogSlug =
+    location.pathname.replace(/^\/blog\//, "").replace(/\/$/, "") ||
+    "unknown-blog-post";
+
+  const signupUrl = new URL("https://console.weaviate.cloud/");
+
+  signupUrl.searchParams.set("utm_source", "blog");
+  signupUrl.searchParams.set("utm_medium", "website");
+  signupUrl.searchParams.set("utm_campaign", "blog_signup");
+  signupUrl.searchParams.set("utm_content", blogSlug);
+  signupUrl.searchParams.set("utm_term", "ready-to-start-building");
+
+  return (
+    <Link to={signupUrl.toString()} className={className}>
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

feat(blog): track blog-to-cloud signups with dynamic UTM parameters

- Add reusable BlogSignupLink component
- Automatically include blog slug as utm_content
- Update shared blog CTA to use tracked signup link
- Improve signup CTA copy

### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [x] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
