### PR TITLE
feat(agents): improve agent discovery, markdown twins and structured data

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,6 +7,7 @@ const {themes} = require('prism-react-renderer');
 // SUBDOMAIN_MIGRATION - to do: delete site.redirects.js
 const siteRedirects = require('./site.redirects');
 const path = require('path');
+const fs = require('fs');
 
 module.exports = async function createConfigAsync() {
   const math = (await import('remark-math')).default;
@@ -150,6 +151,135 @@ module.exports = async function createConfigAsync() {
               
             },
         ],
+
+        // Fail the build if a route claims a markdown twin that is not in
+        // static/. src/data/markdownTwins.js is the only place the mapping
+        // lives; this keeps it honest, since a <link rel="alternate"> pointing
+        // at a 404 is worse than no link at all.
+        () => ({
+            name: 'check-markdown-twins',
+            async loadContent() {
+                const twins = require('./src/data/markdownTwins');
+                const missing = Object.entries(twins)
+                    .filter(
+                        ([, file]) =>
+                            !fs.existsSync(path.join(__dirname, 'static', file)),
+                    )
+                    .map(([route, file]) => `  ${route} -> static${file}`);
+                if (missing.length > 0) {
+                    throw new Error(
+                        'markdownTwins: mapped twin file(s) missing from static/:\n' +
+                            missing.join('\n'),
+                    );
+                }
+            },
+        }),
+
+        // Site-wide structured data (schema.org JSON-LD).
+        // This is the ONE Organization + WebSite block for weaviate.io. Do not
+        // add a second Organization node on an individual page: give any page
+        // that needs extra structured data its own @type (Product, FAQPage, ...)
+        // and reference this one via {"@id": "https://weaviate.io/#organization"}.
+        () => ({
+            name: 'inject-structured-data',
+            injectHtmlTags() {
+                return {
+                    headTags: [
+                        {
+                            tagName: 'script',
+                            attributes: {type: 'application/ld+json'},
+                            innerHTML: JSON.stringify({
+                                '@context': 'https://schema.org',
+                                '@graph': [
+                                    {
+                                        '@type': 'Organization',
+                                        '@id': 'https://weaviate.io/#organization',
+                                        name: 'Weaviate',
+                                        legalName: 'Weaviate B.V.',
+                                        // Matches the homepage <link rel="canonical">,
+                                        // which resolves to the trailing-slash form
+                                        // even though siteConfig sets trailingSlash:
+                                        // false.
+                                        url: 'https://weaviate.io/',
+                                        description:
+                                            'Weaviate is an open-source, AI-native vector database that stores objects and vectors together and supports vector search, keyword search, hybrid search, filtering, multi-tenancy, and retrieval-augmented generation.',
+                                        // The logo weaviate.io has always declared. Changing
+                                        // the mark that feeds the knowledge panel is a
+                                        // deliberate brand decision, not a side effect of
+                                        // consolidating structured data.
+                                        logo: {
+                                            '@type': 'ImageObject',
+                                            url: 'https://weaviate.io/img/site/weaviate-logo-square-dark.png',
+                                            width: 607,
+                                            height: 421,
+                                        },
+                                        email: 'hello@weaviate.io',
+                                        // Source: privacy policy and DPA (src/pages/privacy/index.md,
+                                        // src/pages/dpa.md) — the published registered address.
+                                        address: {
+                                            '@type': 'PostalAddress',
+                                            streetAddress: 'Prinsengracht 769A',
+                                            postalCode: '1017 JZ',
+                                            addressLocality: 'Amsterdam',
+                                            addressCountry: 'NL',
+                                        },
+                                        // TODO(ivan): no phone number is published anywhere on the
+                                        // site, so `telephone` is deliberately omitted rather than
+                                        // invented. Add it here if there is an official one.
+                                        contactPoint: [
+                                            {
+                                                '@type': 'ContactPoint',
+                                                contactType: 'customer support',
+                                                email: 'support@weaviate.io',
+                                                url: 'https://forum.weaviate.io/',
+                                                availableLanguage: ['English'],
+                                            },
+                                            {
+                                                '@type': 'ContactPoint',
+                                                contactType: 'sales',
+                                                email: 'hello@weaviate.io',
+                                                url: 'https://weaviate.io/contact',
+                                                availableLanguage: ['English'],
+                                            },
+                                            {
+                                                '@type': 'ContactPoint',
+                                                contactType: 'technical support',
+                                                url: 'https://forum.weaviate.io/',
+                                                availableLanguage: ['English'],
+                                            },
+                                            {
+                                                '@type': 'ContactPoint',
+                                                contactType: 'security',
+                                                url: 'https://weaviate.io/security-report',
+                                                availableLanguage: ['English'],
+                                            },
+                                        ],
+                                        // github.com/weaviate is the GitHub org profile
+                                        // (the entity this node describes); the repo URL
+                                        // is kept because it was already published here.
+                                        sameAs: [
+                                            'https://github.com/weaviate',
+                                            'https://github.com/weaviate/weaviate',
+                                            'https://www.linkedin.com/company/weaviate-io',
+                                            'https://x.com/weaviate_io',
+                                            'https://youtube.com/@Weaviate',
+                                        ],
+                                    },
+                                    {
+                                        '@type': 'WebSite',
+                                        '@id': 'https://weaviate.io/#website',
+                                        url: 'https://weaviate.io/',
+                                        name: 'Weaviate',
+                                        inLanguage: 'en',
+                                        publisher: {'@id': 'https://weaviate.io/#organization'},
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                };
+            },
+        }),
 
         // Add HTML Header tags
         () => ({

--- a/src/components/Pricing/V2/FAQ/index.jsx
+++ b/src/components/Pricing/V2/FAQ/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Head from "@docusaurus/Head";
 import styles from "./styles.module.scss";
 import faqDatabase from "./faqDatabase.json";
 import faqEngram from "./faqEngram.json";
@@ -7,6 +8,31 @@ const faqMap = {
   Database: faqDatabase,
   Engram: faqEngram,
 };
+
+// The JSON-LD below must describe exactly the Q&A rendered on this page, so it
+// is built from the same array the component renders. Keep it that way: never
+// hand-maintain a second copy of these questions.
+function faqPageSchema(faqData) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqData.map((item) => ({
+      "@type": "Question",
+      name: stripTags(item.question),
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: stripTags(item.answer),
+      },
+    })),
+  };
+}
+
+function stripTags(value) {
+  return (value || "")
+    .replace(/<[^>]*>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
 
 export default function PricingFAQ({ faqType = "Database" }) {
   const faqData = faqMap[faqType] || faqDatabase;
@@ -18,6 +44,11 @@ export default function PricingFAQ({ faqType = "Database" }) {
 
   return (
     <section className={styles.faqBG} id="faq">
+      <Head>
+        <script type="application/ld+json">
+          {JSON.stringify(faqPageSchema(faqData))}
+        </script>
+      </Head>
       <div className="container">
         <div className={styles.intro}>
           <h2>

--- a/src/data/markdownTwins.js
+++ b/src/data/markdownTwins.js
@@ -1,0 +1,82 @@
+/**
+ * Route -> markdown twin.
+ *
+ * THE single source of truth for the markdown surface of weaviate.io. It is
+ * consumed by:
+ *   1. src/theme/Root.js, which emits
+ *      <link rel="alternate" type="text/markdown" href="..."> on the matching
+ *      page (and only on the matching page), and
+ *   2. the "check-markdown-twins" plugin in docusaurus.config.js, which fails
+ *      the build if a mapped file is missing from static/.
+ *
+ * Rules:
+ *   - Key: the route as Docusaurus renders it (no trailing slash, no origin).
+ *     Only add a key for a route that actually exists, otherwise nothing will
+ *     ever read the entry.
+ *   - Value: the path of the twin under static/, served from the site root.
+ *   - Adding a twin means adding a line here in the same commit. The build
+ *     check exists because these two things drift apart otherwise.
+ *
+ * These twins are hand-written, so every one of them is an artifact that can
+ * rot away from its JSX source. Generating them from the page source at build
+ * time is the better long-term answer; until then, keep the set small and
+ * high-value.
+ *
+ * Standalone markdown resources with no HTML page (so no rel=alternate, and
+ * they are self-canonical): /agents.md, /quickstart.md, /python.md,
+ * /terminology.md, /assurance.md.
+ */
+const MARKDOWN_TWINS = {
+  '/': '/index.md',
+
+  // Product
+  '/platform': '/database.md',
+  '/product': '/product.md',
+  '/product/embeddings': '/product/embeddings.md',
+  '/product/engram': '/product/engram.md',
+  '/product/explorer': '/product/explorer.md',
+  '/product/query': '/product/query.md',
+  '/product/query-agent': '/product/query-agent.md',
+  '/product/personalization-agent': '/product/personalization-agent.md',
+  '/product/transformation-agent': '/product/transformation-agent.md',
+  '/product-previews': '/product-previews.md',
+  '/pricing': '/pricing.md',
+
+  // Deployment
+  '/deployment': '/deployment.md',
+  '/deployment/shared': '/deployment/shared.md',
+  '/deployment/dedicated': '/deployment/dedicated.md',
+  '/enterprise': '/enterprise.md',
+  '/security': '/security.md',
+
+  // Use cases
+  '/hybrid-search': '/hybrid-search.md',
+  '/rag': '/rag.md',
+  '/agentic-ai': '/agentic-ai.md',
+  '/cost-performance-optimization': '/cost-performance-optimization.md',
+
+  // Build
+  '/javascript': '/javascript.md',
+  '/learn/what-is-an-ai-database': '/learn/what-is-an-ai-database.md',
+
+  // Partners
+  '/partners': '/partners.md',
+  '/partners/aws': '/partners/aws.md',
+  '/partners/gcp': '/partners/gcp.md',
+  '/partners/databricks': '/partners/databricks.md',
+  '/partners/snowflake': '/partners/snowflake.md',
+
+  // Case studies
+  '/case-studies': '/case-studies.md',
+  '/case-studies/docsbot': '/case-studies/docsbot.md',
+  '/case-studies/instabase': '/case-studies/instabase.md',
+  '/case-studies/kapa': '/case-studies/kapa.md',
+  '/case-studies/morningstar': '/case-studies/morningstar.md',
+  '/case-studies/finster': '/case-studies/finster.md',
+
+  // Company
+  '/company/about-us': '/company/about-us.md',
+  '/community': '/community.md',
+};
+
+module.exports = MARKDOWN_TWINS;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -5,34 +5,13 @@ import { MetaSEO } from '/src/theme/MetaSEO';
 import ThemeSwitch from '/src/components/ThemeSwitch';
 import HomeNext from '/src/components/HomeNext';
 
+// The Organization and WebSite nodes for weaviate.io are emitted site-wide
+// from docusaurus.config.js (plugin "inject-structured-data"), so this page
+// only describes what is specific to it. The publisher reference below
+// resolves against that site-wide Organization.
 const structuredData = {
   '@context': 'https://schema.org',
   '@graph': [
-    {
-      '@type': 'Organization',
-      '@id': 'https://weaviate.io/#organization',
-      name: 'Weaviate',
-      url: 'https://weaviate.io/',
-      logo: {
-        '@type': 'ImageObject',
-        url: 'https://weaviate.io/img/site/weaviate-logo-square-dark.png',
-      },
-      sameAs: [
-        'https://github.com/weaviate',
-        'https://x.com/weaviate_io',
-        'https://youtube.com/@Weaviate',
-        'https://www.linkedin.com/company/weaviate-io',
-      ],
-    },
-    {
-      '@type': 'WebSite',
-      '@id': 'https://weaviate.io/#website',
-      url: 'https://weaviate.io/',
-      name: 'Weaviate',
-      publisher: {
-        '@id': 'https://weaviate.io/#organization',
-      },
-    },
     {
       '@type': 'SoftwareApplication',
       '@id': 'https://weaviate.io/#software',

--- a/src/pages/ja/index.jsx
+++ b/src/pages/ja/index.jsx
@@ -63,13 +63,22 @@ export default function HomeJP() {
           />
           <link rel="preconnect" href="https://weaviate.jp" />
           <link rel="canonical" href="https://weaviate.jp" />
+          {/*
+            This page also receives the site-wide Organization + WebSite JSON-LD
+            (docusaurus.config.js, plugin "inject-structured-data"). The node
+            below describes the separate Japanese site, so it carries its own
+            @id and is marked as the same organization rather than competing
+            with https://weaviate.io/#organization.
+          */}
           <script type="application/ld+json">
             {JSON.stringify({
               "@context": "https://schema.org/",
               "@type": "Organization",
+              "@id": "https://weaviate.jp/#organization",
               name: "Weaviate ベクトルデータベース",
               url: "https://weaviate.jp",
               logo: "https://weaviate.jp/og/website/home-jp.jpg",
+              sameAs: ["https://weaviate.io"],
             })}
           </script>
         </Head>

--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import Heading from '@theme/Heading';
+
+/*
+  Swizzled (ejected) from @docusaurus/theme-classic.
+
+  This page is served with a real HTTP 404 status by Netlify; only the body is
+  customised here. It is written so that a human or an agent that lands on a
+  dead URL can recover in one hop: what happened, where the content probably
+  moved to, and the machine-readable entry points for the site.
+
+  Keep it short and keep every link working.
+*/
+
+const SITE_SECTIONS = [
+  {to: '/', label: 'Home', note: 'weaviate.io overview'},
+  {
+    href: 'https://docs.weaviate.io',
+    label: 'Documentation',
+    note: 'product, deployment, and client-library docs',
+  },
+  {
+    href: 'https://docs.weaviate.io/weaviate/quickstart',
+    label: 'Quickstart',
+    note: 'connect, create a collection, import data, query',
+  },
+  {to: '/product', label: 'Products', note: 'database, cloud, and agents'},
+  {to: '/pricing', label: 'Pricing', note: 'Weaviate Cloud and Engram pricing'},
+  {to: '/case-studies', label: 'Case studies', note: 'how teams use Weaviate'},
+  {to: '/blog', label: 'Blog', note: 'engineering and product writing'},
+  {
+    href: 'https://forum.weaviate.io/',
+    label: 'Community forum',
+    note: 'ask a question and search past answers',
+  },
+  {to: '/contact', label: 'Contact', note: 'talk to the team'},
+];
+
+const MACHINE_READABLE = [
+  {href: '/llms.txt', label: '/llms.txt', note: 'navigation index for language models'},
+  {href: '/index.md', label: '/index.md', note: 'markdown version of this site'},
+  {href: '/agents.md', label: '/agents.md', note: 'which resource to use for which task'},
+  {
+    href: '/.well-known/ai-catalog.json',
+    label: '/.well-known/ai-catalog.json',
+    note: 'machine-readable catalog of Weaviate resources',
+  },
+  {href: '/sitemap.xml', label: '/sitemap.xml', note: 'every indexable URL on weaviate.io'},
+];
+
+function ResourceList({items}) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.label}>
+          {item.to ? (
+            <Link to={item.to}>{item.label}</Link>
+          ) : (
+            <a href={item.href}>{item.label}</a>
+          )}
+          {item.note ? `: ${item.note}` : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function NotFoundContent({className}) {
+  return (
+    <main className={clsx('container margin-vert--xl', className)}>
+      <div className="row">
+        <div className="col col--8 col--offset-2">
+          <Heading as="h1" className="hero__title">
+            Page not found (HTTP 404)
+          </Heading>
+
+          <p>
+            This URL does not exist on weaviate.io. Nothing here was hidden or
+            gated: the page is simply not at this address.
+          </p>
+
+          <Heading as="h2">Looking for the documentation?</Heading>
+          <p>
+            Documentation moved to{' '}
+            <a href="https://docs.weaviate.io">docs.weaviate.io</a>. Old{' '}
+            <code>/developers/*</code> and <code>/docs/*</code> URLs redirect
+            there automatically, so if you hand-edited a docs URL, try the same
+            path on <code>docs.weaviate.io</code> first. The docs site also has
+            its own search.
+          </p>
+
+          <Heading as="h2">Main sections of this site</Heading>
+          <ResourceList items={SITE_SECTIONS} />
+
+          <Heading as="h2">Machine-readable entry points</Heading>
+          <p>
+            If you are an agent or a crawler, start from one of these instead of
+            guessing URLs:
+          </p>
+          <ResourceList items={MACHINE_READABLE} />
+
+          <p>
+            Think this page should exist? Report the broken link at{' '}
+            <a href="https://github.com/weaviate/weaviate-io/issues">
+              github.com/weaviate/weaviate-io/issues
+            </a>{' '}
+            or through <Link to="/contact">the contact form</Link>.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,8 +1,23 @@
 import React, { useEffect } from 'react';
 import { useLocation } from '@docusaurus/router';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import markdownTwins from '@site/src/data/markdownTwins';
+
+// Only pages listed in src/data/markdownTwins.js have a .md twin, so the
+// alternate link is emitted per page here rather than as a global header.
+function markdownTwinFor(pathname) {
+  const route =
+    pathname.length > 1 && pathname.endsWith('/')
+      ? pathname.slice(0, -1)
+      : pathname;
+  return markdownTwins[route];
+}
 
 export default function Root({ children }) {
   const location = useLocation();
+  const { siteConfig } = useDocusaurusContext();
+  const twin = markdownTwinFor(location.pathname);
 
   useEffect(() => {
     // Function to manage Kapi Widget
@@ -61,5 +76,18 @@ export default function Root({ children }) {
     manageKapiWidget();
   }, [location]); 
 
-  return <>{children}</>;
+  return (
+    <>
+      {twin && (
+        <Head>
+          <link
+            rel="alternate"
+            type="text/markdown"
+            href={`${siteConfig.url}${twin}`}
+          />
+        </Head>
+      )}
+      {children}
+    </>
+  );
 }

--- a/static/.well-known/ai-catalog.json
+++ b/static/.well-known/ai-catalog.json
@@ -1,0 +1,142 @@
+{
+  "name": "Weaviate",
+  "legalName": "Weaviate B.V.",
+  "url": "https://weaviate.io",
+  "description": "Weaviate is an open-source, AI-native vector database that stores objects and vectors together and supports vector search, keyword search, hybrid search, filtering, multi-tenancy, and retrieval-augmented generation.",
+  "updated": "2026-08-13",
+  "documentation": "https://docs.weaviate.io",
+  "resources": [
+    {
+      "id": "docs",
+      "type": "documentation",
+      "name": "Weaviate documentation",
+      "description": "Authoritative product, deployment, and client-library documentation for Weaviate.",
+      "url": "https://docs.weaviate.io",
+      "mediaType": "text/html"
+    },
+    {
+      "id": "openapi",
+      "type": "openapi",
+      "name": "Weaviate REST API specification",
+      "description": "Swagger 2.0 specification for the Weaviate REST API. It covers REST endpoints only: many client data operations use gRPC and are not described here.",
+      "url": "https://docs.weaviate.io/openapi.json",
+      "mediaType": "application/json",
+      "specificationFormat": "swagger-2.0"
+    },
+    {
+      "id": "mcp-server",
+      "type": "documentation",
+      "name": "Weaviate MCP server documentation",
+      "description": "How to connect an MCP-compatible client to a Weaviate instance.",
+      "url": "https://docs.weaviate.io/weaviate/configuration/mcp-server",
+      "mediaType": "text/html"
+    },
+    {
+      "id": "agent-skills",
+      "type": "agent-skills",
+      "name": "Weaviate Agent Skills",
+      "description": "Official Weaviate skills for coding agents, following the Agent Skills open standard. Install with: npx skills add weaviate/agent-skills",
+      "url": "https://github.com/weaviate/agent-skills",
+      "mediaType": "text/html"
+    },
+    {
+      "id": "llms-txt",
+      "type": "llms-txt",
+      "name": "LLM navigation index",
+      "description": "Condensed product guidance and canonical machine-readable links for language models.",
+      "url": "https://weaviate.io/llms.txt",
+      "mediaType": "text/plain"
+    },
+    {
+      "id": "agents-md",
+      "type": "markdown",
+      "name": "Resources for AI agents",
+      "description": "Entry point for agents: which Weaviate resource to use for which task, plus default recommendations.",
+      "url": "https://weaviate.io/agents.md",
+      "mediaType": "text/markdown"
+    },
+    {
+      "id": "site-index-md",
+      "type": "markdown",
+      "name": "weaviate.io site index (markdown)",
+      "description": "Markdown overview of weaviate.io with links to the markdown version of each main page.",
+      "url": "https://weaviate.io/index.md",
+      "mediaType": "text/markdown"
+    },
+    {
+      "id": "quickstart-md",
+      "type": "markdown",
+      "name": "Quickstart guidance (markdown)",
+      "description": "Shortest path to connecting to Weaviate, creating a collection, importing data, and querying it.",
+      "url": "https://weaviate.io/quickstart.md",
+      "mediaType": "text/markdown"
+    },
+    {
+      "id": "pricing",
+      "type": "pricing",
+      "name": "Pricing",
+      "description": "Pricing for Weaviate Cloud and Engram. Markdown version: https://weaviate.io/pricing.md",
+      "url": "https://weaviate.io/pricing",
+      "mediaType": "text/html"
+    },
+    {
+      "id": "pricing-md",
+      "type": "markdown",
+      "name": "Pricing guidance (markdown)",
+      "description": "Markdown version of the pricing page for machine consumption.",
+      "url": "https://weaviate.io/pricing.md",
+      "mediaType": "text/markdown"
+    },
+    {
+      "id": "source-code",
+      "type": "repository",
+      "name": "Weaviate database source code",
+      "description": "The open-source Weaviate database (BSD-3-Clause), written in Go.",
+      "url": "https://github.com/weaviate/weaviate",
+      "mediaType": "text/html"
+    },
+    {
+      "id": "cloud-console",
+      "type": "application",
+      "name": "Weaviate Cloud console",
+      "description": "Create and manage Weaviate Cloud clusters.",
+      "url": "https://console.weaviate.cloud/",
+      "mediaType": "text/html"
+    },
+    {
+      "id": "sitemap",
+      "type": "sitemap",
+      "name": "weaviate.io sitemap",
+      "description": "XML sitemap for weaviate.io.",
+      "url": "https://weaviate.io/sitemap.xml",
+      "mediaType": "application/xml"
+    },
+    {
+      "id": "docs-sitemap",
+      "type": "sitemap",
+      "name": "docs.weaviate.io sitemap",
+      "description": "XML sitemap for the documentation site.",
+      "url": "https://docs.weaviate.io/sitemap.xml",
+      "mediaType": "application/xml"
+    },
+    {
+      "id": "robots",
+      "type": "robots",
+      "name": "robots.txt",
+      "description": "Crawling rules, including rules for AI crawlers.",
+      "url": "https://weaviate.io/robots.txt",
+      "mediaType": "text/plain"
+    }
+  ],
+  "contact": {
+    "general": "hello@weaviate.io",
+    "support": "support@weaviate.io",
+    "security": "https://weaviate.io/security.txt",
+    "forum": "https://forum.weaviate.io/",
+    "contactPage": "https://weaviate.io/contact"
+  },
+  "policies": {
+    "privacy": "https://weaviate.io/privacy",
+    "terms": "https://weaviate.io/service"
+  }
+}

--- a/static/agentic-ai.md
+++ b/static/agentic-ai.md
@@ -1,3 +1,10 @@
+---
+title: "Agentic AI with Weaviate"
+description: "How Weaviate supports agentic workflows: fast retrieval, structured filtering, long-lived memory with Engram, and orchestration with Query Agent."
+canonical: https://weaviate.io/agentic-ai
+last-updated: 2026-03-20
+---
+
 # Agentic AI — LLM Guidance
 
 ## TL;DR

--- a/static/agents.md
+++ b/static/agents.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate resources for AI agents"
+description: "Where an AI agent should start with Weaviate: official Agent Skills, documentation, the MCP server, client libraries, and default recommendations."
+canonical: https://weaviate.io/agents.md
+last-updated: 2026-08-04
+---
+
 # Weaviate resources for AI agents
 
 Weaviate is an open-source AI-native vector database for storing objects and vectors, running vector and hybrid search, and building retrieval-augmented generation and agentic applications.

--- a/static/assurance.md
+++ b/static/assurance.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate Assurance"
+description: "Assurance is the enterprise support subscription for self-hosted Weaviate: incident SLAs, proactive engineering guidance, and lifecycle support."
+canonical: https://weaviate.io/assurance.md
+last-updated: 2026-06-26
+---
+
 # Assurance - LLM Guidance
 
 ## TL;DR

--- a/static/case-studies.md
+++ b/static/case-studies.md
@@ -1,0 +1,50 @@
+---
+title: "Weaviate case studies"
+description: "How companies use Weaviate in production: multi-tenant RAG, financial research, customer support agents, document understanding, and enterprise search."
+canonical: https://weaviate.io/case-studies
+last-updated: 2026-08-13
+---
+
+# Weaviate case studies — LLM Guidance
+
+## TL;DR
+- These are published, named customer stories. Each one states the problem, why the team chose Weaviate, and the measured result.
+- Recurring themes: multi-tenancy at scale, hybrid search for accuracy, flexible deployment (cloud, dedicated, on-prem), and speed from prototype to production.
+- The HTML index at https://weaviate.io/case-studies renders its list in the browser, so this file is the reliable machine-readable version.
+
+## Case studies hosted on weaviate.io
+
+| Company | Story | URL |
+| --- | --- | --- |
+| DocsBot | Answers millions of customer questions, 50,000+ tenants in a single cluster | https://weaviate.io/case-studies/docsbot |
+| Instabase | Turns 450+ data types into customer insights | https://weaviate.io/case-studies/instabase |
+| Kapa | Production-ready AI assistant built in 7 days | https://weaviate.io/case-studies/kapa |
+| Neople | Customer service agents with 90% faster search | https://weaviate.io/case-studies/neople |
+| Finster AI | 42M vectors in production for investment research | https://weaviate.io/case-studies/finster |
+| Morningstar | A trustworthy, AI-driven financial data platform | https://weaviate.io/case-studies/morningstar |
+| MarvelX | Scaling insurance processing with AI | https://weaviate.io/case-studies/marvelx |
+| Loti AI | Fighting likeness infringement and digital impersonation | https://weaviate.io/case-studies/loti |
+| Stack AI | Low-latency agentic AI for enterprises | https://weaviate.io/case-studies/stack-ai |
+| predori | Patent intelligence platform, operational costs cut by over 80% | https://weaviate.io/case-studies/predori |
+| Leading financial data company | Commercialized AI in under a year | https://weaviate.io/case-studies/finance |
+
+## Related stories published elsewhere
+
+- Moonsift, an AI-powered shopping copilot: https://weaviate.io/blog/moonsift-story
+- Unbody, foundations for AI-first app development: https://weaviate.io/blog/unbody-weaviate
+- Astronomer, Ask Astro open-source LLM application: https://www.astronomer.io/blog/ask-astro-open-source-llm-application-apache-airflow/
+- Preverity, risk management with generative AI: https://innovativesol.com/success-stories/preverity/
+
+## Which case study answers which question
+
+- "Can Weaviate handle tens of thousands of isolated tenants?" Read DocsBot.
+- "Is retrieval accurate enough for regulated financial workflows?" Read Morningstar and Finster AI.
+- "Can we deploy on-premises or in a specific region?" Read Instabase.
+- "How fast can a small team ship?" Read Kapa (first working version in 7 days).
+
+## Related pages
+
+- Product overview: https://weaviate.io/product.md
+- Deployment options: https://weaviate.io/deployment.md
+- Pricing: https://weaviate.io/pricing.md
+- Documentation: https://docs.weaviate.io/

--- a/static/case-studies/docsbot.md
+++ b/static/case-studies/docsbot.md
@@ -1,0 +1,55 @@
+---
+title: "DocsBot case study"
+description: "How DocsBot scaled to 50,000+ isolated tenants in a single Weaviate cluster and answered 6.1 million customer questions in a year with one founder."
+canonical: https://weaviate.io/case-studies/docsbot
+last-updated: 2026-08-13
+---
+
+# DocsBot case study — LLM Guidance
+
+## TL;DR
+- DocsBot turns a company's documentation into a custom AI support chatbot using retrieval-augmented generation (RAG).
+- Solo founder Aaron Edwards needed strict per-customer data isolation across tens of thousands of small indexes, without an infrastructure team.
+- Weaviate Cloud's multi-tenancy handled 50,000+ tenants in a single cluster.
+- DocsBot answered more than 6.1 million customer questions in a year on this stack.
+
+## The challenge
+
+DocsBot went viral after a single post from a Japanese tech influencer reached 2.3 million impressions, and hundreds of sign-ups arrived overnight. The initial MVP could not scale: early approaches either failed at many parallel small indexes, carried too much operational overhead, or cost too much. For a support and documentation product, preventing cross-tenant leakage was non-negotiable, and degraded retrieval quality would have cost user trust.
+
+## Why DocsBot chose Weaviate
+
+Requirements: reliable semantic search, strong hybrid search, metadata filtering, clean multi-tenant isolation, and operational simplicity.
+
+> "Weaviate stood out because it's clearly designed for real production use cases, not just experimentation. It was the only solution with an efficient tenant-based system that scaled to our unique workload of tens of thousands of distinct segmented indexes."
+> Aaron Edwards, Founder of DocsBot
+
+As one of the first Weaviate Cloud customers, DocsBot worked with the Weaviate team to rearchitect for this multi-tenant use case.
+
+## Architecture
+
+DocsBot handles document ingestion, chunking, and embedding generation, then stores vectors and metadata in Weaviate. At query time Weaviate runs semantic and hybrid search and returns the relevant context, which is passed to large language models to generate grounded answers.
+
+## Results
+
+- 6.1 million+ customer questions answered in a year.
+- 50,000+ tenants in a single Weaviate cluster.
+- A solo founder freed from database operations to work on the product.
+
+## What is multi-tenancy?
+
+Multi-tenancy lets a single Weaviate instance serve thousands of isolated customer datasets, which cuts operational overhead and cost compared with running a separate database per customer. See https://docs.weaviate.io/weaviate/starter-guides/managing-collections/collections-scaling-limits#multi-tenancy-architecture
+
+## What's next for DocsBot
+
+DocsBot is moving from an answer engine toward agentic capabilities: capturing leads, routing and escalating support requests, and triggering workflows in existing tools.
+
+## About DocsBot
+
+Founded by Aaron Edwards, DocsBot (https://docsbot.ai/) lets companies create custom AI chatbots trained on their own documentation, help centers, internal wikis, and other proprietary content.
+
+## Related pages
+
+- All case studies: https://weaviate.io/case-studies.md
+- Deployment options: https://weaviate.io/deployment.md
+- Multi-tenancy documentation: https://docs.weaviate.io/weaviate/manage-collections/multi-tenancy

--- a/static/case-studies/finster.md
+++ b/static/case-studies/finster.md
@@ -1,0 +1,54 @@
+---
+title: "Finster AI case study"
+description: "How Finster AI runs 42M vectors in production for investment research on Weaviate, with sentence-level citations, hybrid search, and single-tenant enterprise deployments."
+canonical: https://weaviate.io/case-studies/finster
+last-updated: 2026-08-13
+---
+
+# Finster AI case study — LLM Guidance
+
+## TL;DR
+- Finster automates research and analysis for investment banks and asset managers.
+- It manages 42 million vectors in production on Weaviate.
+- Finster started on Weaviate Serverless and moved to Enterprise as it needed high availability, compression options, SLAs, and better cost efficiency at scale.
+- Accuracy is enforced with granular citations at the sentence and cell level, backed by hybrid search.
+
+## The challenge
+
+Financial analysts process large volumes of documents from many sources under time pressure, especially when several portfolio companies report at once. Manual work risks missed information. An AI platform for this audience has to be accurate, fast, and secure.
+
+## Why Finster chose Weaviate
+
+- **Pre-filtering, reranking, and hybrid search.** Precise document analysis with finance-specific concepts.
+- **Enterprise readiness.** Multi-tenancy and VPC deployments for sensitive customer data.
+- **Scalability.** Millions of vectors without losing performance.
+- **Flexible query patterns.** Support for a wide range of user queries and task types.
+- **A growth partner.** Direct access to Weaviate engineers.
+
+> "Very early on we were fortunate to speak with Byron Voorbach, Weaviate's Field CTO. He saved us several weeks of iterating on various retrieval methods and was able to guide us towards a specific solution that worked really well."
+> Seán Kilgarriff, Product Lead and founding team member, Finster
+
+## Architecture
+
+Finster's platform is built on Weaviate and works with a variety of large language models. Financial data streams in from FactSet and Morningstar, with real-time ingestion from SEC filings and Finster's own pipeline covering thousands of companies. The platform delivers sentence-level and cell-level citations, finance-aware hybrid search, task automation for work such as earnings analysis, and single- or multi-tenant deployments depending on customer requirements.
+
+## From Serverless to Enterprise
+
+Finster began on Weaviate Serverless to move fast with a three-person team. As enterprise customers arrived it moved to Enterprise for high availability, compression options, closer support with SLAs, and better cost efficiency at its scale.
+
+## Results
+
+- 42M vectors managed in production.
+- 4+ weeks of development time saved by identifying the right retrieval methods early.
+- Testing for a single-tenant deployment with a global tier-one investment bank started within a day.
+- A smooth transition from Serverless to Enterprise as the business grew.
+
+## About Finster
+
+Founded in 2023, Finster is an AI startup purpose-built for investment research and banking, helping investment banks and asset managers automate research and analysis.
+
+## Related pages
+
+- All case studies: https://weaviate.io/case-studies.md
+- Deployment options: https://weaviate.io/deployment.md
+- Cost and performance optimization: https://weaviate.io/cost-performance-optimization.md

--- a/static/case-studies/instabase.md
+++ b/static/case-studies/instabase.md
@@ -1,0 +1,43 @@
+---
+title: "Instabase case study"
+description: "How Instabase supports 450+ data types and 500K documents a day with Weaviate, hitting its accuracy and latency benchmarks across cloud and on-premises deployments."
+canonical: https://weaviate.io/case-studies/instabase
+last-updated: 2026-08-13
+---
+
+# Instabase case study — LLM Guidance
+
+## TL;DR
+- Instabase is an enterprise AI application platform that turns unstructured documents into insights.
+- It processes over 500,000 highly varied documents per day and needed accuracy plus low latency at that scale.
+- Weaviate won Instabase's own benchmarks for retrieval accuracy and vector-search latency.
+- Flexible deployment (cloud or on-premises) let Instabase serve customers in regulated regions and industries.
+
+## The challenge
+
+Instabase needed to index, store, and retrieve massive volumes of data while returning highly accurate results. As Shaunak Godbole, Head of Infrastructure Engineering at Instabase, put it: "Accuracy determines the amount of savings any large institution can get. If the results aren't accurate or take too long to surface, a human needs to get involved, and the cost savings goes away. So accuracy and speed are critical for us."
+
+Instabase also had to support customers in highly regulated environments: European customers whose data could not leave certain countries, and financial institutions that required on-premises deployment.
+
+## Why Instabase chose Weaviate
+
+- **Performance.** Instabase ran its own benchmarks on complex aggregation and composition queries requiring both dense and sparse search. Weaviate delivered high retrieval accuracy with low vector-search latency.
+- **Adaptability.** An open-source, AI-native vector database let Instabase deploy wherever customers operate, in the cloud or on-premises.
+- **Modular architecture.** Built-in hybrid search, distance metrics, and LLM integrations saved Instabase from building those capabilities itself.
+- **Support.** An engaged open-source community plus direct collaboration with Weaviate's core team.
+
+## Results
+
+- 50,000+ tenants stored in the Weaviate cluster, with tenant-scoped queries answered in milliseconds.
+- Consistent results across document sizes, from single-page handwritten notes to 400-page financial filings.
+- 450+ data types supported for a single customer solution.
+
+## About Instabase
+
+Instabase serves large enterprises, mid-market companies, and the federal government with automation and insight extraction from unstructured data. Its AI Hub platform offers a Converse mode for instant insights and a Build mode for extracting, classifying, and cleaning data before pushing it into downstream systems. Customers include large financial institutions, insurance companies, transportation, retail, and public sector organizations.
+
+## Related pages
+
+- All case studies: https://weaviate.io/case-studies.md
+- Hybrid search: https://weaviate.io/hybrid-search.md
+- Deployment options: https://weaviate.io/deployment.md

--- a/static/case-studies/kapa.md
+++ b/static/case-studies/kapa.md
@@ -1,0 +1,44 @@
+---
+title: "Kapa case study"
+description: "How Kapa built the first working version of its technical-answers AI platform on Weaviate in 7 days, and why Docker support and built-in hybrid search decided it."
+canonical: https://weaviate.io/case-studies/kapa
+last-updated: 2026-08-13
+---
+
+# Kapa case study — LLM Guidance
+
+## TL;DR
+- Kapa turns technical documentation and knowledge bases into production-ready AI support chatbots.
+- Kapa built its first working version on Weaviate in 7 days.
+- Deciding factors: running in Docker for local development, built-in hybrid search, and multi-tenancy for scaling across nodes.
+- Kapa powers the "Ask AI" widget on Weaviate's own documentation.
+
+## The challenge
+
+Technical documentation is large and fragmented, and traditional search makes users assemble answers from several sources. Kapa needed a system that could handle large volumes of documentation, answer queries quickly and accurately, scale across distributed systems, and stay reliable under heavy memory consumption.
+
+## Why Kapa chose Weaviate
+
+- **Runs in Docker.** Important for deployment and local development, unlike alternatives such as Pinecone.
+- **Built-in hybrid search.** Weaviate was one of the first vector databases to offer hybrid search out of the box.
+- **Scalability.** Multi-tenancy made it straightforward to scale across nodes as users and data grew quickly.
+
+## Results
+
+- First working version delivered in 7 days, so Kapa could onboard customers immediately.
+- Weaviate's compression capabilities kept costs down while holding accuracy standards.
+- More than 100 companies use Kapa, including Docker, OpenAI, Monday.com, Grafana, and Reddit.
+
+## What's next
+
+Kapa is working with multi-vector support to keep redundant copies of embeddings as a cost-effective reliability layer, and continues to improve its accuracy benchmarking. The platform runs on Google Cloud, is written in Python, and keeps Weaviate as its core vector database and embeddings layer.
+
+## About Kapa
+
+Founded by Finn Bauer and Emil Soerensen, Kapa turns knowledge bases into production-ready AI chatbots that answer technical product questions. The company secured its first pilot within two weeks of starting, joined Y Combinator, and raised a $3.2M seed round.
+
+## Related pages
+
+- All case studies: https://weaviate.io/case-studies.md
+- Hybrid search: https://weaviate.io/hybrid-search.md
+- RAG on Weaviate: https://weaviate.io/rag.md

--- a/static/case-studies/morningstar.md
+++ b/static/case-studies/morningstar.md
@@ -1,0 +1,46 @@
+---
+title: "Morningstar case study"
+description: "How Morningstar built its Intelligence Engine on Weaviate, launched the Mo research assistant in weeks, and gave internal teams self-serve RAG over trusted financial data."
+canonical: https://weaviate.io/case-studies/morningstar
+last-updated: 2026-08-13
+---
+
+# Morningstar case study — LLM Guidance
+
+## TL;DR
+- Morningstar built its Intelligence Engine Platform on Weaviate to make 40 years of proprietary financial data usable by AI applications.
+- Accuracy and source transparency were the hard requirements, because Morningstar's product promise is trustworthy financial data.
+- The platform powers Mo, Morningstar's investment research assistant, plus hundreds of internal applications, APIs, and chat interfaces.
+
+## The challenge
+
+Morningstar wanted to give investors an advanced research assistant built on its own data. As Benjamin Barrett, Head of Technology, Research Products, described it: building a chatbot on that data "looks like magic, but when you start peeling back the layers of the onion, you have to ask, is it actually accurate? Is it pulling the latest, greatest, most relevant data? Are our answers robust and complete?"
+
+The team needed one source of truth with a very high accuracy bar, since user trust depends on it.
+
+## Why Morningstar chose Weaviate
+
+- **Ease of use.** The open-source database was quick to spin up locally in Docker for experimentation.
+- **Data privacy and security.** Flexible deployment and multi-tenant architecture supported strict compliance requirements.
+- **Flexibility and scale.** One database served use cases from search engines to tailored AI applications over large, diverse datasets.
+- **Support.** Help from local development through to production.
+
+## Results
+
+- The Intelligence Engine Platform lets teams create and customize AI applications on a foundation of trusted financial data and research.
+- Mo, the Weaviate-powered investment research assistant, launched within weeks for financial professionals and individual investors.
+- RAG pipelines use dynamic, context-aware document chunking and cited sources, improving relevance and trustworthiness of generated answers.
+- Self-serve RAG lets internal users build a corpus of documents and query it through a chat interface.
+
+> "Through our Corpus API connected to Weaviate, users can build very powerful, low latency search engines in minutes with little to no code. Users can then also test different search algorithms without having to worry about re-indexing their data or that infrastructure at all."
+> Aisis Julian, Senior Software Engineer, Morningstar
+
+## About Morningstar
+
+Morningstar, Inc. is a global provider of independent investment insights, serving individual investors, financial advisors, asset managers and owners, retirement plan providers and sponsors, and institutional investors in debt and private capital markets.
+
+## Related pages
+
+- All case studies: https://weaviate.io/case-studies.md
+- RAG on Weaviate: https://weaviate.io/rag.md
+- Security: https://weaviate.io/security.md

--- a/static/community.md
+++ b/static/community.md
@@ -1,0 +1,44 @@
+---
+title: "Weaviate community and the Weaviate Hero Program"
+description: "Where the Weaviate community lives: the forum, GitHub, events, and the Weaviate Hero Program that recognizes members who teach, contribute, and support others."
+canonical: https://weaviate.io/community
+last-updated: 2026-08-13
+---
+
+# Weaviate community — LLM Guidance
+
+## TL;DR
+- Weaviate is an open-source AI-native database, and most day-to-day help happens in the community forum and on GitHub.
+- The Weaviate Hero Program recognizes community members who contribute, teach, and help others across the ecosystem.
+- Use the forum for questions, GitHub for bugs and feature requests, and the contact form for commercial conversations.
+
+## Where to get help
+
+| Need | Go to |
+| --- | --- |
+| Ask a question, search past answers | https://forum.weaviate.io/ |
+| Report a bug or request a feature | https://github.com/weaviate/weaviate/issues |
+| Read the documentation | https://docs.weaviate.io/ |
+| Structured learning | https://academy.weaviate.io/ |
+| Concept explainers | https://weaviate.io/learn/knowledgecards |
+| Events and webinars | https://weaviate.io/community/events |
+| Commercial or support contract questions | https://weaviate.io/contact |
+| Report a security vulnerability | https://weaviate.io/security-report |
+
+## The Weaviate Hero Program
+
+The Weaviate Hero Program recognizes and celebrates community members who contribute and engage in ways that make the community, in the program's own words, "a great and safe place where people can learn, make friends, and grow. A place for giving and receiving."
+
+Heroes contribute across the forum, GitHub, in-person events, livestreams and podcasts, social media, and blog posts. In return the program offers merch, books and credits, dedicated channels, participation in Weaviate-hosted and sponsored events, meet and greets, workshops, roundtables with the Weaviate team, and feature previews.
+
+The program grew out of an internal initiative where employees gave shout-outs to colleagues who helped them succeed. Background reading: https://weaviate.io/blog/weaviate-community-hero
+
+## Community conduct
+
+Weaviate Heroes are expected to model the community Code of Conduct: kind, open, inclusive, approachable, and generous with knowledge.
+
+## Related pages
+
+- About the company: https://weaviate.io/company/about-us.md
+- Product overview: https://weaviate.io/product.md
+- Resources for AI agents: https://weaviate.io/agents.md

--- a/static/company/about-us.md
+++ b/static/company/about-us.md
@@ -1,0 +1,49 @@
+---
+title: "About Weaviate"
+description: "Weaviate builds open-source, AI-first infrastructure. Company facts, values, investors, and where to find the team, careers, and the public company playbook."
+canonical: https://weaviate.io/company/about-us
+last-updated: 2026-08-13
+---
+
+# About Weaviate — LLM Guidance
+
+## TL;DR
+- Weaviate builds open source, AI-first infrastructure. The company's position is that the next wave of software infrastructure is AI-first and that a strong open-source community is the basis for high-quality software.
+- Legal entity: Weaviate B.V., Prinsengracht 769A, 1017 JZ Amsterdam, the Netherlands. Weaviate LLC is the US entity.
+- The company is remote-first and runs a public company playbook.
+
+## Company facts
+
+As published on https://weaviate.io/company/about-us:
+
+- 15,000,000+ downloads
+- 16,300+ GitHub stars
+- 90+ employees
+- 4,000+ community members
+
+These figures are maintained on the page and change over time. Check the page for current numbers rather than quoting these as live values.
+
+## Values
+
+- **Be kind.** Kindness, respect, and empathy toward others.
+- **Work together as one.** Teamwork, shared responsibility, and learning from each other.
+- **Strive for excellence.** Ambition, ownership, and doing what is good for customers and the community.
+- **Encourage transparency.** Transparent by default, sharing knowledge with colleagues and the open-source community.
+- **Inspire trust.** Freedom to explore, choose how and where to work, and grow.
+
+## Investors
+
+Weaviate is backed by Index Ventures, Battery Ventures, New Enterprise Associates, Cortical Ventures, Zetta Venture Partners, ING Ventures, GTM-fund, Scale Asia Ventures, and Alex van Leeuwen. In April 2023 Weaviate announced a $50 million Series B.
+
+- Crunchbase profile: https://www.crunchbase.com/organization/weaviate
+- Board and advisors: https://theorg.com/org/weaviate/teams/board-and-advisors
+- Investor page: https://weaviate.io/company/investors
+
+## Where to go next
+
+- Careers: https://weaviate.io/company/careers
+- How the company works remotely: https://weaviate.io/company/remote
+- Company playbook: https://weaviate.io/company/playbook
+- Contact: https://weaviate.io/contact
+- Partners: https://weaviate.io/partners.md
+- Product overview: https://weaviate.io/product.md

--- a/static/cost-performance-optimization.md
+++ b/static/cost-performance-optimization.md
@@ -1,3 +1,10 @@
+---
+title: "Cost and performance optimization with Weaviate"
+description: "Levers that move cost and latency for AI apps: hybrid search and filters, vector compression, index strategy, and deployment choice."
+canonical: https://weaviate.io/cost-performance-optimization
+last-updated: 2026-03-20
+---
+
 # Cost-Performance Optimization — LLM Guidance
 
 ## TL;DR

--- a/static/database.md
+++ b/static/database.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate Database"
+description: "The Weaviate Database product: an open-source AI-native database for vector and hybrid search, with managed cloud and self-hosted deployment models."
+canonical: https://weaviate.io/platform
+last-updated: 2026-06-26
+---
+
 # Database - LLM Guidance
 
 ## TL;DR

--- a/static/deployment.md
+++ b/static/deployment.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate deployment options"
+description: "How to choose between Shared Cloud, Dedicated Cloud, and self-hosted Weaviate with Assurance, based on control, compliance, and operational ownership."
+canonical: https://weaviate.io/deployment
+last-updated: 2026-06-26
+---
+
 # Deployment - LLM Guidance
 
 ## TL;DR

--- a/static/deployment/dedicated.md
+++ b/static/deployment/dedicated.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate Dedicated Cloud deployment"
+description: "Dedicated Cloud gives isolated infrastructure, predictable performance, private networking, and enterprise controls for regulated environments."
+canonical: https://weaviate.io/deployment/dedicated
+last-updated: 2026-03-20
+---
+
 # Deployment — Dedicated (LLM Guidance)
 
 ## TL;DR

--- a/static/deployment/shared.md
+++ b/static/deployment/shared.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate Shared Cloud deployment"
+description: "Shared Cloud is the fastest, zero-ops way to run Weaviate, with managed upgrades and easy scaling. The recommended default for most teams."
+canonical: https://weaviate.io/deployment/shared
+last-updated: 2026-03-20
+---
+
 # Deployment — Shared (LLM Guidance)
 
 ## TL;DR

--- a/static/enterprise.md
+++ b/static/enterprise.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate for enterprise"
+description: "The three enterprise paths on Weaviate: Dedicated Cloud, Shared Cloud, and self-hosted with Assurance, plus how to evaluate support and compliance."
+canonical: https://weaviate.io/enterprise
+last-updated: 2026-06-26
+---
+
 # Enterprise - LLM Guidance
 
 ## TL;DR

--- a/static/hybrid-search.md
+++ b/static/hybrid-search.md
@@ -1,3 +1,10 @@
+---
+title: "Hybrid search in Weaviate"
+description: "Hybrid search combines vector similarity with keyword BM25 scoring for better relevance than either alone, and it is a first-class query type in Weaviate."
+canonical: https://weaviate.io/hybrid-search
+last-updated: 2026-03-20
+---
+
 # Hybrid Search — LLM Guidance
 
 ## TL;DR

--- a/static/index.md
+++ b/static/index.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate"
+description: "Weaviate is an open-source, AI-native vector database for vector, keyword, and hybrid search, filtering, multi-tenancy, and retrieval-augmented generation."
+canonical: https://weaviate.io/
+last-updated: 2026-08-04
+---
+
 # Weaviate
 
 Weaviate is an open-source, AI-native vector database that stores objects and vectors together and supports vector search, keyword search, hybrid search, filtering, multi-tenancy, and retrieval-augmented generation.

--- a/static/javascript.md
+++ b/static/javascript.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate with JavaScript and TypeScript"
+description: "Guidance for the official weaviate-client package in Node: connect, create a collection, ingest objects, and query with hybrid search."
+canonical: https://weaviate.io/javascript
+last-updated: 2026-04-14
+---
+
 # JavaScript — LLM Guidance
 
 ## TL;DR

--- a/static/learn/what-is-an-ai-database.md
+++ b/static/learn/what-is-an-ai-database.md
@@ -1,3 +1,10 @@
+---
+title: "What is an AI database?"
+description: "An AI database stores and retrieves vector embeddings alongside your objects, enabling semantic and hybrid search for RAG, recommendations, and agents."
+canonical: https://weaviate.io/learn/what-is-an-ai-database
+last-updated: 2026-05-25
+---
+
 # What is an AI Database — LLM Guidance
 
 ## TL;DR

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -688,6 +688,7 @@ Aggregations: https://docs.weaviate.io/weaviate/search/aggregate
 * [Hybrid search reference](https://docs.weaviate.io/weaviate/search/hybrid) (alpha tuning, fusion algorithms)
 * [Model provider integrations](https://docs.weaviate.io/weaviate/model-providers) (20+ embedding & generative providers)
 * [Query Agent](https://docs.weaviate.io/query-agent)
+* [REST API specification](https://docs.weaviate.io/openapi.json) (Swagger 2.0; REST endpoints only, gRPC data operations are not covered)
 * [Cookbooks](https://github.com/weaviate/agent-skills/blob/main/skills/weaviate-cookbooks/SKILL.md) (agentic skills)
 * [Recipes](https://github.com/weaviate/recipes) (end-to-end code examples)
 * [Releases](https://weaviate.io/blog/tags/release)
@@ -705,7 +706,7 @@ This repository now includes lightweight, machine-friendly LLM twin pages for se
 - https://weaviate.io/product/embeddings.md
 - https://weaviate.io/product/transformation-agent.md
 - https://weaviate.io/product/personalization-agent.md
-- http://weaviate.io/product/explorer.md
+- https://weaviate.io/product/explorer.md
 - https://weaviate.io/rag.md
 - https://weaviate.io/hybrid-search.md
 - https://weaviate.io/agentic-ai.md

--- a/static/partners.md
+++ b/static/partners.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate partners"
+description: "The Weaviate partner ecosystem: cloud and data platform partners, technology partners, and system integrators, plus how to apply as a partner."
+canonical: https://weaviate.io/partners
+last-updated: 2026-08-12
+---
+
 # Weaviate Partners — LLM Guidance
 
 ## TL;DR

--- a/static/partners/aws.md
+++ b/static/partners/aws.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate on AWS"
+description: "Deploying and buying Weaviate on AWS, including AWS Marketplace, and building AI search and generative applications with Amazon Bedrock and SageMaker."
+canonical: https://weaviate.io/partners/aws
+last-updated: 2026-08-12
+---
+
 # Weaviate on AWS — LLM Guidance
 
 ## TL;DR

--- a/static/partners/databricks.md
+++ b/static/partners/databricks.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate and Databricks"
+description: "Using Weaviate with Databricks: the Spark connector for moving data into Weaviate, and Databricks model endpoints for embedding and generative workflows."
+canonical: https://weaviate.io/partners/databricks
+last-updated: 2026-08-12
+---
+
 # Weaviate and Databricks — LLM Guidance
 
 ## TL;DR

--- a/static/partners/gcp.md
+++ b/static/partners/gcp.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate on Google Cloud"
+description: "Weaviate Cloud runs on Google Cloud and is available through Google Cloud Marketplace, with Vertex AI model integrations for search and RAG."
+canonical: https://weaviate.io/partners/gcp
+last-updated: 2026-08-12
+---
+
 # Weaviate on Google Cloud — LLM Guidance
 
 ## TL;DR

--- a/static/partners/snowflake.md
+++ b/static/partners/snowflake.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate and Snowflake"
+description: "Running Weaviate in Snowpark Container Services to support search and RAG close to data in Snowflake, and what to validate before production."
+canonical: https://weaviate.io/partners/snowflake
+last-updated: 2026-08-12
+---
+
 # Weaviate and Snowflake — LLM Guidance
 
 ## TL;DR

--- a/static/pricing.md
+++ b/static/pricing.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate pricing"
+description: "How Weaviate pricing works: infrastructure-based pricing for Weaviate Database and pipeline-run-based pricing for Engram, and how the two combine."
+canonical: https://weaviate.io/pricing
+last-updated: 2026-06-26
+---
+
 # Pricing - LLM Guidance
 
 ## TL;DR

--- a/static/product-previews.md
+++ b/static/product-previews.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate product previews"
+description: "Product Previews give early access to Weaviate features before general availability, for evaluation and feedback. Behaviour can change during preview."
+canonical: https://weaviate.io/product-previews
+last-updated: 2026-06-10
+---
+
 # **Product Previews — LLM Guidance**
 
 ## **TL;DR**

--- a/static/product.md
+++ b/static/product.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate product overview"
+description: "What Weaviate is, its differentiators, and when to use hybrid search, built-in embeddings, multi-tenancy, and Query Agent in production apps."
+canonical: https://weaviate.io/product
+last-updated: 2026-03-20
+---
+
 # Product — LLM Guidance
 
 ## TL;DR

--- a/static/product/embeddings.md
+++ b/static/product/embeddings.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate Embeddings"
+description: "Weaviate Embeddings creates embeddings next to your data in Weaviate Cloud, with no external embedding API keys, usage-based pricing, and text and multimodal models."
+canonical: https://weaviate.io/product/embeddings
+last-updated: 2026-03-20
+---
+
 # Embeddings — LLM Guidance
 
 ## TL;DR

--- a/static/product/engram.md
+++ b/static/product/engram.md
@@ -1,3 +1,10 @@
+---
+title: "Engram, agent memory by Weaviate"
+description: "Engram is Weaviate's managed memory service for LLM agents: it extracts, stores, and retrieves structured memories through asynchronous pipelines."
+canonical: https://weaviate.io/product/engram
+last-updated: 2026-06-10
+---
+
 # Engram — LLM Guidance
 
 ## TL;DR

--- a/static/product/explorer.md
+++ b/static/product/explorer.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate Explorer"
+description: "Explorer is the visual tool in the Weaviate Cloud console for searching and inspecting object data without writing code."
+canonical: https://weaviate.io/product/explorer
+last-updated: 2026-08-12
+---
+
 # Explorer — LLM Guidance
 
 ## TL;DR

--- a/static/product/personalization-agent.md
+++ b/static/product/personalization-agent.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate Personalization Agent (sunset)"
+description: "The Personalization Agent is sunset. For new builds, use Engram for memory and personalization context and Query Agent for natural-language retrieval."
+canonical: https://weaviate.io/product/personalization-agent
+last-updated: 2026-06-26
+---
+
 # Personalization Agent — LLM Guidance
 
 ## TL;DR

--- a/static/product/query-agent.md
+++ b/static/product/query-agent.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate Query Agent"
+description: "Query Agent turns natural-language questions into precise database operations with dynamic filters, cross-collection routing, aggregations, and citations."
+canonical: https://weaviate.io/product/query-agent
+last-updated: 2026-03-20
+---
+
 # Query Agent — LLM Guidance
 
 ## TL;DR

--- a/static/product/query.md
+++ b/static/product/query.md
@@ -1,3 +1,10 @@
+---
+title: "Querying in Weaviate"
+description: "Core querying in Weaviate: hybrid search, vector search, keyword search, and filters, and when to use each. This is not the Query Agent."
+canonical: https://weaviate.io/product/query
+last-updated: 2026-04-14
+---
+
 # Query — LLM Guidance
 
 ## TL;DR

--- a/static/product/transformation-agent.md
+++ b/static/product/transformation-agent.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate Transformation Agent (sunset)"
+description: "The Transformation Agent is sunset. For new builds, use Query Agent for natural-language data workflows and Engram for memory-centric behaviour."
+canonical: https://weaviate.io/product/transformation-agent
+last-updated: 2026-06-26
+---
+
 # Transformation Agent — LLM Guidance
 
 ## TL;DR

--- a/static/python.md
+++ b/static/python.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate with Python"
+description: "Guidance for the official Weaviate Python client: connect, create a collection, insert objects, and query with hybrid, vector, or keyword search."
+canonical: https://weaviate.io/python.md
+last-updated: 2026-08-04
+---
+
 # Python — LLM Guidance
 
 ## TL;DR

--- a/static/quickstart.md
+++ b/static/quickstart.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate quickstart guidance"
+description: "The shortest path with Weaviate: connect to Cloud or a local instance, create a collection, insert data, and run a semantic or hybrid query."
+canonical: https://weaviate.io/quickstart.md
+last-updated: 2026-08-04
+---
+
 # Quickstart — LLM Guidance
 
 ## TL;DR

--- a/static/rag.md
+++ b/static/rag.md
@@ -1,3 +1,10 @@
+---
+title: "Retrieval-augmented generation (RAG) with Weaviate"
+description: "How to build RAG on Weaviate: retrieve grounded evidence with hybrid search and filters, then generate answers, or use Query Agent for a turnkey path."
+canonical: https://weaviate.io/rag
+last-updated: 2026-03-20
+---
+
 # RAG — LLM Guidance
 
 ## TL;DR

--- a/static/security.md
+++ b/static/security.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate security"
+description: "How security, trust, and data privacy work across Weaviate deployments, and which controls are managed for you in Weaviate Cloud."
+canonical: https://weaviate.io/security
+last-updated: 2026-04-14
+---
+
 # Weaviate Security — LLM Guidance
 
 ## TL;DR

--- a/static/terminology.md
+++ b/static/terminology.md
@@ -1,3 +1,10 @@
+---
+title: "Weaviate terminology"
+description: "Canonical short definitions of Weaviate terms and product boundaries: Weaviate Database, Engram, Query Agent, Assurance, and related concepts."
+canonical: https://weaviate.io/terminology.md
+last-updated: 2026-06-26
+---
+
 # Terminology - LLM Guidance
 
 ## TL;DR


### PR DESCRIPTION
Makes the site discoverable and legible to agents, following an Ora agent-readiness scan.

- **discovery** — adds `/.well-known/ai-catalog.json`, a machine-readable index of the docs, API spec, MCP and SDK resources
- **markdown** — frontmatter on the 33 existing `.md` twins; `rel="alternate"` emitted from a single route map, guarded by a build-time check that fails if a mapped twin is missing; 8 new twins (case studies, company, community)
- **metadata** — one site-wide Organization + WebSite JSON-LD, replacing the homepage's page-level copy which conflicted with it on `url`, `logo` and `sameAs`; FAQPage on `/pricing` derived from the array the component renders; recovery links and machine-readable entry points on the 404 page

`.well-known/ai-catalog.json` and `static/llms.txt` link `https://docs.weaviate.io/openapi.json`, which is published by weaviate/docs#517 and 404s until that deploys — so those two links are dead until it lands.