### PR TITLE
chore(llms.txt): bump recommended Weaviate Server version to v1.38.3

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -10,7 +10,7 @@ Weaviate is an open-source vector database (Go) that stores objects, vectors, an
 
 If you run Weaviate yourself (Docker / Kubernetes / on-prem), **use at least these versions** to avoid outdated examples:
 
-- **Weaviate Server (OSS)**: v1.38.2+
+- **Weaviate Server (OSS)**: v1.38.3+
 - **Python client (weaviate-client)**: v4.22.0+
 - **TypeScript client (weaviate-client)**: v3.13.1+
 - **Java client (client6)**: v6.3.0+


### PR DESCRIPTION
The nightly `llms.txt Tests` suite (`test_llms_txt_recommended_versions_are_current`) is failing because `static/llms.txt` recommends an out-of-date Weaviate Server version.

- `Weaviate Server (OSS): v1.38.2+` → `v1.38.3+` (latest `weaviate/weaviate` GitHub release).

All client versions (Python 4.22.0, TypeScript 3.13.1, Java 6.3.0, C# 1.1.1, Agents 1.6.0) are current and unchanged. The test reads the live `weaviate.io/llms.txt`, so it clears once this merges and weaviate-io redeploys.
