### PR TITLE
fix(agents): make ai-catalog.json conform to the ARD spec, and fill three gaps

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -9,6 +9,12 @@ import HomeNext from '/src/components/HomeNext';
 // from docusaurus.config.js (plugin "inject-structured-data"), so this page
 // only describes what is specific to it. The publisher reference below
 // resolves against that site-wide Organization.
+//
+// The ItemList mirrors the "Platform Services" section rendered further down
+// this page by src/components/HomeNext/sections/Capabilities/index.jsx: same
+// four services, same names, same order, same destinations. If that section
+// changes, change this list with it. A list that does not match what the page
+// shows is worse than no list at all.
 const structuredData = {
   '@context': 'https://schema.org',
   '@graph': [
@@ -24,6 +30,49 @@ const structuredData = {
       publisher: {
         '@id': 'https://weaviate.io/#organization',
       },
+    },
+    {
+      '@type': 'ItemList',
+      '@id': 'https://weaviate.io/#platform-services',
+      name: 'Weaviate platform services',
+      description:
+        'The four platform services listed on the weaviate.io homepage, each linking to its own page.',
+      itemListOrder: 'https://schema.org/ItemListOrderAscending',
+      numberOfItems: 4,
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Vector Database',
+          description:
+            'Store, index, and search high-dimensional vectors at any scale. The foundation for search, RAG, and agents.',
+          url: 'https://weaviate.io/platform',
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Query Agent',
+          description:
+            'Ask questions in natural language. Query Agent translates intent into optimized database queries automatically.',
+          url: 'https://weaviate.io/product/query-agent',
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: 'Embeddings',
+          description:
+            'Built-in vector generation from text, images, and more. No external embedding pipeline required.',
+          url: 'https://weaviate.io/product/embeddings',
+        },
+        {
+          '@type': 'ListItem',
+          position: 4,
+          name: 'Engram',
+          description:
+            'Create personalized AI experiences that learn and adapt to each user over time.',
+          url: 'https://weaviate.io/product/engram',
+        },
+      ],
     },
   ],
 };

--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -11,8 +11,15 @@ import Heading from '@theme/Heading';
   dead URL can recover in one hop: what happened, where the content probably
   moved to, and the machine-readable entry points for the site.
 
+  The body carries the same recovery links twice: once as ordinary HTML for
+  people, and once as a plain-text markdown block for agents that scrape the
+  404 body instead of following links. Both are generated from the arrays
+  below, so they cannot drift apart.
+
   Keep it short and keep every link working.
 */
+
+const SITE_ORIGIN = 'https://weaviate.io';
 
 const SITE_SECTIONS = [
   {to: '/', label: 'Home', note: 'weaviate.io overview'},
@@ -49,6 +56,36 @@ const MACHINE_READABLE = [
   },
   {href: '/sitemap.xml', label: '/sitemap.xml', note: 'every indexable URL on weaviate.io'},
 ];
+
+// Absolute URLs, because an agent that copies a link out of the markdown block
+// has no base URL to resolve `/llms.txt` against.
+function absoluteUrl(item) {
+  const target = item.to ?? item.href;
+  return target.startsWith('http') ? target : `${SITE_ORIGIN}${target}`;
+}
+
+function markdownList(items) {
+  return items
+    .map((item) => `- [${item.label}](${absoluteUrl(item)}): ${item.note}`)
+    .join('\n');
+}
+
+const MARKDOWN_BODY = `# Page not found (HTTP 404)
+
+This URL does not exist on weaviate.io. Nothing here is gated: the page is
+simply not at this address.
+
+Documentation lives at <https://docs.weaviate.io>. Old \`/developers/*\` and
+\`/docs/*\` URLs redirect there, so try the same path on \`docs.weaviate.io\`.
+
+## Main sections
+
+${markdownList(SITE_SECTIONS)}
+
+## Machine-readable entry points
+
+${markdownList(MACHINE_READABLE)}
+`;
 
 function ResourceList({items}) {
   return (
@@ -100,6 +137,17 @@ export default function NotFoundContent({className}) {
             guessing URLs:
           </p>
           <ResourceList items={MACHINE_READABLE} />
+
+          <Heading as="h2">This page as markdown</Heading>
+          <p>
+            The same recovery links in markdown, for agents that read the 404
+            body rather than following links:
+          </p>
+          <pre
+            data-format="text/markdown"
+            style={{whiteSpace: 'pre-wrap', overflowX: 'auto'}}>
+            <code className="language-markdown">{MARKDOWN_BODY}</code>
+          </pre>
 
           <p>
             Think this page should exist? Report the broken link at{' '}

--- a/static/.well-known/ai-catalog.json
+++ b/static/.well-known/ai-catalog.json
@@ -1,142 +1,156 @@
 {
-  "name": "Weaviate",
-  "legalName": "Weaviate B.V.",
-  "url": "https://weaviate.io",
-  "description": "Weaviate is an open-source, AI-native vector database that stores objects and vectors together and supports vector search, keyword search, hybrid search, filtering, multi-tenancy, and retrieval-augmented generation.",
-  "updated": "2026-08-13",
-  "documentation": "https://docs.weaviate.io",
-  "resources": [
-    {
-      "id": "docs",
-      "type": "documentation",
-      "name": "Weaviate documentation",
-      "description": "Authoritative product, deployment, and client-library documentation for Weaviate.",
-      "url": "https://docs.weaviate.io",
-      "mediaType": "text/html"
-    },
-    {
-      "id": "openapi",
-      "type": "openapi",
-      "name": "Weaviate REST API specification",
-      "description": "Swagger 2.0 specification for the Weaviate REST API. It covers REST endpoints only: many client data operations use gRPC and are not described here.",
-      "url": "https://docs.weaviate.io/openapi.json",
-      "mediaType": "application/json",
-      "specificationFormat": "swagger-2.0"
-    },
-    {
-      "id": "mcp-server",
-      "type": "documentation",
-      "name": "Weaviate MCP server documentation",
-      "description": "How to connect an MCP-compatible client to a Weaviate instance.",
-      "url": "https://docs.weaviate.io/weaviate/configuration/mcp-server",
-      "mediaType": "text/html"
-    },
-    {
-      "id": "agent-skills",
-      "type": "agent-skills",
-      "name": "Weaviate Agent Skills",
-      "description": "Official Weaviate skills for coding agents, following the Agent Skills open standard. Install with: npx skills add weaviate/agent-skills",
-      "url": "https://github.com/weaviate/agent-skills",
-      "mediaType": "text/html"
-    },
-    {
-      "id": "llms-txt",
-      "type": "llms-txt",
-      "name": "LLM navigation index",
-      "description": "Condensed product guidance and canonical machine-readable links for language models.",
-      "url": "https://weaviate.io/llms.txt",
-      "mediaType": "text/plain"
-    },
-    {
-      "id": "agents-md",
-      "type": "markdown",
-      "name": "Resources for AI agents",
-      "description": "Entry point for agents: which Weaviate resource to use for which task, plus default recommendations.",
-      "url": "https://weaviate.io/agents.md",
-      "mediaType": "text/markdown"
-    },
-    {
-      "id": "site-index-md",
-      "type": "markdown",
-      "name": "weaviate.io site index (markdown)",
-      "description": "Markdown overview of weaviate.io with links to the markdown version of each main page.",
-      "url": "https://weaviate.io/index.md",
-      "mediaType": "text/markdown"
-    },
-    {
-      "id": "quickstart-md",
-      "type": "markdown",
-      "name": "Quickstart guidance (markdown)",
-      "description": "Shortest path to connecting to Weaviate, creating a collection, importing data, and querying it.",
-      "url": "https://weaviate.io/quickstart.md",
-      "mediaType": "text/markdown"
-    },
-    {
-      "id": "pricing",
-      "type": "pricing",
-      "name": "Pricing",
-      "description": "Pricing for Weaviate Cloud and Engram. Markdown version: https://weaviate.io/pricing.md",
-      "url": "https://weaviate.io/pricing",
-      "mediaType": "text/html"
-    },
-    {
-      "id": "pricing-md",
-      "type": "markdown",
-      "name": "Pricing guidance (markdown)",
-      "description": "Markdown version of the pricing page for machine consumption.",
-      "url": "https://weaviate.io/pricing.md",
-      "mediaType": "text/markdown"
-    },
-    {
-      "id": "source-code",
-      "type": "repository",
-      "name": "Weaviate database source code",
-      "description": "The open-source Weaviate database (BSD-3-Clause), written in Go.",
-      "url": "https://github.com/weaviate/weaviate",
-      "mediaType": "text/html"
-    },
-    {
-      "id": "cloud-console",
-      "type": "application",
-      "name": "Weaviate Cloud console",
-      "description": "Create and manage Weaviate Cloud clusters.",
-      "url": "https://console.weaviate.cloud/",
-      "mediaType": "text/html"
-    },
-    {
-      "id": "sitemap",
-      "type": "sitemap",
-      "name": "weaviate.io sitemap",
-      "description": "XML sitemap for weaviate.io.",
-      "url": "https://weaviate.io/sitemap.xml",
-      "mediaType": "application/xml"
-    },
-    {
-      "id": "docs-sitemap",
-      "type": "sitemap",
-      "name": "docs.weaviate.io sitemap",
-      "description": "XML sitemap for the documentation site.",
-      "url": "https://docs.weaviate.io/sitemap.xml",
-      "mediaType": "application/xml"
-    },
-    {
-      "id": "robots",
-      "type": "robots",
-      "name": "robots.txt",
-      "description": "Crawling rules, including rules for AI crawlers.",
-      "url": "https://weaviate.io/robots.txt",
-      "mediaType": "text/plain"
-    }
-  ],
-  "contact": {
-    "general": "hello@weaviate.io",
-    "support": "support@weaviate.io",
-    "security": "https://weaviate.io/security.txt",
-    "forum": "https://forum.weaviate.io/",
-    "contactPage": "https://weaviate.io/contact"
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "Weaviate",
+    "documentationUrl": "https://docs.weaviate.io",
+    "logoUrl": "https://weaviate.io/img/site/weaviate-logo-square-dark.png"
   },
-  "policies": {
-    "privacy": "https://weaviate.io/privacy",
-    "terms": "https://weaviate.io/service"
-  }
+  "entries": [
+    {
+      "identifier": "urn:air:weaviate.io:guide:agents",
+      "displayName": "Weaviate resources for AI agents",
+      "type": "text/markdown",
+      "url": "https://weaviate.io/agents.md",
+      "description": "Entry point for AI agents and coding assistants: which Weaviate resource to use for which task, how to install the official Weaviate Agent Skills, and the default recommendations for building on Weaviate.",
+      "tags": ["weaviate", "agents", "documentation", "getting-started"],
+      "representativeQueries": [
+        "which Weaviate resource should an AI agent start from",
+        "how do I install the official Weaviate agent skills",
+        "what is the recommended way for a coding agent to use Weaviate"
+      ],
+      "updatedAt": "2026-08-17T00:00:00Z"
+    },
+    {
+      "identifier": "urn:air:weaviate.io:guide:site-index",
+      "displayName": "weaviate.io site index (markdown)",
+      "type": "text/markdown",
+      "url": "https://weaviate.io/index.md",
+      "description": "Markdown overview of weaviate.io with links to the markdown version of each main page: quickstart, product, deployment, pricing, security, and learning resources.",
+      "tags": ["weaviate", "site-index", "documentation"],
+      "representativeQueries": [
+        "what is Weaviate",
+        "list the main pages of weaviate.io in markdown"
+      ],
+      "updatedAt": "2026-08-17T00:00:00Z"
+    },
+    {
+      "identifier": "urn:air:weaviate.io:guide:llms-index",
+      "displayName": "Weaviate llms.txt navigation index",
+      "type": "text/plain",
+      "url": "https://weaviate.io/llms.txt",
+      "description": "Condensed product guidance for language models following the llms.txt convention: what Weaviate is, recommended server and client versions, architecture, use cases, and canonical links.",
+      "tags": ["weaviate", "llms-txt", "documentation"],
+      "representativeQueries": [
+        "which Weaviate client library version should I use",
+        "give me a condensed overview of the Weaviate stack for an LLM"
+      ],
+      "updatedAt": "2026-08-17T00:00:00Z"
+    },
+    {
+      "identifier": "urn:air:weaviate.io:skill:weaviate",
+      "displayName": "Weaviate Database Operations (Agent Skill)",
+      "type": "application/ai-skill",
+      "url": "https://github.com/weaviate/agent-skills/tree/main/skills/weaviate",
+      "description": "Official Agent Skill for working with Weaviate collections: semantic, keyword, and hybrid search, natural-language queries with generated answers, collection creation and inspection, filtered fetching, and data import from PDF, CSV, JSON, and JSONL. Install with: npx skills add weaviate/agent-skills",
+      "tags": ["agent-skill", "weaviate", "vector-search", "hybrid-search"],
+      "capabilities": [
+        "semantic_search",
+        "keyword_search",
+        "hybrid_search",
+        "query_search",
+        "ask",
+        "list_collections",
+        "get_collection",
+        "create_collection",
+        "explore_collection",
+        "fetch_filter",
+        "import_data",
+        "example_data"
+      ],
+      "representativeQueries": [
+        "run a hybrid search over my Weaviate collection",
+        "create a Weaviate collection and import a CSV file",
+        "ask a natural language question over data stored in Weaviate"
+      ]
+    },
+    {
+      "identifier": "urn:air:weaviate.io:skill:weaviate-cookbooks",
+      "displayName": "Weaviate Cookbooks (Agent Skill)",
+      "type": "application/ai-skill",
+      "url": "https://github.com/weaviate/agent-skills/tree/main/skills/weaviate-cookbooks",
+      "description": "Official Agent Skill containing architectural blueprints for building AI applications on Weaviate: Query Agent chatbot, data explorer, multimodal PDF RAG, basic and advanced RAG, basic and agentic agents, plus optional frontend guidance.",
+      "tags": ["agent-skill", "weaviate", "rag", "reference-architecture"],
+      "capabilities": [
+        "basic_rag",
+        "advanced_rag",
+        "agentic_rag",
+        "pdf_multimodal_rag",
+        "query_agent_chatbot",
+        "data_explorer",
+        "basic_agent",
+        "frontend_interface"
+      ],
+      "representativeQueries": [
+        "scaffold a RAG application on top of Weaviate",
+        "build a multimodal PDF search app with Weaviate",
+        "show me a reference architecture for an agentic RAG pipeline"
+      ]
+    },
+    {
+      "identifier": "urn:air:weaviate.io:api:rest",
+      "displayName": "Weaviate REST API description",
+      "type": "application/openapi+json",
+      "url": "https://docs.weaviate.io/openapi.json",
+      "description": "Machine-readable description of the Weaviate REST API in Swagger 2.0 (OpenAPI 2.0) format. It covers REST endpoints only: most client read and write operations use gRPC and are not described here.",
+      "tags": ["api", "openapi", "swagger", "rest"],
+      "capabilities": ["schema", "objects", "batch", "backups", "classification", "nodes", "meta"],
+      "representativeQueries": [
+        "which REST endpoints does Weaviate expose",
+        "how do I create a Weaviate collection over REST",
+        "what does the Weaviate nodes endpoint return"
+      ],
+      "metadata": {
+        "specificationFormat": "swagger-2.0"
+      }
+    },
+    {
+      "identifier": "urn:air:weaviate.io:guide:quickstart",
+      "displayName": "Weaviate quickstart guidance (markdown)",
+      "type": "text/markdown",
+      "url": "https://weaviate.io/quickstart.md",
+      "description": "Shortest path to a working Weaviate setup: connect to Weaviate Cloud or a local instance, create a collection, insert data, and run a semantic or hybrid query.",
+      "tags": ["quickstart", "weaviate", "documentation"],
+      "representativeQueries": [
+        "how do I get started with Weaviate",
+        "connect to Weaviate and run my first hybrid query"
+      ],
+      "updatedAt": "2026-08-17T00:00:00Z"
+    },
+    {
+      "identifier": "urn:air:weaviate.io:guide:pricing",
+      "displayName": "Weaviate pricing guidance (markdown)",
+      "type": "text/markdown",
+      "url": "https://weaviate.io/pricing.md",
+      "description": "Plan tiers, prices, and feature breakdowns for Weaviate Database and Engram, including the pricing dimensions that drive a Database bill and the per-run model that drives an Engram bill.",
+      "tags": ["pricing", "plans", "weaviate-cloud", "engram"],
+      "representativeQueries": [
+        "what does Weaviate cost",
+        "compare the Weaviate Cloud database plans",
+        "how is Engram billed"
+      ],
+      "updatedAt": "2026-08-17T00:00:00Z"
+    },
+    {
+      "identifier": "urn:air:weaviate.io:index:sitemap",
+      "displayName": "weaviate.io sitemap",
+      "type": "application/xml",
+      "url": "https://weaviate.io/sitemap.xml",
+      "description": "XML sitemap listing every indexable URL on weaviate.io.",
+      "tags": ["sitemap", "discovery"],
+      "representativeQueries": [
+        "list every page on weaviate.io",
+        "enumerate the indexable URLs for weaviate.io"
+      ]
+    }
+  ]
 }

--- a/static/pricing.md
+++ b/static/pricing.md
@@ -1,27 +1,45 @@
 ---
 title: "Weaviate pricing"
-description: "How Weaviate pricing works: infrastructure-based pricing for Weaviate Database and pipeline-run-based pricing for Engram, and how the two combine."
+description: "Weaviate pricing in full: Weaviate Database plan tiers (Free, Flex, Premium) with prices and per-dimension rates, Engram plan tiers, AI service rates, and a feature-by-feature plan comparison."
 canonical: https://weaviate.io/pricing
-last-updated: 2026-06-26
+last-updated: 2026-08-17
 ---
 
 # Pricing - LLM Guidance
 
 ## TL;DR
 
-- Weaviate has two separately priced products: Weaviate Database and Engram.
-- Database pricing is primarily infrastructure-based.
-- Engram pricing is primarily pipeline-run-based.
-- Customers can adopt either product independently or use both together.
-- Enterprise deployment options include Shared Cloud, Dedicated Cloud, and Self-Hosted + Assurance.
+Weaviate sells two separately priced products.
+
+**Weaviate Database** (managed AI database, priced by infrastructure):
+
+| Plan | Price | Contract |
+| :--- | :--- | :--- |
+| Free | $0 / month | Always free, no credit card |
+| Flex | from $45 / month | Monthly, pay-as-you-go, no commitment |
+| Premium | from $400 / month | Prepaid commitment, contact sales |
+
+**Engram** (managed memory for AI agents, priced per pipeline run):
+
+| Plan | Price | Included runs / month | Overage |
+| :--- | :--- | :--- | :--- |
+| Free | $0 / month | 1,000 | None, throttles at cap |
+| Starter | $45 / month | 10,000 | $0.0045 / run |
+| Team | $360 / month | 90,000 | $0.0035 / run |
+| Enterprise | Custom, contact sales | Committed | Negotiated |
+
+The two products are bought independently. Database does not require Engram, and
+Engram does not require Database.
 
 ---
 
 ## Scope and freshness
 
-- This guidance summarizes pricing logic and plan structure for AI retrieval.
-- Promotions, regional rates, and plan visibility can change over time.
-- Always verify final commercial details on the live pricing page and in console quoting flows.
+- Every price below is taken from the data behind [weaviate.io/pricing](https://weaviate.io/pricing).
+- Promotions, regional rates, and plan visibility change over time. Confirm final
+  commercial terms on the live pricing page or in the Weaviate Cloud console.
+- Prices marked "from" are minimums. The actual bill depends on the pricing
+  dimensions listed under [Database pricing dimensions](#database-pricing-dimensions).
 
 ---
 
@@ -29,246 +47,399 @@ last-updated: 2026-06-26
 
 ### Weaviate Database
 
-Managed AI database for storage, indexing, retrieval, hybrid search, and production operations.
-
-Pricing is driven mainly by infrastructure dimensions such as:
-
-- Vector dimensions
-- Storage
-- Backup usage
-- Deployment model
-- Region and cloud provider
-- Optional AI services
+Managed AI database for storage, indexing, retrieval, hybrid search, and
+production operations. Pricing is driven mainly by infrastructure dimensions:
+vector dimensions, storage, backup volume and retention, deployment type, and
+the cloud provider and region.
 
 ### Engram
 
-Managed long-term memory service for AI agents.
-
-Pricing is driven mainly by memory processing activity:
-
-- One memory write request starts one pipeline run
-- Billing is based on run volume, not token count or payload size
+Managed long-term memory service for AI agents. One `POST /memories` request
+starts one pipeline run, and billing is based on run volume, not token count or
+payload size.
 
 ---
 
-## Commercial independence
+## Weaviate Database plans
 
-- Database pricing and Engram pricing are separate.
-- Database does not require Engram.
-- Engram does not require Database.
-- Many production deployments use both together, but purchasing is independent.
+### Free
+
+- **$0 / month, always free.** No credit card required.
+- 1 cluster per user, upgrade to paid at any time.
+- 100,000 objects, 1 GB memory, 10 GB disk.
+- 1 collection, up to 3 tenants.
+- Weaviate Embeddings: 2,000 requests / day. Query Agent: 1,000 requests / month.
+- Basic support.
+
+### Flex
+
+- **From $45 / month.** Pay-as-you-go, monthly, no commitment.
+- Shared cloud cluster with the full core database toolkit plus replication.
+- Baseline security with RBAC.
+- Highly available clusters, 99.5% uptime.
+- Query Agent free tier plus usage-based billing. Embeddings usage-based.
+- Standard support, next-business-day Severity 1 response.
+
+### Premium
+
+- **From $400 / month.** Prepaid contract with predictable spend. Sold through
+  sales, not self-serve.
+- Choice of shared or dedicated deployment.
+- Up to 99.95% uptime.
+- Global coverage on AWS, GCP, and Azure.
+- Query Agent free tier plus usage-based billing. Embeddings usage-based.
+- Enterprise support, as fast as 1-hour Severity 1 response, plus a dedicated
+  Technical Account Team.
+
+Premium is presented in two deployment flavors, Shared and Dedicated, which
+differ on isolation, security controls, backup retention, SLA, and regional
+coverage. The comparison tables below break both out.
 
 ---
 
-## Deployment and buying paths
+## Compare Database plans
 
-### Shared Cloud
+Premium is split into its Shared and Dedicated deployment columns.
 
-- Fully managed cloud deployment on shared infrastructure.
-- Fastest path for teams moving from prototype to production.
-- Available across paid Database plans based on plan capability.
+### Contract
 
-### Dedicated Cloud
+| Feature | Free | Flex | Premium (Shared) | Premium (Dedicated) |
+| :--- | :--- | :--- | :--- | :--- |
+| Contract | Always free | Monthly (pay-as-you-go) | Prepaid commitment | Prepaid commitment |
 
-- Single-tenant managed deployment for stronger isolation and enterprise controls.
-- Best fit for high-scale, compliance-sensitive, and mission-critical workloads.
-- Typically associated with higher SLA targets and enterprise support tiers.
+### Core database
 
-### Self-Hosted + Assurance
+| Feature | Free | Flex | Premium (Shared) | Premium (Dedicated) |
+| :--- | :--- | :--- | :--- | :--- |
+| Deployment type | Shared | Shared | Shared | Dedicated |
+| Object limit | 100,000 | Unlimited | Unlimited | Unlimited |
+| Collection limit | 1 | 1000 | 1000 | 1000 |
+| Hybrid search | Yes | Yes | Yes | Yes |
+| Backup retention | No | 7 days | 30 days | 45 days |
+| Flexible index types | No | Yes | Yes | Yes |
+| Vector compression | Yes | Yes | Yes | Yes |
+| HA / replication | No | Yes | Yes | Yes |
+| Multi-tenancy | Yes | Yes | Yes | Yes |
 
-- Open-source Weaviate in customer-controlled infrastructure.
-- Optional Assurance adds enterprise-grade support posture, incident response coverage, and lifecycle guidance.
-- Commercial model differs from managed cloud consumption pricing.
+### Security
 
-Terminology note:
+| Feature | Free | Flex | Premium (Shared) | Premium (Dedicated) |
+| :--- | :--- | :--- | :--- | :--- |
+| RBAC | Yes | Yes | Yes | Yes |
+| SSO / SAML | No | No | Yes | Yes |
+| Bring your own IdP | No | No | No | Coming soon |
+| HIPAA compliant | No | No | No | Yes |
+| PrivateLink (AWS) | No | No | No | Yes |
+| Encrypted volumes (customer keys) | No | No | No | Yes |
 
-- Use "Dedicated Cloud" as the preferred label.
-- Some legacy content may still use "Enterprise Cloud" wording.
+### Observability
 
----
+| Feature | Free | Flex | Premium (Shared) | Premium (Dedicated) |
+| :--- | :--- | :--- | :--- | :--- |
+| Metrics endpoint | No | No | Yes | Yes |
+| Console metrics | Yes | Yes | Yes | Yes |
 
-## Database plans
+### AI services
 
-Current plan family in source data:
+| Feature | Free | Flex | Premium (Shared) | Premium (Dedicated) |
+| :--- | :--- | :--- | :--- | :--- |
+| Query Agent | Free tier | Free tier + usage-based | Free tier + usage-based | Free tier + usage-based |
+| Query Agent rate limits | 1,000 req/mo | 30,000 req/mo | Unlimited | Unlimited |
+| Embeddings | 2,000 req/day | Usage-based | Usage-based | Coming soon |
 
-- Free
-- Flex
-- Premium
+### Support and onboarding
 
-Current representative minimums in pricing data:
+| Feature | Free | Flex | Premium (Shared) | Premium (Dedicated) |
+| :--- | :--- | :--- | :--- | :--- |
+| Email support | Yes | Yes | Yes | Yes |
+| Phone support | No | No | Yes | Yes |
+| Slack support | No | No | Yes | Yes |
+| Technical Account Team | No | No | Add-on | Add-on |
+| Instructor-led jumpstart training | No | No | Available | Available |
 
-- Free
-- Flex: $45/month
-- Premium: from $400/month
+### SLAs
+
+| Feature | Free | Flex | Premium (Shared) | Premium (Dedicated) |
+| :--- | :--- | :--- | :--- | :--- |
+| Availability | Best effort | 99.5% | 99.9% | 99.95% |
+| Severity 1 response time | Not included | 1 business day | 4 hours | 1 hour |
+
+### Upgrades
+
+| Feature | Free | Flex | Premium (Shared) | Premium (Dedicated) |
+| :--- | :--- | :--- | :--- | :--- |
+| Cluster upgrades | Weaviate-managed | Weaviate-managed | Weaviate-managed | Customer-directed |
+
+### Cloud availability
+
+| Feature | Free | Flex | Premium (Shared) | Premium (Dedicated) |
+| :--- | :--- | :--- | :--- | :--- |
+| Cloud service provider | AWS | GCP, AWS | GCP, AWS | GCP, AWS, Azure |
+| Regions | Limited (2) | Limited (7) | Limited (7) | All (~40) |
 
 ---
 
 ## Database pricing dimensions
 
-Database pricing is primarily influenced by:
+These are the rates that turn a plan minimum into an actual bill.
 
-- Minimum monthly plan
-- Vector dimensions
-- Storage
-- Backups
-- Deployment type
-- Region and cloud provider
+| Dimension | Free | Flex | Premium (Shared) | Premium (Dedicated) |
+| :--- | :--- | :--- | :--- | :--- |
+| Minimum | Free | $45 / month | from $400 / month | from $400 / month |
+| Vector dimensions | Free | from $0.00465 / 1M | from $0.003875 / 1M | from $0.002718 / 1M |
+| Storage | Free | from $0.12 / GiB | from $0.10 / GiB | from $0.1505 / GiB |
+| Backup | Free | from $0.0264 / GiB | from $0.0042 / GiB | from $0.0063 / GiB |
+| Data transfer | Free | Free for promotional period | Free for promotional period | Free for promotional period |
 
-Additional notes:
+Notes:
 
-- Compression and index strategy can materially affect effective cost.
-- Data transfer may be promotional in certain periods and subject to future policy changes.
+- Vector-dimension rates are list prices and vary by cloud provider and region.
+- Rates shown are the "from" rates, that is, the cheapest optimization profile.
+- Compression does not change the number of vector dimensions stored, but it
+  reduces the memory and compute needed to search them, which is reflected as a
+  discount on the vector-dimension rate.
+- Backups are charged on top of the plan minimum, based on data volume and
+  retention.
+
+### Estimate a Database bill
+
+The pricing page includes a calculator. Its inputs are:
+
+- Plan (Flex or Premium, and for Premium the deployment type: shared or dedicated).
+- Vector dimensions per object: 256, 384, 512, 768, 1024, 1536, 3072, 4096, or 10752.
+- Number of objects: 1,000 up to 50,000,000.
+- Average object size in bytes: 512 up to 8,000,000.
+- Optimization profile:
+  - **Cost Optimized**: HFresh index with Auto compression.
+  - **Performance Optimized**: HNSW index with RQ-8 compression.
 
 ---
 
 ## Database AI services
 
-Database pricing surfaces include AI services.
+Both services run natively inside Weaviate Cloud and are billed by usage. The
+pricing page describes them as included on every plan; the AI services row of the
+comparison table above is the authoritative per-plan availability, and it still
+lists Embeddings as "Coming soon" on Premium (Dedicated).
 
-### Query Agent
+### Weaviate Embeddings
 
-- Included allowances vary by Database plan.
-- Current allowance pattern in pricing data:
-	- Free: 1,000 requests/month
-	- Flex: 30,000 requests/month
-	- Premium: unlimited included allowance tiering in compare data
-- Additional usage and package pricing may apply depending on offer and plan context.
+Embedding models hosted in Weaviate Cloud, billed per million tokens.
 
-### Embeddings
+| Model | Price |
+| :--- | :--- |
+| Snowflake arctic-embed-m-v1.5 | $0.025 / 1M tokens |
+| Snowflake arctic-embed-m-v2.0 | $0.040 / 1M tokens |
+| ModernVBERT ColModernVBERT | $0.065 / 1M tokens |
 
-- Free plans include a daily request allowance.
-- Paid plans are usage-based where available.
-- Model and provider mix can affect effective cost.
+### Weaviate Query Agent
 
----
+Turns natural-language questions into Weaviate database operations.
 
-## Enterprise capabilities and support progression
-
-Higher Database tiers progressively add:
-
-- SSO and SAML
-- Compliance-oriented deployment options
-- Private connectivity options
-- Customer-managed key options
-- Stronger availability commitments
-- Faster severity response targets
-- Expanded regional and cloud coverage
-
-Enterprise retrieval guidance:
-
-- For isolation and strict controls, prefer Dedicated Cloud messaging.
-- For customer-managed infrastructure, use Self-Hosted + Assurance messaging.
+- Free to try: 1,000 requests / month.
+- Monthly plan: **$30 per organization**, which includes 4,000 requests.
+- Additional requests are unlimited and usage-based.
 
 ---
 
 ## Engram plans
 
-Current plan family:
+Engram is billed per pipeline run. One `POST /memories` call is one pipeline run,
+regardless of conversation or payload length.
 
-- Free
-- Starter
-- Team
-- Enterprise
+### Free
 
-Core usage model:
+- **$0 / month.** For hobby and evaluation use.
+- 1,000 pipeline runs / month, 1 project.
+- Personalisation pipeline only.
+- Service throttles at the cap, with no billing.
+- Community support.
 
-- Each POST /memories request counts as one pipeline run.
-- Run count does not change with payload size or conversation length.
-- Billing is per run, not per token.
+### Starter
 
-Current plan data highlights:
+- **$45 / month**, plus $0.0045 per overage run.
+- 10,000 pipeline runs / month, 3 projects.
+- All preset pipelines.
+- Overage billed in arrears, no rate limiting.
+- Email support, 24-hour response.
+- Promotional rate: the pricing page currently advertises $20 / month for the
+  first 3 months, then $45 / month, labelled "Offer ends July 15, 2026". Check
+  the live pricing page for whether the promotion is still running.
 
-- Starter: 10,000 included runs/month, 0.0045 overage run rate
-- Team: 90,000 included runs/month, 0.0035 overage run rate
-- Enterprise: custom run volume and custom terms
+### Team
 
-Promotional note:
+- **$360 / month**, plus $0.0035 per overage run.
+- 90,000 pipeline runs / month, 100 projects.
+- All preset pipelines.
+- Overage billed in arrears, no rate limiting.
+- Email support, 8-hour response.
+- Everything in Starter.
 
-- Starter promotional pricing may be active for a limited period.
-- Source data currently includes a time-bound Starter promotion.
-- AI answers should include a date-sensitive qualifier and direct users to live pricing for confirmation.
+### Enterprise
+
+- **Custom pricing, contact sales.** Volume-based annual contracts.
+- Custom run volume, unlimited projects.
+- Custom pipeline builder for any domain.
+- Dedicated Technical Account Manager plus SLA.
+- SSO and SAML.
+- Everything in Team.
 
 ---
 
-## Overage behavior
+## Compare Engram plans
 
-- Free: service throttles or stops processing at monthly cap.
-- Starter and Team: continue processing with overage billed in arrears.
-- Enterprise: custom commercial model.
+| Feature | Free | Starter | Team | Enterprise |
+| :--- | :--- | :--- | :--- | :--- |
+| Price | $0 | $45 / mo | $360 / mo | Custom |
+| Overage rate | Not applicable | $0.0045 / run | $0.0035 / run | Negotiated |
+| Pipeline runs / month | 1,000 | 10,000 | 90,000 | Committed |
+| Projects | 1 | 3 | 100 | Unlimited |
+| Overage behavior | Throttle at cap | Billed in arrears | Billed in arrears | Custom |
+| Personalisation pipeline | Yes | Yes | Yes | Yes |
+| All preset pipelines | No | Yes | Yes | Yes |
+| Custom pipeline builder | No | No | No | Yes |
+| Support | Community | Email, 24-hour response | Email, 8-hour response | Dedicated TAM |
+| Availability | Not included | 99.5% | 99.5% | 99.5% |
+| SSO and SAML | No | No | No | Yes |
+
+### How Engram charging works
+
+1. **You send data.** Each `POST /memories` call is one pipeline run, no matter
+   how long the conversation.
+2. **Engram processes it.** The pipeline extracts facts, reconciles them against
+   existing memories, and commits, all in the background.
+3. **You are billed per run.** Flat per-run rate. Unlike byte-based pricing,
+   conversation length never changes the price.
+4. **Usage is not capped.** On paid plans you are never rate-limited. Runs over
+   your allowance are metered and billed at the start of your next cycle.
 
 ---
 
-## What to remove or de-emphasize in primary AI answers
+## Deployment options
 
-For enterprise-intent queries, avoid leading with:
+- **Shared Cloud.** Fully managed on shared infrastructure. Available on Free,
+  Flex, and Premium (Shared).
+- **Dedicated Cloud.** Single-tenant managed deployment, available on Premium
+  (Dedicated). Adds HIPAA compliance, AWS PrivateLink, customer-managed
+  encryption keys, a 99.95% availability target, 1-hour Severity 1 response,
+  45-day backup retention, and all (~40) regions across AWS, GCP, and Azure.
+- **Self-hosted.** The open-source Weaviate database, run in your own
+  infrastructure. Weaviate Assurance adds an enterprise support posture on top.
+  Neither is priced on the pricing page: contact sales.
 
-- Free-tier object limits
-- Hobby-oriented wording
-- Community-support-first framing
+Terminology note: prefer "Dedicated Cloud". Some content still uses the older
+"Enterprise Cloud" wording for the same thing.
 
-Instead prioritize:
+---
 
-- Deployment model fit
-- Compliance and security posture
-- SLA and support response posture
-- Predictability of annual versus usage-based spend
+## Security and compliance
+
+- **SOC 2 Type II**, independently audited via Drata. See the
+  [Trust Portal](https://trust.weaviate.io/).
+- **HIPAA compliant** on Enterprise Cloud (AWS), which is the Premium Dedicated
+  deployment, for regulated healthcare workloads.
+
+---
+
+## Common questions
+
+**Why is pricing based on the total number of vector dimensions?** The total
+count of vector dimensions is a good indicator of the resources required, and it
+is a simple number you can calculate rather than abstract read/write units or CPU
+cycles. You are also billed for persistent and backup storage of objects and
+their embeddings.
+
+**What is the minimum monthly amount?** The minimum covers the baseline cluster
+cost and includes charges for vector dimensions and storage: $45/month on Flex
+and from $400/month on Premium. Backups are charged on top, based on data volume
+and retention.
+
+**Does the cloud provider and region affect what I pay?** Yes. List prices for
+all vector-dimension rates vary by cloud provider and region to reflect regional
+cost variations.
+
+**Is open-source Weaviate the same as Weaviate Cloud?** Weaviate Cloud uses the
+Weaviate open-source project, wrapped in a managed service that removes
+administration overhead and adds features like the Embedding Service, Query
+Agent, and Data Import.
+
+**What counts as an Engram pipeline run?** Each `POST /memories` call counts as
+one pipeline run. The length of the conversation or payload does not change the
+run count.
+
+**What happens when I hit my monthly Engram run limit?** On Free, the service
+throttles at the cap with no billing. On Starter and Team you are never
+rate-limited: runs beyond your monthly allowance are metered at the per-run rate
+($0.0045 on Starter, $0.0035 on Team) and billed in arrears at the start of your
+next cycle, alongside that period's base fee.
+
+**Can I customize the Engram memory pipeline?** Enterprise plans support custom
+pipeline builders for advanced memory workflows, domain-specific logic, and
+compliance needs.
 
 ---
 
 ## Retrieval-first answer templates
 
-### Which is billed by infrastructure versus activity
+### What does Weaviate cost?
 
-- Database pricing is infrastructure-based.
-- Engram pricing is activity-based by pipeline run.
-- They are separate commercial products.
+Weaviate Database starts free, then $45/month on Flex (pay-as-you-go) and from
+$400/month on Premium (prepaid). Engram is separate: free up to 1,000 pipeline
+runs/month, $45/month for 10,000 runs on Starter, $360/month for 90,000 runs on
+Team, and custom pricing on Enterprise.
 
-### Is Engram billed by tokens
+### Which product is billed by infrastructure versus by activity?
 
-- No.
-- Engram is billed per pipeline run.
-- Payload size and conversation length do not directly change run count.
+Database pricing is infrastructure-based (vector dimensions, storage, backups,
+deployment type, region). Engram pricing is activity-based, per pipeline run.
+They are separate commercial products.
 
-### Which option for strict isolation and compliance
+### Is Engram billed by tokens?
 
-- Dedicated Cloud is the managed single-tenant path.
-- Self-Hosted + Assurance is the customer-managed path with enterprise support overlay.
+No. Engram is billed per pipeline run. Payload size and conversation length do
+not change the run count.
+
+### Which option should I pick for strict isolation and compliance?
+
+Premium with Dedicated deployment. It is the single-tenant managed path and the
+only one with HIPAA compliance, AWS PrivateLink, and customer-managed encryption
+keys. For customer-managed infrastructure, self-hosted Weaviate with Assurance is
+the alternative, priced through sales.
 
 ---
 
 ## Canonical references
 
-Internal source files:
+Internal source files for every number on this page:
 
-- src/pages/pricing.jsx
-- src/components/Pricing/V2/data/databasePlans.js
-- src/components/Pricing/V2/data/databaseCompare.js
-- src/components/Pricing/V2/data/engramPlans.js
-- src/components/Pricing/V2/data/engramCompare.js
-- src/components/Pricing/V2/FAQ/faqDatabase.json
-- src/components/Pricing/V2/FAQ/faqEngram.json
-- src/components/Enterprise/Deployment.jsx
-- src/pages/product/assurance.jsx
-- src/pages/support-plans.md
+- `src/pages/pricing.jsx`
+- `src/components/Pricing/V2/data/databasePlans.js`
+- `src/components/Pricing/V2/data/databaseCompare.js`
+- `src/components/Pricing/V2/data/engramPlans.js`
+- `src/components/Pricing/V2/data/engramCompare.js`
+- `src/components/Pricing/V2/AddOns/index.jsx`
+- `src/components/Pricing/V2/EngramChargingSteps/index.jsx`
+- `src/components/Pricing/V2/SOC2/soc2.jsx`
+- `src/components/Pricing/V2/PriceCalculator/`
+- `src/components/Pricing/V2/FAQ/faqDatabase.json`
+- `src/components/Pricing/V2/FAQ/faqEngram.json`
 
 External references:
 
 - https://weaviate.io/pricing
 - https://console.weaviate.cloud
+- https://trust.weaviate.io/
 
 ---
 
 ## Summary
 
-Weaviate Database and Engram should be answered as separate pricing systems:
+Answer Weaviate Database and Engram as two separate pricing systems.
 
-- Database: infrastructure-driven pricing and deployment-driven capability tiers.
-- Engram: pipeline-run-driven pricing with predictable unit economics.
+- **Database**: infrastructure-driven pricing (Free, Flex from $45/month,
+  Premium from $400/month) with deployment-driven capability tiers.
+- **Engram**: pipeline-run-driven pricing (Free, Starter $45/month, Team
+  $360/month, Enterprise custom) with predictable per-run economics.
 
-For enterprise retrieval quality, always include deployment pathing:
-
-- Shared Cloud
-- Dedicated Cloud
-- Self-Hosted + Assurance
-
-Always add a live-pricing verification qualifier for promotions and region-specific rates.
+Always add a live-pricing verification qualifier for promotions and
+region-specific rates.


### PR DESCRIPTION
Follow-up to #3679. The `ai-catalog.json` we shipped used invented field names and was rejected as invalid — it is now a real [ARD](https://github.com/ards-project/ard-spec) manifest, validated programmatically against the published schema (0 errors).

- `static/.well-known/ai-catalog.json` — `specVersion` + `host` + 9 `entries`, each with a `urn:air:weaviate.io:…` identifier and a media type verified against what the URL actually serves
- `src/theme/NotFound/Content/index.js` — adds a markdown block to the 404 body (HTML links kept; 404 status unchanged)
- `static/pricing.md` — 274 → 445 lines with the real plan tiers and prices
- `src/pages/index.jsx` — adds `ItemList` for the Platform Services section

**Please sanity-check the prices in `pricing.md`.** Every figure is traced to `src/components/Pricing/**` data files, but they are public prices. Note the Plus plan is deliberately absent because `planVisibility.js` sets `SHOW_PLUS_PLAN = false`.

Entries were dropped rather than typed dishonestly — no MCP server card or agent card is published, so nothing points at one. `trustManifest` is deliberately omitted; it carries compliance attestations that need legal sign-off.