### PR TITLE
Add LLM pages for partnerships 

### DIFF
--- a/.netlify/edge-functions/track-llm-pages.js
+++ b/.netlify/edge-functions/track-llm-pages.js
@@ -22,6 +22,11 @@ const TRACKED_PATHS = [
   "/product/engram.md",
   "/product/explorer.md",
   "/product-previews.md",
+  "/partners.md",
+  "/partners/aws.md",
+  "/partners/gcp.md",
+  "/partners/databricks.md",
+  "/partners/snowflake.md",
 ];
 
 const TRACKED_PATH_SET = new Set(TRACKED_PATHS);

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -712,3 +712,8 @@ This repository now includes lightweight, machine-friendly LLM twin pages for se
 - https://weaviate.io/deployment/dedicated.md
 - https://weaviate.io/learn/what-is-an-ai-database.md
 - https://weaviate.io/cost-performance-optimization.md
+- https://weaviate.io/partners.md
+- https://weaviate.io/partners/aws.md
+- https://weaviate.io/partners/gcp.md
+- https://weaviate.io/partners/databricks.md
+- https://weaviate.io/partners/snowflake.md

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -705,6 +705,7 @@ This repository now includes lightweight, machine-friendly LLM twin pages for se
 - https://weaviate.io/product/embeddings.md
 - https://weaviate.io/product/transformation-agent.md
 - https://weaviate.io/product/personalization-agent.md
+- http://weaviate.io/product/explorer.md
 - https://weaviate.io/rag.md
 - https://weaviate.io/hybrid-search.md
 - https://weaviate.io/agentic-ai.md

--- a/static/partners.md
+++ b/static/partners.md
@@ -1,0 +1,53 @@
+# Weaviate Partners — LLM Guidance
+
+## TL;DR
+- The Weaviate partner ecosystem brings together cloud and data platforms, technology providers, and service partners for AI application delivery.
+- Platform partners provide infrastructure or data-platform integrations with Weaviate.
+- Technology partners extend AI application stacks with models, data tooling, observability, orchestration, and related capabilities.
+- System integrators and consultancies help customers design, build, manage, and scale applications using Weaviate.
+- Organisations can apply to become a partner or register a joint sales opportunity through the Weaviate partner page.
+
+## Partner categories
+
+### Platform partners
+Platform partners integrate their infrastructure or services with Weaviate. Dedicated Weaviate pages are available for:
+
+- [Amazon Web Services (AWS)](https://weaviate.io/partners/aws)
+- [Google Cloud](https://weaviate.io/partners/gcp)
+- [Databricks](https://weaviate.io/partners/databricks)
+- [Snowflake](https://weaviate.io/partners/snowflake)
+
+The partner directory also presents Microsoft Azure and Confluent as platform partners.
+
+### Technology partners
+Technology partners provide complementary components used in AI systems, such as model providers, data ingestion and processing tools, application frameworks, and evaluation or observability products. Availability and supported features vary by integration; use the relevant [Weaviate integrations documentation](https://docs.weaviate.io/integrations) to verify current technical support.
+
+### System integrators
+Managed service providers and consultancies use Weaviate to build, manage, and scale AI applications for customers. The right partner depends on geography, industry experience, delivery model, and the required Weaviate or cloud-platform expertise.
+
+## When to use a partner
+- You want to purchase or deploy Weaviate through an existing cloud marketplace relationship.
+- Your architecture depends on a particular cloud, data platform, model provider, or application framework.
+- You need implementation, migration, managed-service, or production-scaling support.
+- You are assembling an end-to-end search, RAG, or agentic application from multiple technologies.
+
+## How to evaluate a partner path
+1. Identify the required deployment location, data boundary, and procurement route.
+2. Confirm that the integration supports the exact Weaviate deployment and feature set you plan to use.
+3. Review the linked technical documentation and current version requirements.
+4. Validate networking, security, data movement, support ownership, and pricing with the relevant providers.
+5. Run a representative proof of concept before making production commitments.
+
+## Limitations and verification
+- A listing on the partner page does not mean every product combination or feature is supported.
+- Marketplace terms, regional availability, model availability, and pricing can change independently of Weaviate.
+- Empty or logo-only links on the visual partner directory may not provide implementation guidance; use first-party documentation or contact the partner team when a dedicated page is unavailable.
+- Confirm current technical compatibility in documentation before designing a production architecture.
+
+## Next steps
+- Explore the [Weaviate partner programme](https://weaviate.io/partners).
+- Review [Weaviate integrations documentation](https://docs.weaviate.io/integrations).
+- Use the partner-page form to become a partner or register a deal.
+
+## Canonical source
+[Weaviate Partners](https://weaviate.io/partners)

--- a/static/partners/aws.md
+++ b/static/partners/aws.md
@@ -1,0 +1,54 @@
+# Weaviate on AWS — LLM Guidance
+
+## TL;DR
+- Weaviate can be deployed on AWS and purchased through AWS Marketplace.
+- The integration path supports AI search and generative AI applications using Weaviate with AWS services such as Amazon Bedrock and Amazon SageMaker.
+- Use this path when AWS is your required cloud, procurement channel, or security boundary.
+- Validate the selected deployment model, region, networking, model access, capacity, and support terms before production use.
+
+## What the partnership provides
+Weaviate is an open-source AI database used for semantic search, hybrid search, vector retrieval, and retrieval-augmented generation (RAG). On AWS, teams can combine Weaviate retrieval with AWS infrastructure and AI services.
+
+The current Weaviate partner page highlights:
+
+- Integration with Amazon Bedrock and Amazon SageMaker.
+- Support for model-provider integrations and custom models.
+- An AWS Marketplace procurement and deployment route.
+- Architecture for semantic search and multi-tenant AI applications.
+
+## When to use
+- Your organisation standardises infrastructure, networking, governance, or procurement on AWS.
+- You want to use Amazon Bedrock models with data retrieved from Weaviate.
+- You want to use Amazon SageMaker or another supported model provider alongside Weaviate.
+- You need a marketplace route for commercial procurement.
+
+## Typical architecture
+1. Store source data in the AWS services appropriate to your application.
+2. Create embeddings using a supported AWS or third-party model integration.
+3. Store objects and vectors in Weaviate.
+4. Retrieve relevant objects with vector, keyword, or hybrid search.
+5. Pass retrieved context to a generative model, such as a model available through Amazon Bedrock.
+
+The exact data ingestion, networking, authentication, and model configuration depend on your deployment and should be confirmed in the current documentation.
+
+## Deployment and procurement considerations
+- Decide whether you need Weaviate Cloud, a marketplace deployment, or a self-managed architecture.
+- Confirm AWS region availability for Weaviate and every dependent model or service.
+- Review VPC design, private connectivity, encryption, IAM, backup, and recovery requirements.
+- Confirm who owns infrastructure operations and application support.
+- Review marketplace pricing and contract terms directly in AWS Marketplace.
+
+## Limitations and verification
+- AWS Marketplace availability does not guarantee that every Weaviate feature or AWS model is available in every region.
+- Performance depends on data shape, index configuration, workload, and allocated infrastructure; test with representative data.
+- The visual AWS partner page contains some legacy integration copy that is not used as technical guidance here. Use current documentation for implementation decisions.
+
+## Next steps and resources
+- [Weaviate on AWS](https://weaviate.io/partners/aws)
+- [Weaviate integration with Amazon Bedrock](https://docs.weaviate.io/weaviate/model-providers/aws)
+- [Weaviate deployment documentation](https://docs.weaviate.io/deploy)
+- [Weaviate pricing](https://weaviate.io/pricing)
+- [AWS Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-ng2dfhb4yjoic)
+
+## Canonical source
+[Weaviate on AWS](https://weaviate.io/partners/aws)

--- a/static/partners/databricks.md
+++ b/static/partners/databricks.md
@@ -1,0 +1,51 @@
+# Weaviate and Databricks — LLM Guidance
+
+## TL;DR
+- Weaviate integrates with Databricks for data pipelines and model-powered AI applications.
+- The Weaviate Spark connector can move data from Apache Spark and Databricks into Weaviate.
+- Weaviate can use supported Databricks model endpoints for embedding and generative workflows.
+- Use this combination when data engineering or model serving is centred on Databricks and the application needs semantic, hybrid, or RAG retrieval from Weaviate.
+
+## What the integration provides
+The integration connects two distinct roles:
+
+- **Databricks:** data preparation and processing with Spark, plus supported model-serving capabilities.
+- **Weaviate:** storage and retrieval of objects and vectors for semantic search, hybrid search, multimodal search, and RAG.
+
+This division lets teams prepare data in Databricks, ingest it into Weaviate, retrieve relevant context at application time, and use supported models to generate or enrich results.
+
+## Integration paths
+
+### Spark connector
+Use the Weaviate Spark connector when a Spark or Databricks pipeline needs to write processed records into Weaviate. Confirm the connector version, schema mapping, authentication, batching, and retry behaviour before running a production load.
+
+### Databricks model endpoints
+Weaviate supports Databricks as a model-provider integration for supported embedding and generative workflows. Configure the applicable endpoint and credentials, then select the corresponding Weaviate integration for the collection or query.
+
+## When to use
+- Your source data and transformation pipelines already run in Databricks.
+- You need to publish curated records from Spark into a retrieval database.
+- You want to use Databricks-hosted embedding or generative models with Weaviate.
+- Your application needs low-latency semantic or hybrid retrieval after batch or streaming preparation.
+
+## When to use another path
+- Use a simpler direct import when the data does not require Spark processing.
+- Use a different model-provider integration when the required model is not exposed through a supported Databricks endpoint.
+- Keep analytical processing in Databricks; Weaviate is the retrieval layer, not a replacement for warehouse or lakehouse analytics.
+
+## Production considerations
+- Define a stable record identifier so retries do not create unintended duplicates.
+- Map source columns to Weaviate properties and vectorisation rules explicitly.
+- Plan incremental updates, deletions, error handling, and backfills.
+- Verify endpoint authentication, network access, quotas, and regional availability.
+- Test retrieval quality and latency using representative application queries.
+
+## Next steps and resources
+- [Weaviate and Databricks](https://weaviate.io/partners/databricks)
+- [Databricks model-provider integration](https://docs.weaviate.io/weaviate/model-providers/databricks)
+- [Databricks data-platform integration](https://docs.weaviate.io/integrations/data-platforms/databricks)
+- [Databricks Spark connector recipe](https://github.com/weaviate/recipes/blob/main/integrations/data-platforms/databricks/databricks-spark-connector-demo.ipynb)
+- [Build scalable GenAI data pipelines with Weaviate and Databricks](https://weaviate.io/blog/genai-apps-with-weaviate-and-databricks)
+
+## Canonical source
+[Weaviate and Databricks](https://weaviate.io/partners/databricks)

--- a/static/partners/gcp.md
+++ b/static/partners/gcp.md
@@ -1,0 +1,52 @@
+# Weaviate on Google Cloud — LLM Guidance
+
+## TL;DR
+- Weaviate Cloud runs on Google Cloud infrastructure, and Weaviate is also available through Google Cloud Marketplace.
+- Weaviate integrates with Google Cloud AI services, including Vertex AI model integrations, for search and RAG applications.
+- Use this path when Google Cloud is your required infrastructure, data boundary, AI platform, or procurement channel.
+- Confirm current models, regions, networking, deployment options, and marketplace terms before production use.
+
+## What the partnership provides
+Weaviate is an open-source AI database used for semantic search, hybrid search, vector retrieval, and retrieval-augmented generation (RAG). The Google Cloud partnership supports architectures that combine Weaviate with Google Cloud infrastructure, managed data services, and generative AI models.
+
+The current Weaviate partner page highlights:
+
+- Weaviate Cloud infrastructure on Google Cloud and scaling with Google Kubernetes Engine.
+- Integration with Vertex AI for embedding and generative model workflows.
+- Deployment through Google Cloud Marketplace.
+- The option to keep application infrastructure and data services inside a Google Cloud VPC architecture.
+
+## When to use
+- Your organisation standardises infrastructure, networking, governance, or procurement on Google Cloud.
+- Your source data already resides in Google Cloud databases or object storage.
+- You want to combine Vertex AI models with Weaviate retrieval.
+- You need a marketplace route for commercial procurement.
+
+## Typical architecture
+1. Load or stream relevant source data from Google Cloud or another approved source.
+2. Generate embeddings with a supported Vertex AI or third-party model.
+3. Store objects and vectors in Weaviate.
+4. Retrieve context using vector, keyword, or hybrid search.
+5. Use retrieved context with a supported generative model to build a RAG or agentic application.
+
+## Deployment and procurement considerations
+- Choose between Weaviate Cloud, Google Cloud Marketplace, or another supported deployment model.
+- Confirm region compatibility across Weaviate, source data, and Vertex AI models.
+- Review VPC design, private connectivity, identity, encryption, backup, and recovery requirements.
+- Verify current model names and availability in Google Cloud documentation; older page copy may reference superseded model generations.
+- Review marketplace pricing and support terms directly with the providers.
+
+## Limitations and verification
+- Model availability and names change over time and vary by region.
+- Marketplace availability does not guarantee support for every product combination.
+- Performance and scale claims should be tested using representative data and workload patterns.
+
+## Next steps and resources
+- [Weaviate on Google Cloud](https://weaviate.io/partners/gcp)
+- [Weaviate Google model-provider integrations](https://docs.weaviate.io/weaviate/model-providers/google)
+- [Weaviate deployment documentation](https://docs.weaviate.io/deploy)
+- [Weaviate pricing](https://weaviate.io/pricing)
+- [Weaviate on Google Cloud Marketplace](https://console.cloud.google.com/marketplace/product/weaviate-gcp-mktplace/weaviate)
+
+## Canonical source
+[Weaviate on Google Cloud](https://weaviate.io/partners/gcp)

--- a/static/partners/snowflake.md
+++ b/static/partners/snowflake.md
@@ -1,0 +1,48 @@
+# Weaviate and Snowflake — LLM Guidance
+
+## TL;DR
+- Weaviate can run in Snowpark Container Services (SPCS) to support search and RAG applications close to data in Snowflake.
+- This architecture can keep Weaviate data operations, including embedding and vector-search workflows, within the customer-controlled Snowflake environment described by the integration.
+- Use this path when Snowflake is the primary data platform and minimising data movement is a core requirement.
+- The implementation is an architecture choice, not a universal default; validate SPCS availability, sizing, networking, persistence, and operations before production use.
+
+## What the integration provides
+Weaviate is an open-source AI database used for semantic search, hybrid search, vector retrieval, multimodal search, and retrieval-augmented generation (RAG). Snowpark Container Services provides a route to run containerised applications, including Weaviate, within a Snowflake environment.
+
+The current Weaviate partner page highlights three uses:
+
+- Run Weaviate in Snowpark Container Services.
+- Retrieve relevant Snowflake-connected data for LLM applications.
+- Build Python application interfaces using tools such as Streamlit.
+
+## When to use
+- Source data already resides in Snowflake and data movement is tightly controlled.
+- Your team operates applications through Snowpark Container Services.
+- You need vector or hybrid retrieval as part of a Snowflake-centred AI application.
+- You want to prototype an application using Weaviate retrieval and a Python or Streamlit interface.
+
+## When to use another path
+- Use Weaviate Cloud or another deployment model when you do not need Weaviate to run inside SPCS.
+- Keep warehouse-scale analytical queries in Snowflake; Weaviate should serve retrieval-oriented application queries.
+- Choose another architecture if your required SPCS region, operational model, or networking pattern is unavailable.
+
+## Production considerations
+- Confirm how Weaviate data is persisted, backed up, restored, and upgraded in SPCS.
+- Size compute and storage using representative object counts, vectors, tenants, and query load.
+- Define data synchronisation, updates, deletions, and recovery behaviour.
+- Review network access, secrets, roles, encryption, and model-provider connectivity.
+- Validate the support boundary between Weaviate, Snowflake, and any implementation partner.
+
+## Limitations and verification
+- Running Weaviate inside SPCS changes operational ownership compared with a fully managed Weaviate deployment.
+- Data-residency and security outcomes depend on the complete configuration, not the container location alone.
+- Feature, region, and pricing availability can change; verify current Snowflake and Weaviate documentation.
+
+## Next steps and resources
+- [Weaviate and Snowflake](https://weaviate.io/partners/snowflake)
+- [Getting started with Weaviate on SPCS](https://github.com/Snowflake-Labs/sfguide-getting-started-weaviate-on-spcs)
+- [Running Weaviate in Snowflake using Snowpark Container Services](https://medium.com/snowflake/running-weaviate-vector-db-in-snowflake-using-snowpark-container-services-490b1c391795)
+- [Weaviate deployment documentation](https://docs.weaviate.io/deploy)
+
+## Canonical source
+[Weaviate and Snowflake](https://weaviate.io/partners/snowflake)

--- a/static/product/explorer.md
+++ b/static/product/explorer.md
@@ -1,0 +1,46 @@
+# Explorer — LLM Guidance
+
+## TL;DR
+- Explorer is a visual tool in the Weaviate Cloud Console for searching and validating object data without writing code.
+- Use it to inspect objects in a collection and test searches while developing or troubleshooting.
+- Explorer is available now and opens from the Weaviate Cloud Console.
+- Use a Weaviate client library or API for repeatable application logic, automated testing, or production queries.
+
+## What Explorer is
+Explorer provides an interactive interface for developers and non-technical users to examine object data within a collection on a Weaviate Cloud cluster. It is intended for direct exploration and validation rather than application-side query implementation.
+
+## When to use
+- Inspect whether imported objects and properties appear as expected.
+- Explore a collection without first writing client code.
+- Test searches during development or troubleshooting.
+- Validate data and retrieval behaviour with teammates who do not use the API directly.
+
+## When not to use
+- Do not use Explorer as the query layer for a production application.
+- Use the Weaviate client libraries or API when queries need to be repeatable, version-controlled, tested, or automated.
+- Use Query Agent when you want a managed agent to translate natural-language questions into database operations.
+- Use monitoring and observability tooling for continuous production health checks.
+
+## Requirements
+- A Weaviate Cloud account.
+- Access to the relevant cluster and collection.
+- Permission to view or query the required data.
+
+## How to start
+1. Open the Weaviate Cloud Console.
+2. Select the relevant cluster.
+3. Open Explorer.
+4. Choose a collection and inspect or search its objects.
+5. Move validated query behaviour into application code when it needs to be reused.
+
+## Limitations and considerations
+- The available controls depend on the current Cloud Console and your permissions.
+- Interactive results are useful for validation but are not a substitute for an application-level relevance test suite.
+- Avoid exposing sensitive object data to users who do not require access.
+
+## Canonical links
+- Explorer product page: https://weaviate.io/product/explorer
+- Explorer documentation: https://docs.weaviate.io/cloud/tools/explorer-tool
+- Open Weaviate Cloud Console: https://weaviate.io/go/console
+- Core querying guidance: https://weaviate.io/product/query.md
+- Query Agent guidance: https://weaviate.io/product/query-agent.md


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Added guidance pages
- Partner/Product ecosystem overview
- AWS
- Google Cloud
- Databricks
- Snowflake
- Explorer

Supporting changes

- Added the new pages to the LLM-friendly section of llms.txt.
- Added partnership endpoints to the tracking-v2 curated allowlist.
- Added the previously tracked but missing /product/explorer.md page.
- Preserved the existing GA4 llm_page_view event and tracking-v2 attribution model.
- Kept analytics fail-open so tracking cannot prevent pages from being served.

### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [x] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
