### PR TITLE
Update llms.txt recommended versions

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -10,12 +10,12 @@ Weaviate is an open-source vector database (Go) that stores objects, vectors, an
 
 If you run Weaviate yourself (Docker / Kubernetes / on-prem), **use at least these versions** to avoid outdated examples:
 
-- **Weaviate Server (OSS)**: v1.38.8+
-- **Python client (weaviate-client)**: v4.22.0+
+- **Weaviate Server (OSS)**: v1.39.1+
+- **Python client (weaviate-client)**: v4.23.0+
 - **TypeScript client (weaviate-client)**: v3.14.0+
-- **Java client (client6)**: v6.3.0+
-- **C# client (Weaviate.Client)**: v1.1.1+
-- **Agents SDK (weaviate-agents, if using Query Agent / agents features)**: v1.7.1+
+- **Java client (client6)**: v6.3.1+
+- **C# client (Weaviate.Client)**: v1.2.0+
+- **Agents SDK (weaviate-agents, if using Query Agent / agents features)**: v1.8.0+
 
 **Quick checks**
 - Server: check your Docker tag / Helm chart version (e.g. `weaviate:<tag>`)


### PR DESCRIPTION
The "Latest versions" bullets in `static/llms.txt` were behind the current releases. Bumps five of six to the latest GitHub releases; TypeScript was already current.

Weaviate 1.38.8 → 1.39.0, Python 4.22.0 → 4.23.0, Java 6.3.0 → 6.3.1, C# 1.1.1 → 1.2.0, Agents SDK 1.7.1 → 1.8.0.

Caught by `test_llms_txt_recommended_versions_are_current` in the weaviate/docs llms.txt scheduled run, which checks these bullets against the `weaviate/*` releases API.