### PR TITLE
MD improvements

### DIFF
--- a/src/data/markdownTwins.js
+++ b/src/data/markdownTwins.js
@@ -24,7 +24,7 @@
  *
  * Standalone markdown resources with no HTML page (so no rel=alternate, and
  * they are self-canonical): /agents.md, /quickstart.md, /python.md,
- * /terminology.md, /assurance.md.
+ * /terminology.md, /assurance.md, /auth.md.
  */
 const MARKDOWN_TWINS = {
   '/': '/index.md',

--- a/static/.well-known/ai-catalog.json
+++ b/static/.well-known/ai-catalog.json
@@ -21,6 +21,20 @@
       "updatedAt": "2026-08-17T00:00:00Z"
     },
     {
+      "identifier": "urn:air:weaviate.io:guide:auth",
+      "displayName": "Weaviate authentication guide",
+      "type": "text/markdown",
+      "url": "https://weaviate.io/auth.md",
+      "description": "Machine-readable guidance for Weaviate Cloud API keys, applicable OIDC deployments, RBAC least privilege, credential rotation and revocation, Cloud onboarding, and official SDK installation.",
+      "tags": ["weaviate", "authentication", "authorization", "rbac", "sdk"],
+      "representativeQueries": [
+        "how do I authenticate to Weaviate Cloud",
+        "which Weaviate SDKs are officially maintained",
+        "how do I rotate a Weaviate API key"
+      ],
+      "updatedAt": "2026-08-25T00:00:00Z"
+    },
+    {
       "identifier": "urn:air:weaviate.io:guide:site-index",
       "displayName": "weaviate.io site index (markdown)",
       "type": "text/markdown",
@@ -103,7 +117,15 @@
       "url": "https://docs.weaviate.io/openapi.json",
       "description": "Machine-readable description of the Weaviate REST API in Swagger 2.0 (OpenAPI 2.0) format. It covers REST endpoints only: most client read and write operations use gRPC and are not described here.",
       "tags": ["api", "openapi", "swagger", "rest"],
-      "capabilities": ["schema", "objects", "batch", "backups", "classification", "nodes", "meta"],
+      "capabilities": [
+        "schema",
+        "objects",
+        "batch",
+        "backups",
+        "classification",
+        "nodes",
+        "meta"
+      ],
       "representativeQueries": [
         "which REST endpoints does Weaviate expose",
         "how do I create a Weaviate collection over REST",

--- a/static/agents.md
+++ b/static/agents.md
@@ -2,7 +2,7 @@
 title: "Weaviate resources for AI agents"
 description: "Where an AI agent should start with Weaviate: official Agent Skills, documentation, the MCP server, client libraries, and default recommendations."
 canonical: https://weaviate.io/agents.md
-last-updated: 2026-08-04
+last-updated: 2026-08-25
 ---
 
 # Weaviate resources for AI agents
@@ -27,11 +27,13 @@ The repository also documents installation through the Claude Code Plugin Manage
 - [Weaviate documentation](https://docs.weaviate.io/): authoritative product and API documentation.
 - [Quickstart](https://weaviate.io/quickstart.md): the shortest path to creating and querying a collection.
 - [LLM navigation index](https://weaviate.io/llms.txt): concise product guidance and canonical machine-readable links.
+- [Authentication guide](https://weaviate.io/auth.md): machine-readable authentication, RBAC, credential lifecycle, and SDK installation guidance.
 - [MCP server documentation](https://docs.weaviate.io/weaviate/configuration/mcp-server): connect an MCP-compatible client to a Weaviate instance.
-- [Python client](https://docs.weaviate.io/weaviate/client-libraries/python)
-- [TypeScript client](https://docs.weaviate.io/weaviate/client-libraries/typescript/typescript-v3)
-- [Java client](https://docs.weaviate.io/weaviate/client-libraries/java)
-- [C# client](https://docs.weaviate.io/weaviate/client-libraries/csharp)
+- [Python client documentation](https://docs.weaviate.io/weaviate/client-libraries/python) — [PyPI: `weaviate-client`](https://pypi.org/project/weaviate-client/)
+- [TypeScript client documentation](https://docs.weaviate.io/weaviate/client-libraries/typescript/typescript-v3) — [npm: `weaviate-client`](https://www.npmjs.com/package/weaviate-client)
+- [Go client documentation](https://docs.weaviate.io/weaviate/client-libraries/go) — [Go module: `github.com/weaviate/weaviate-go-client/v5`](https://pkg.go.dev/github.com/weaviate/weaviate-go-client/v5)
+- [Java client documentation](https://docs.weaviate.io/weaviate/client-libraries/java) — [Maven: `io.weaviate:client6`](https://central.sonatype.com/artifact/io.weaviate/client6)
+- [C# client documentation](https://docs.weaviate.io/weaviate/client-libraries/csharp) — [NuGet: `Weaviate.Client`](https://www.nuget.org/packages/Weaviate.Client)
 
 ## Default recommendations
 

--- a/static/auth.md
+++ b/static/auth.md
@@ -1,0 +1,63 @@
+---
+title: "Weaviate authentication"
+description: "Machine-readable authentication, authorization, credential lifecycle, and SDK installation guidance for Weaviate."
+canonical: https://weaviate.io/auth.md
+last-updated: 2026-08-25
+---
+
+# Weaviate authentication
+
+Use this guide with the [official authentication documentation](https://docs.weaviate.io/deploy/configuration/authentication). Do not put credentials in source code, prompts, logs, or committed files.
+
+## Weaviate Cloud
+
+Weaviate Cloud (WCD) clusters are pre-configured for API-key authentication.
+
+1. Open the cluster in the [Weaviate Cloud Console](https://console.weaviate.cloud/).
+2. Open the cluster's API keys section and choose **Create an API key**.
+3. Assign only the RBAC roles required by the application, then copy the key when it is shown.
+
+Store the key in a secret manager or an environment variable. The cluster URL and key are application inputs, not values to infer:
+
+```sh
+export WEAVIATE_URL="https://your-cluster.weaviate.cloud"
+export WEAVIATE_API_KEY="replace-with-a-secret"
+```
+
+The Cloud console supports editing assigned roles, rotating a key (which invalidates the old key), and deleting a key. Use rotation for planned replacement and deletion for immediate revocation. See [Cloud authentication](https://docs.weaviate.io/cloud/manage-clusters/authentication) and [Cloud authorization](https://docs.weaviate.io/cloud/manage-clusters/authorization).
+
+## OIDC
+
+Self-hosted Weaviate supports OpenID Connect (OIDC) when configured with an OpenID Connect Discovery-compatible issuer. API-key and OIDC authentication can be enabled together. Configure OIDC on the deployment using the documented settings in [Authentication: OIDC](https://docs.weaviate.io/deploy/configuration/authentication#oidc-authentication), including the issuer, client ID, username claim, and optional client scopes required by the identity provider.
+
+OIDC users can be assigned Weaviate RBAC roles. The supported token flow and client behavior depend on the identity provider and SDK; follow the [OIDC configuration guide](https://docs.weaviate.io/deploy/configuration/oidc) and the SDK documentation.
+
+**Weaviate Cloud database authentication is documented using API keys.** The official Cloud documentation does not currently describe a Weaviate-hosted delegated OAuth 2.0 consent flow. Do not infer OAuth scopes, token endpoints, manifests, or authorization flows. Self-hosted OIDC uses an external identity provider and is not a substitute for Cloud API-key authentication.
+
+## RBAC and least privilege
+
+Authentication identifies a user; RBAC authorizes actions. Use a separate identity or API key for each application, assign the smallest custom role that covers its required resources, and constrain permissions by collection and tenant where needed. Do not use `root` for routine application traffic. The built-in `viewer` role is read-only; custom roles and available permissions are defined in the [RBAC documentation](https://docs.weaviate.io/weaviate/configuration/rbac).
+
+## Rotation and revocation
+
+- Cloud: rotate or delete keys in the cluster API keys section; rotation invalidates the old key and deletion revokes it.
+- Self-hosted: the user management API can create and delete users, assign and revoke roles, and rotate user API keys. See [Manage users](https://docs.weaviate.io/weaviate/configuration/rbac/manage-users).
+- Replace the value in the secret manager or environment, deploy the new value, verify access, and then revoke the old credential.
+
+## Cloud onboarding
+
+Sign in to [Weaviate Cloud](https://console.weaviate.cloud/) and create a cluster, trial, or free product option currently offered in the console. Use the endpoint and generated API key supplied for that resource, then follow the [Cloud connection guide](https://docs.weaviate.io/cloud/manage-clusters/connect). Pricing, quotas, expiry, and available plans can change, so use the values shown in the console rather than assuming them.
+
+## Official SDKs
+
+These are the officially maintained SDKs listed by the [Weaviate client-library index](https://docs.weaviate.io/weaviate/client-libraries/). Registry links and installation commands are canonical:
+
+| SDK | Registry | Install |
+| --- | --- | --- |
+| Python | [PyPI: `weaviate-client`](https://pypi.org/project/weaviate-client/) | `python -m pip install -U weaviate-client` |
+| TypeScript / JavaScript | [npm: `weaviate-client`](https://www.npmjs.com/package/weaviate-client) | `npm install weaviate-client` |
+| Go | [Go package: `github.com/weaviate/weaviate-go-client/v5`](https://pkg.go.dev/github.com/weaviate/weaviate-go-client/v5) | `go get github.com/weaviate/weaviate-go-client/v5` |
+| Java | [Maven Central: `io.weaviate:client6`](https://central.sonatype.com/artifact/io.weaviate/client6) | Add `io.weaviate:client6` using the current version shown in Maven Central |
+| C# | [NuGet: `Weaviate.Client`](https://www.nuget.org/packages/Weaviate.Client) | `dotnet add package Weaviate.Client` |
+
+Use the current version and authentication examples from the relevant [client-library documentation](https://docs.weaviate.io/weaviate/client-libraries/).

--- a/static/index.md
+++ b/static/index.md
@@ -2,7 +2,7 @@
 title: "Weaviate"
 description: "Weaviate is an open-source, AI-native vector database for vector, keyword, and hybrid search, filtering, multi-tenancy, and retrieval-augmented generation."
 canonical: https://weaviate.io/
-last-updated: 2026-08-04
+last-updated: 2026-08-25
 ---
 
 # Weaviate
@@ -18,6 +18,7 @@ Use Weaviate as the retrieval and data layer for AI applications. Start with Wea
 - [Weaviate Cloud console](https://console.weaviate.cloud/)
 - [Pricing](https://weaviate.io/pricing.md)
 - [Security](https://weaviate.io/security.md)
+- [Authentication guide](https://weaviate.io/auth.md)
 - [LLM navigation index](https://weaviate.io/llms.txt)
 - [Resources for AI agents](https://weaviate.io/agents.md)
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -30,6 +30,8 @@ If you run Weaviate yourself (Docker / Kubernetes / on-prem), **use at least the
 - **Build** — Quickstart · Best Practices · MCP server · Client code examples (Python / TypeScript / Java / C#)
 - Further Resources
 
+Authentication and SDK installation: [auth.md](https://weaviate.io/auth.md)
+
 > **Evaluate** — what Weaviate is and when to use it
 
 ## The Weaviate Stack


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

- Adds a standalone `/auth.md` guide covering Cloud API keys, applicable self-hosted OIDC, RBAC and least privilege, credential rotation/revocation, Cloud onboarding and official SDK packages.
- Carefully distinguishes Cloud API-key authentication from external-identity-provider OIDC and does not claim a Weaviate-hosted delegated OAuth consent flow.
- Adds canonical PyPI, npm, Go package, Maven Central and NuGet links for the five officially maintained client libraries.
- Links `/auth.md` from `/agents.md`, `/index.md`, `llms.txt` and the ARD catalog.
- Adds `/auth.md` to the documented list of standalone Markdown resources without incorrectly adding it to the HTML-to-Markdown twin map.
- Updates relevant Markdown `last-updated` metadata to 25 August 2026.
- Keeps `llms.txt` below the agreed limit at 29,583 characters.


### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [x] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **GitHub action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
