### PR TITLE
Improve LLM request tracking and crawler attribution

### DIFF
--- a/.netlify/edge-functions/track-llm-pages.js
+++ b/.netlify/edge-functions/track-llm-pages.js
@@ -1,47 +1,211 @@
-const AI_CRAWLERS = [
-  { pattern: "GPTBot",        source: "ChatGPT" },
-  { pattern: "ChatGPT-User",  source: "ChatGPT" },
-  { pattern: "ClaudeBot",     source: "Claude" },
-  { pattern: "anthropic-ai",  source: "Claude" },
-  { pattern: "PerplexityBot", source: "Perplexity" },
-  { pattern: "Google-Extended", source: "Gemini" },
-  { pattern: "Googlebot",     source: "Google" },
-  { pattern: "bingbot",       source: "Bing/Copilot" },
+const TRACKED_PATHS = [
+  "/llms.txt",
+  "/product.md",
+  "/pricing.md",
+  "/rag.md",
+  "/hybrid-search.md",
+  "/agentic-ai.md",
+  "/cost-performance-optimization.md",
+  "/learn/what-is-an-ai-database.md",
+  "/quickstart.md",
+  "/python.md",
+  "/javascript.md",
+  "/deployment.md",
+  "/deployment/shared.md",
+  "/deployment/dedicated.md",
+  "/security.md",
+  "/product/query.md",
+  "/product/query-agent.md",
+  "/product/embeddings.md",
+  "/product/transformation-agent.md",
+  "/product/personalization-agent.md",
+  "/product/engram.md",
+  "/product/explorer.md",
+  "/product-previews.md",
 ];
 
-function detectAISource(ua) {
-  for (const { pattern, source } of AI_CRAWLERS) {
-    if (ua.includes(pattern)) return source;
+const TRACKED_PATH_SET = new Set(TRACKED_PATHS);
+
+const REQUEST_AGENTS = [
+
+  {
+    pattern: "OAI-SearchBot",
+    source: "ChatGPT",
+    family: "OAI-SearchBot",
+    trafficType: "ai_search_crawler",
+  },
+  {
+    pattern: "GPTBot",
+    source: "ChatGPT",
+    family: "GPTBot",
+    trafficType: "ai_crawler",
+  },
+  {
+    pattern: "ChatGPT-User",
+    source: "ChatGPT",
+    family: "ChatGPT-User",
+    trafficType: "ai_user_fetcher",
+  },
+
+  // Anthropic
+  {
+    pattern: "Claude-SearchBot",
+    source: "Claude",
+    family: "Claude-SearchBot",
+    trafficType: "ai_search_crawler",
+  },
+  {
+    pattern: "Claude-User",
+    source: "Claude",
+    family: "Claude-User",
+    trafficType: "ai_user_fetcher",
+  },
+  {
+    pattern: "ClaudeBot",
+    source: "Claude",
+    family: "ClaudeBot",
+    trafficType: "ai_crawler",
+  },
+  {
+    pattern: "anthropic-ai",
+    source: "Claude",
+    family: "anthropic-ai",
+    trafficType: "ai_crawler",
+  },
+  {
+    pattern: "Perplexity-User",
+    source: "Perplexity",
+    family: "Perplexity-User",
+    trafficType: "ai_user_fetcher",
+  },
+  {
+    pattern: "PerplexityBot",
+    source: "Perplexity",
+    family: "PerplexityBot",
+    trafficType: "ai_search_crawler",
+  },
+  {
+    pattern: "Google-GeminiNotebook",
+    source: "Gemini Notebook",
+    family: "Google-GeminiNotebook",
+    trafficType: "ai_user_fetcher",
+  },
+  {
+    pattern: "Google-NotebookLM",
+    source: "Gemini Notebook",
+    family: "Google-NotebookLM",
+    trafficType: "ai_user_fetcher",
+  },
+  {
+    pattern: "Google-Agent",
+    source: "Google Agent",
+    family: "Google-Agent",
+    trafficType: "ai_user_agent",
+  },
+  {
+    pattern: "Googlebot",
+    source: "Google",
+    family: "Googlebot",
+    trafficType: "search_crawler",
+  },
+  {
+    pattern: "bingbot",
+    source: "Bing",
+    family: "bingbot",
+    trafficType: "search_crawler",
+  },
+  {
+    pattern: "CCBot",
+    source: "Common Crawl",
+    family: "CCBot",
+    trafficType: "generic_crawler",
+  },
+];
+
+function detectRequestAgent(ua) {
+  if (!ua) {
+    return {
+      source: "unknown",
+      family: "no_user_agent",
+      trafficType: "unknown",
+      recognised: false,
+    };
   }
-  return "unknown";
+
+  const lowerUA = ua.toLowerCase();
+
+  for (const agent of REQUEST_AGENTS) {
+    if (lowerUA.includes(agent.pattern.toLowerCase())) {
+      return {
+        ...agent,
+        recognised: true,
+      };
+    }
+  }
+
+  
+  if (/(bot|crawler|spider|slurp|fetcher|scanner|preview)/i.test(ua)) {
+    return {
+      source: "unknown",
+      family: "other_automated",
+      trafficType: "other_automated",
+      recognised: false,
+    };
+  }
+
+  if (/(curl|wget|python-requests|go-http-client|okhttp|node-fetch)/i.test(ua)) {
+    return {
+      source: "unknown",
+      family: "script_client",
+      trafficType: "script_client",
+      recognised: false,
+    };
+  }
+
+  if (/(mozilla\/5\.0|chrome\/|safari\/|firefox\/|edg\/)/i.test(ua)) {
+    return {
+      source: "unknown",
+      family: "browser_like",
+      trafficType: "browser_like",
+      recognised: false,
+    };
+  }
+
+  return {
+    source: "unknown",
+    family: "unknown_client",
+    trafficType: "unknown",
+    recognised: false,
+  };
 }
 
 export default async (request, context) => {
-  const path = new URL(request.url).pathname;
+  const url = new URL(request.url);
+  const path = url.pathname;
 
-  // Only act on our LLM-optimised pages
-  const isTracked =
-    path === "/llms.txt" ||
-    path.endsWith(".md");
-
-  if (!isTracked) return context.next();
+  // Defence in depth: only our curated LLM endpoints.
+  if (request.method !== "GET" || !TRACKED_PATH_SET.has(path)) {
+    return context.next();
+  }
 
   const measurementId =
     Netlify.env.get("GA4_MEASUREMENT_ID") ||
     Netlify.env.get("GOOGLE_TRACKING_ID");
+
   const apiSecret = Netlify.env.get("GA4_API_SECRET");
 
   if (measurementId && apiSecret) {
     const ua = request.headers.get("user-agent") || "";
-    const aiSource = detectAISource(ua);
+    const agent = detectRequestAgent(ua);
 
-    // Fire-and-forget — never delays serving the file
     context.waitUntil(
       fetch(
         `https://www.google-analytics.com/mp/collect?measurement_id=${measurementId}&api_secret=${apiSecret}`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+          },
           body: JSON.stringify({
             client_id: context.ip || "edge-server",
             events: [
@@ -49,17 +213,32 @@ export default async (request, context) => {
                 name: "llm_page_view",
                 params: {
                   page_path: path,
-                  page_location: request.url,
-                  ai_source: aiSource,
-                  is_ai_crawler: aiSource !== "unknown" ? "true" : "false",
+
+                  // Strip query strings to avoid unnecessary GA cardinality.
+                  page_location: `${url.origin}${path}`,
+
+                  // Existing dimensions — keep for backwards compatibility.
+                  ai_source: agent.source,
+                  is_ai_crawler: agent.recognised ? "true" : "false",
+
+                  // New diagnostic dimensions.
+                  agent_family: agent.family,
+                  traffic_type: agent.trafficType,
+                  tracking_version: "v2",
                 },
               },
             ],
           }),
         }
-      ).catch(() => {}) // silently fail — never block the file being served
+      ).catch(() => {})
     );
   }
 
   return context.next();
+};
+
+
+export const config = {
+  path: TRACKED_PATHS,
+  method: "GET",
 };

--- a/.netlify/edge-functions/track-llm-pages.js
+++ b/.netlify/edge-functions/track-llm-pages.js
@@ -27,218 +27,151 @@ const TRACKED_PATHS = [
 const TRACKED_PATH_SET = new Set(TRACKED_PATHS);
 
 const REQUEST_AGENTS = [
-
-  {
-    pattern: "OAI-SearchBot",
-    source: "ChatGPT",
-    family: "OAI-SearchBot",
-    trafficType: "ai_search_crawler",
-  },
-  {
-    pattern: "GPTBot",
-    source: "ChatGPT",
-    family: "GPTBot",
-    trafficType: "ai_crawler",
-  },
-  {
-    pattern: "ChatGPT-User",
-    source: "ChatGPT",
-    family: "ChatGPT-User",
-    trafficType: "ai_user_fetcher",
-  },
+  // OpenAI
+  { pattern: "OAI-SearchBot", source: "ChatGPT", family: "OAI-SearchBot", trafficType: "ai_search_crawler" },
+  { pattern: "GPTBot", source: "ChatGPT", family: "GPTBot", trafficType: "ai_crawler" },
+  { pattern: "ChatGPT-User", source: "ChatGPT", family: "ChatGPT-User", trafficType: "ai_user_fetcher" },
 
   // Anthropic
-  {
-    pattern: "Claude-SearchBot",
-    source: "Claude",
-    family: "Claude-SearchBot",
-    trafficType: "ai_search_crawler",
-  },
-  {
-    pattern: "Claude-User",
-    source: "Claude",
-    family: "Claude-User",
-    trafficType: "ai_user_fetcher",
-  },
-  {
-    pattern: "ClaudeBot",
-    source: "Claude",
-    family: "ClaudeBot",
-    trafficType: "ai_crawler",
-  },
-  {
-    pattern: "anthropic-ai",
-    source: "Claude",
-    family: "anthropic-ai",
-    trafficType: "ai_crawler",
-  },
-  {
-    pattern: "Perplexity-User",
-    source: "Perplexity",
-    family: "Perplexity-User",
-    trafficType: "ai_user_fetcher",
-  },
-  {
-    pattern: "PerplexityBot",
-    source: "Perplexity",
-    family: "PerplexityBot",
-    trafficType: "ai_search_crawler",
-  },
-  {
-    pattern: "Google-GeminiNotebook",
-    source: "Gemini Notebook",
-    family: "Google-GeminiNotebook",
-    trafficType: "ai_user_fetcher",
-  },
-  {
-    pattern: "Google-NotebookLM",
-    source: "Gemini Notebook",
-    family: "Google-NotebookLM",
-    trafficType: "ai_user_fetcher",
-  },
-  {
-    pattern: "Google-Agent",
-    source: "Google Agent",
-    family: "Google-Agent",
-    trafficType: "ai_user_agent",
-  },
-  {
-    pattern: "Googlebot",
-    source: "Google",
-    family: "Googlebot",
-    trafficType: "search_crawler",
-  },
-  {
-    pattern: "bingbot",
-    source: "Bing",
-    family: "bingbot",
-    trafficType: "search_crawler",
-  },
-  {
-    pattern: "CCBot",
-    source: "Common Crawl",
-    family: "CCBot",
-    trafficType: "generic_crawler",
-  },
+  { pattern: "Claude-SearchBot", source: "Claude", family: "Claude-SearchBot", trafficType: "ai_search_crawler" },
+  { pattern: "Claude-User", source: "Claude", family: "Claude-User", trafficType: "ai_user_fetcher" },
+  { pattern: "ClaudeBot", source: "Claude", family: "ClaudeBot", trafficType: "ai_crawler" },
+  { pattern: "anthropic-ai", source: "Claude", family: "anthropic-ai", trafficType: "ai_crawler" },
+
+  // Perplexity
+  { pattern: "Perplexity-User", source: "Perplexity", family: "Perplexity-User", trafficType: "ai_user_fetcher" },
+  { pattern: "PerplexityBot", source: "Perplexity", family: "PerplexityBot", trafficType: "ai_search_crawler" },
+
+  // Google
+  { pattern: "Google-GeminiNotebook", source: "Gemini Notebook", family: "Google-GeminiNotebook", trafficType: "ai_user_fetcher" },
+  { pattern: "Google-NotebookLM", source: "Gemini Notebook", family: "Google-NotebookLM", trafficType: "ai_user_fetcher" },
+  { pattern: "Google-Agent", source: "Google Agent", family: "Google-Agent", trafficType: "ai_user_agent" },
+  { pattern: "Googlebot", source: "Google", family: "Googlebot", trafficType: "search_crawler" },
+
+  // Apple — more specific pattern MUST precede the shorter one it contains
+  { pattern: "Applebot-Extended", source: "Apple", family: "Applebot-Extended", trafficType: "ai_crawler" },
+  { pattern: "Applebot", source: "Apple", family: "Applebot", trafficType: "search_crawler" },
+
+  // Other search / generic crawlers
+  { pattern: "bingbot", source: "Bing", family: "bingbot", trafficType: "search_crawler" },
+  { pattern: "DuckDuckBot", source: "DuckDuckGo", family: "DuckDuckBot", trafficType: "search_crawler" },
+  { pattern: "YandexBot", source: "Yandex", family: "YandexBot", trafficType: "search_crawler" },
+  { pattern: "CCBot", source: "Common Crawl", family: "CCBot", trafficType: "generic_crawler" },
+
+  // Other AI-training crawlers
+  { pattern: "Bytespider", source: "ByteDance", family: "Bytespider", trafficType: "ai_crawler" },
+  { pattern: "Amazonbot", source: "Amazon", family: "Amazonbot", trafficType: "ai_crawler" },
 ];
 
 function detectRequestAgent(ua) {
   if (!ua) {
-    return {
-      source: "unknown",
-      family: "no_user_agent",
-      trafficType: "unknown",
-      recognised: false,
-    };
+    return { source: "unknown", family: "no_user_agent", trafficType: "unknown", recognised: false };
   }
 
   const lowerUA = ua.toLowerCase();
 
   for (const agent of REQUEST_AGENTS) {
     if (lowerUA.includes(agent.pattern.toLowerCase())) {
-      return {
-        ...agent,
-        recognised: true,
-      };
+      return { ...agent, recognised: true };
     }
   }
 
-  
   if (/(bot|crawler|spider|slurp|fetcher|scanner|preview)/i.test(ua)) {
-    return {
-      source: "unknown",
-      family: "other_automated",
-      trafficType: "other_automated",
-      recognised: false,
-    };
+    return { source: "unknown", family: "other_automated", trafficType: "other_automated", recognised: false };
   }
 
   if (/(curl|wget|python-requests|go-http-client|okhttp|node-fetch)/i.test(ua)) {
-    return {
-      source: "unknown",
-      family: "script_client",
-      trafficType: "script_client",
-      recognised: false,
-    };
+    return { source: "unknown", family: "script_client", trafficType: "script_client", recognised: false };
   }
 
   if (/(mozilla\/5\.0|chrome\/|safari\/|firefox\/|edg\/)/i.test(ua)) {
-    return {
-      source: "unknown",
-      family: "browser_like",
-      trafficType: "browser_like",
-      recognised: false,
-    };
+    return { source: "unknown", family: "browser_like", trafficType: "browser_like", recognised: false };
   }
 
-  return {
-    source: "unknown",
-    family: "unknown_client",
-    trafficType: "unknown",
-    recognised: false,
-  };
+  return { source: "unknown", family: "unknown_client", trafficType: "unknown", recognised: false };
+}
+
+async function hashClientId(ip) {
+  if (!ip) return "edge-server";
+  const data = new TextEncoder().encode(ip);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 32);
+}
+
+// Runs entirely inside context.waitUntil() — must never be awaited by the
+// main handler, and must never throw past its own boundary.
+async function sendLlmPageViewEvent({ measurementId, apiSecret, ip, path, origin, agent }) {
+  try {
+    const clientId = await hashClientId(ip);
+    await fetch(
+      `https://www.google-analytics.com/mp/collect?measurement_id=${measurementId}&api_secret=${apiSecret}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: clientId,
+          events: [
+            {
+              name: "llm_page_view",
+              params: {
+                page_path: path,
+                page_location: `${origin}${path}`,
+                ai_source: agent.source,
+                is_ai_crawler: agent.trafficType.startsWith("ai_") ? "true" : "false",
+                agent_family: agent.family,
+                traffic_type: agent.trafficType,
+                tracking_version: "v2",
+              },
+            },
+          ],
+        }),
+      }
+    );
+  } catch {
+    // Fire-and-forget: response has already been served, nothing to recover.
+  }
 }
 
 export default async (request, context) => {
   const url = new URL(request.url);
   const path = url.pathname;
 
-  // Defence in depth: only our curated LLM endpoints.
+  // Defence in depth: only our curated LLM endpoints, GET only.
   if (request.method !== "GET" || !TRACKED_PATH_SET.has(path)) {
     return context.next();
   }
 
-  const measurementId =
-    Netlify.env.get("GA4_MEASUREMENT_ID") ||
-    Netlify.env.get("GOOGLE_TRACKING_ID");
+  try {
+    const measurementId =
+      Netlify.env.get("GA4_MEASUREMENT_ID") || Netlify.env.get("GOOGLE_TRACKING_ID");
+    const apiSecret = Netlify.env.get("GA4_API_SECRET");
 
-  const apiSecret = Netlify.env.get("GA4_API_SECRET");
+    if (measurementId && apiSecret) {
+      const ua = request.headers.get("user-agent") || "";
+      const agent = detectRequestAgent(ua);
 
-  if (measurementId && apiSecret) {
-    const ua = request.headers.get("user-agent") || "";
-    const agent = detectRequestAgent(ua);
-
-    context.waitUntil(
-      fetch(
-        `https://www.google-analytics.com/mp/collect?measurement_id=${measurementId}&api_secret=${apiSecret}`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            client_id: context.ip || "edge-server",
-            events: [
-              {
-                name: "llm_page_view",
-                params: {
-                  page_path: path,
-
-                  // Strip query strings to avoid unnecessary GA cardinality.
-                  page_location: `${url.origin}${path}`,
-
-                  // Existing dimensions — keep for backwards compatibility.
-                  ai_source: agent.source,
-                  is_ai_crawler: agent.recognised ? "true" : "false",
-
-                  // New diagnostic dimensions.
-                  agent_family: agent.family,
-                  traffic_type: agent.trafficType,
-                  tracking_version: "v2",
-                },
-              },
-            ],
-          }),
-        }
-      ).catch(() => {})
-    );
+      context.waitUntil(
+        sendLlmPageViewEvent({
+          measurementId,
+          apiSecret,
+          ip: context.ip,
+          path,
+          origin: url.origin,
+          agent,
+        })
+      );
+    }
+  } catch {
+    // Analytics must never block or break the served file — swallow and continue.
   }
 
   return context.next();
 };
 
-
 export const config = {
   path: TRACKED_PATHS,
-  method: "GET",
+  onError: "bypass",
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -58,11 +58,6 @@ to = "/404"
 status = 404
 force = true
 
-  [[redirects]]
-  from = "/slack"
-  to = "https://forum.weaviate.io/t/saying-goodbye-to-our-public-slack/22266"
-  status = 301
-
 [[edge_functions]]
 function = "block-feed-bot"
 path = "/blog/rss.xml"
@@ -78,23 +73,3 @@ path = "/blog/feed"
 [[edge_functions]]
 function = "block-feed-bot"
 path = "/blog/feed.xml"
-
-[[edge_functions]]
-  path = "/llms.txt"
-  function = "track-llm-pages"
-
-[[edge_functions]]
-  path = "/*.md"
-  function = "track-llm-pages"
-
-[[edge_functions]]
-  path = "/product/*.md"
-  function = "track-llm-pages"
-
-[[edge_functions]]
-  path = "/deployment/*.md"
-  function = "track-llm-pages"
-
-[[edge_functions]]
-  path = "/learn/*.md"
-  function = "track-llm-pages"


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

- Restrict LLM tracking to an explicit allowlist of curated /llms.txt and .md endpoints.
- Remove broad wildcard tracking that was capturing unrelated markdown probes.
- Expand AI/search crawler detection for OpenAI, Anthropic, Perplexity, Google, Apple, Bing, Common Crawl and other known agents.


### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [x] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
