### PR TITLE
Add static/banner/v1.json, the art Weaviate fetches for its repeat banner

### DIFF
--- a/static/banner/v1.json
+++ b/static/banner/v1.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "art": [
+    "  ██▁▁▁▁▁██▁███████▁▁█████▁▁██▁▁▁▁██▁██▁▁█████▁▁████████▁███████",
+    "  ██▁▁▁▁▁██▁██▁▁▁▁▁▁██▁▁▁██▁██▁▁▁▁██▁██▁██▁▁▁██▁▁▁▁██▁▁▁▁██▁▁▁▁▁",
+    "  ██▁▁█▁▁██▁█████▁▁▁███████▁██▁▁▁▁██▁██▁███████▁▁▁▁██▁▁▁▁█████▁▁",
+    "  ██▁███▁██▁██▁▁▁▁▁▁██▁▁▁██▁▁██▁▁██▁▁██▁██▁▁▁██▁▁▁▁██▁▁▁▁██▁▁▁▁▁",
+    "  ▁███▁███▁▁███████▁██▁▁▁██▁▁▁████▁▁▁██▁██▁▁▁██▁▁▁▁██▁▁▁▁███████"
+  ],
+  "_comment": "Startup banner art fetched by Weaviate Database (v1.40+) for its repeat banner. Keep lines <= 100 columns and <= 10 lines; only printable characters; a newer format must use a new file (v2.json), never change this one's shape."
+}

--- a/static/banner/v1.json
+++ b/static/banner/v1.json
@@ -7,5 +7,8 @@
     "  ██▁███▁██▁██▁▁▁▁▁▁██▁▁▁██▁▁██▁▁██▁▁██▁██▁▁▁██▁▁▁▁██▁▁▁▁██▁▁▁▁▁",
     "  ▁███▁███▁▁███████▁██▁▁▁██▁▁▁████▁▁▁██▁██▁▁▁██▁▁▁▁██▁▁▁▁███████"
   ],
-  "_comment": "Startup banner art fetched by Weaviate Database (v1.40+) for its repeat banner. Keep lines <= 100 columns and <= 10 lines; only printable characters; a newer format must use a new file (v2.json), never change this one's shape."
+  "message": [
+    "Weaviate 1.39 is out: https://weaviate.io/blog/weaviate-1-39-release"
+  ],
+  "_comment": "Startup banner content fetched by Weaviate Database (v1.40+) for its repeat banner. art: <= 10 lines of <= 100 printable columns. message: optional news printed under the banner as a '► News:' line, e.g. a release or feature announcement; <= 3 lines of <= 100 columns, one line of text ending in a link works best; leave it empty when there is nothing to announce. A newer format must use a new file (v2.json), never change this one's shape."
 }

--- a/static/banner/v1.json
+++ b/static/banner/v1.json
@@ -1,14 +1,10 @@
 {
   "schema_version": 1,
   "art": [
-    "  ██▁▁▁▁▁██▁███████▁▁█████▁▁██▁▁▁▁██▁██▁▁█████▁▁████████▁███████",
-    "  ██▁▁▁▁▁██▁██▁▁▁▁▁▁██▁▁▁██▁██▁▁▁▁██▁██▁██▁▁▁██▁▁▁▁██▁▁▁▁██▁▁▁▁▁",
-    "  ██▁▁█▁▁██▁█████▁▁▁███████▁██▁▁▁▁██▁██▁███████▁▁▁▁██▁▁▁▁█████▁▁",
-    "  ██▁███▁██▁██▁▁▁▁▁▁██▁▁▁██▁▁██▁▁██▁▁██▁██▁▁▁██▁▁▁▁██▁▁▁▁██▁▁▁▁▁",
-    "  ▁███▁███▁▁███████▁██▁▁▁██▁▁▁████▁▁▁██▁██▁▁▁██▁▁▁▁██▁▁▁▁███████"
+    "WEAVIATE"
   ],
   "message": [
     "Weaviate 1.39 is out: https://weaviate.io/blog/weaviate-1-39-release"
   ],
-  "_comment": "Startup banner content fetched by Weaviate Database (v1.40+) for its repeat banner. art: <= 10 lines of <= 100 printable columns. message: optional news printed under the banner as a '► News:' line, e.g. a release or feature announcement; <= 3 lines of <= 100 columns, one line of text ending in a link works best; leave it empty when there is nothing to announce. A newer format must use a new file (v2.json), never change this one's shape."
+  "_comment": "Startup banner content fetched by Weaviate Database (v1.40+) for its repeat banner. art: <= 10 lines of <= 100 printable columns. message: optional news printed under the banner as a news entry, e.g. a release or feature announcement; <= 3 lines of <= 100 columns, one line of text ending in a link works best; leave it empty when there is nothing to announce. A newer format must use a new file (v2.json), never change this one's shape."
 }


### PR DESCRIPTION
Weaviate Database v1.40+ (weaviate/weaviate#12738) logs a startup banner and repeats it every `BANNER_INTERVAL`; the repeat draws its art from `https://weaviate.io/banner/v1.json` when it can fetch it and falls back to embedded art otherwise. This adds that file under `static/banner/`.

The shape (`schema_version: 1`, `art`: up to 10 lines of up to 100 columns, printable characters only) is a contract with released binaries: change the art freely, never the shape — a new format gets `v2.json`.

**Update 2026-08-27.** The file also carries an optional `message`: up to 3 lines of up to 100 columns that Weaviate prints under the banner as a `► News:` line, for a release or feature announcement; leave it empty when there is nothing to announce. It currently carries the 1.39 announcement — the blog URL in it should be checked against the published post before merge.
